### PR TITLE
Fix code scanning alert no. 3: Exposure of private information

### DIFF
--- a/EasyFinance.Server/Config/EmailSender.cs
+++ b/EasyFinance.Server/Config/EmailSender.cs
@@ -31,8 +31,8 @@ namespace EasyFinance.Server.Config
 
             var response = await sendGridClient.SendEmailAsync(msg);
             this.logger.LogInformation(response.IsSuccessStatusCode
-                                   ? $"Email to {toEmail} queued successfully!"
-                                   : $"Failure Email to {toEmail}");
+                                   ? "Email queued successfully!"
+                                   : "Failure in queuing email");
         }
 
         private SendGridMessage createDefaultEmail(string toEmail, string subject, string message)


### PR DESCRIPTION
Fixes [https://github.com/FelipePSoares/EconoFlow/security/code-scanning/3](https://github.com/FelipePSoares/EconoFlow/security/code-scanning/3)

To fix the problem, we should avoid logging the email address directly. Instead, we can log a generic message that does not include sensitive information. This way, we maintain the functionality of logging the success or failure of the email sending process without exposing private data.

- Replace the log message on line 33 to exclude the `toEmail` parameter.
- Ensure the log message still provides useful information for debugging and monitoring purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
