### PR TITLE
Fix: Jump one month when is day 31, validate future date.

### DIFF
--- a/EasyFinance.Domain/Financial/BaseFinancial.cs
+++ b/EasyFinance.Domain/Financial/BaseFinancial.cs
@@ -54,7 +54,7 @@ namespace EasyFinance.Domain.Models.Financial
             if (amount < 0)
                 throw new ValidationException(nameof(this.Amount), string.Format(ValidationMessages.PropertyCantBeLessThanZero, nameof(this.Amount)));
 
-            if (this.Date > DateTime.Today.ToUniversalTime().AddDays(1) && this.Amount > 0)
+            if (this.Date > DateTime.Today.ToUniversalTime().AddDays(1) && amount > 0)
                 throw new ValidationException(nameof(this.Date), ValidationMessages.CantAddFutureExpense);
 
             this.Amount = amount;

--- a/EasyFinance.Server/Mappers/ExpenseItemMap.cs
+++ b/EasyFinance.Server/Mappers/ExpenseItemMap.cs
@@ -51,8 +51,8 @@ namespace EasyFinance.Server.Mappers
             if (expenseItem != null)
             {
                 expenseItem.SetName(expenseItemDTO.Name);
-                expenseItem.SetDate(expenseItemDTO.Date);
                 expenseItem.SetAmount(expenseItemDTO.Amount);
+                expenseItem.SetDate(expenseItemDTO.Date);
                 expenseItem.SetItems(expenseItemDTO.Items.FromDTO(expenseItem.Items.ToList()));
                 return expenseItem;
             }

--- a/EasyFinance.Server/Mappers/ExpenseMap.cs
+++ b/EasyFinance.Server/Mappers/ExpenseMap.cs
@@ -51,9 +51,9 @@ namespace EasyFinance.Server.Mappers
             if (expense != null)
             {
                 expense.SetName(expenseDTO.Name);
-                expense.SetDate(expenseDTO.Date);
-                expense.SetAmount(expenseDTO.Amount);
                 expense.SetBudget(expenseDTO.Budget);
+                expense.SetAmount(expenseDTO.Amount);
+                expense.SetDate(expenseDTO.Date);
                 expense.SetItems(expenseDTO.Items.FromDTO(expense.Items.ToList()));
                 return expense;
             }

--- a/easyfinance.client/src/app/core/components/current-date/current-date.component.ts
+++ b/easyfinance.client/src/app/core/components/current-date/current-date.component.ts
@@ -57,7 +57,7 @@ export class CurrentDateComponent {
 
   changeDate(value: number) {
     var newDate = new Date(this.currentDate);
-    newDate.setMonth(this.currentDate.getMonth() + value);
+    newDate.setMonth(this.currentDate.getMonth() + value, 1);
     this.currentDate = newDate;
     this.dateUpdatedEvent.emit(this.currentDate);
   }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization

## Description

Fixed when user try change to next month on day 31.
Change order of the validation to set amount first and then validate the date.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No, and this is why: because it's a hotfix
- [ ] I need help with writing tests
