### PR TITLE
Fix: progress bar bug when don't have budget

### DIFF
--- a/EasyFinance.Domain.Tests/Financial/ExpenseItemTests.cs
+++ b/EasyFinance.Domain.Tests/Financial/ExpenseItemTests.cs
@@ -37,7 +37,7 @@ namespace EasyFinance.Domain.Tests.Financial
             var action = () => new ExpenseItemBuilder().AddAmount(1).AddDate(date).Build();
 
             action.Should().Throw<ValidationException>()
-                .WithMessage(ValidationMessages.CantAddFutureExpense)
+                .WithMessage(ValidationMessages.CantAddFutureExpenseIncome)
                 .And.Property.Should().Be("Date");
         }
 

--- a/EasyFinance.Domain.Tests/Financial/ExpenseTests.cs
+++ b/EasyFinance.Domain.Tests/Financial/ExpenseTests.cs
@@ -57,7 +57,7 @@ namespace EasyFinance.Domain.Tests.Financial
             var action = () => new ExpenseBuilder().AddAmount(1).AddDate(date).Build();
 
             action.Should().Throw<ValidationException>()
-                .WithMessage(ValidationMessages.CantAddFutureExpense)
+                .WithMessage(ValidationMessages.CantAddFutureExpenseIncome)
                 .And.Property.Should().Be("Date");
         }
 

--- a/EasyFinance.Domain.Tests/Financial/IncomeTests.cs
+++ b/EasyFinance.Domain.Tests/Financial/IncomeTests.cs
@@ -37,7 +37,7 @@ namespace EasyFinance.Domain.Tests.Financial
             var action = () => new IncomeBuilder().AddAmount(1).AddDate(date).Build();
 
             action.Should().Throw<ValidationException>()
-                .WithMessage(ValidationMessages.CantAddFutureExpense)
+                .WithMessage(ValidationMessages.CantAddFutureExpenseIncome)
                 .And.Property.Should().Be("Date");
         }
 

--- a/EasyFinance.Domain/Financial/BaseFinancial.cs
+++ b/EasyFinance.Domain/Financial/BaseFinancial.cs
@@ -41,7 +41,7 @@ namespace EasyFinance.Domain.Models.Financial
         public void SetDate(DateTime date)
         {
             if (date > DateTime.Today.ToUniversalTime().AddDays(1) && this.Amount > 0)
-                throw new ValidationException(nameof(this.Date), ValidationMessages.CantAddFutureExpense);
+                throw new ValidationException(nameof(this.Date), ValidationMessages.CantAddFutureExpenseIncome);
 
             if (date < DateTime.Today.AddYears(-5))
                 throw new ValidationException(nameof(this.Date), string.Format(ValidationMessages.CantAddExpenseOlderThanYears, 5));
@@ -55,7 +55,7 @@ namespace EasyFinance.Domain.Models.Financial
                 throw new ValidationException(nameof(this.Amount), string.Format(ValidationMessages.PropertyCantBeLessThanZero, nameof(this.Amount)));
 
             if (this.Date > DateTime.Today.ToUniversalTime().AddDays(1) && amount > 0)
-                throw new ValidationException(nameof(this.Date), ValidationMessages.CantAddFutureExpense);
+                throw new ValidationException(nameof(this.Date), ValidationMessages.CantAddFutureExpenseIncome);
 
             this.Amount = amount;
         }

--- a/EasyFinance.Infrastructure/ValidationMessages.Designer.cs
+++ b/EasyFinance.Infrastructure/ValidationMessages.Designer.cs
@@ -76,11 +76,11 @@ namespace EasyFinance.Infrastructure {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can&apos;t add future expense.
+        ///   Looks up a localized string similar to You can&apos;t add future expense/income.
         /// </summary>
-        public static string CantAddFutureExpense {
+        public static string CantAddFutureExpenseIncome {
             get {
-                return ResourceManager.GetString("CantAddFutureExpense", resourceCulture);
+                return ResourceManager.GetString("CantAddFutureExpenseIncome", resourceCulture);
             }
         }
         

--- a/EasyFinance.Infrastructure/ValidationMessages.resx
+++ b/EasyFinance.Infrastructure/ValidationMessages.resx
@@ -138,8 +138,8 @@
   <data name="PropertyCantBeNullOrEmpty" xml:space="preserve">
     <value>{0} can't be null or empty</value>
   </data>
-  <data name="CantAddFutureExpense" xml:space="preserve">
-    <value>You can't add future expense</value>
+  <data name="CantAddFutureExpenseIncome" xml:space="preserve">
+    <value>You can't add future expense/income</value>
   </data>
   <data name="CantAddExpenseOlderThanYears" xml:space="preserve">
     <value>You can't add expense older than {0} years</value>

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
@@ -151,7 +151,7 @@ export class ListCategoriesComponent implements OnInit {
   }
 
   getPercentageWaste(waste: number, budget: number): number {
-    return budget === 0 ? 0 : waste * 100 / budget;
+    return budget === 0 ? waste !== 0 ? 101 : 0 : waste * 100 / budget;
   }
 
   getClassToProgressBar(percentage: number): string {

--- a/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.ts
+++ b/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.ts
@@ -184,7 +184,7 @@ export class ListExpensesComponent implements OnInit {
   }
 
   getPercentageWaste(waste: number, budget: number): number {
-    return budget === 0 ? 0 : waste * 100 / budget;
+    return budget === 0 ? waste !== 0 ? 101 : 0 : waste * 100 / budget;
   }
 
   getClassToProgressBar(percentage: number): string {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization

## Description

Fixed bug that show progress bar with 0 when don't have any budget.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #205 
- Closes #205 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
