### PR TITLE
Feat [frontend] #267 User Deletion

### DIFF
--- a/easyfinance.client/src/app/core/services/token.service.ts
+++ b/easyfinance.client/src/app/core/services/token.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TokenService {
+  private deleteToken: string | null = null;
+
+  setToken(token: string): void {
+    this.deleteToken = token;
+  }
+
+  getToken(): string | null {
+    return this.deleteToken;
+  }
+
+  clearToken(): void {
+    this.deleteToken = null;
+  }
+}

--- a/easyfinance.client/src/app/core/services/token.service.ts
+++ b/easyfinance.client/src/app/core/services/token.service.ts
@@ -5,16 +5,23 @@ import { Injectable } from '@angular/core';
 })
 export class TokenService {
   private deleteToken: string | null = null;
-
-  setToken(token: string): void {
+  private confirmationMessage: string | null = null;
+  
+  setToken(token: string, confirmationMessage: string): void {
     this.deleteToken = token;
+    this.confirmationMessage = confirmationMessage
   }
 
   getToken(): string | null {
     return this.deleteToken;
   }
 
+  getConfirmationMessage(): string | null{
+    return this.confirmationMessage
+  }
+
   clearToken(): void {
     this.deleteToken = null;
+    this.confirmationMessage = null; 
   }
 }

--- a/easyfinance.client/src/app/features/user/detail-user/detail-user.component.html
+++ b/easyfinance.client/src/app/features/user/detail-user/detail-user.component.html
@@ -183,6 +183,9 @@
           (click)="openDeleteDialog()">
           Delete Account
         </button>
+        <div *ngIf="deleteError" class="mt-2">
+          <p class="text-warning text-center">{{ deleteError }}</p>
+        </div>
       </div>    
     </div>
   </div>
@@ -197,6 +200,9 @@
       <p>Are you sure you want to delete your account? This action cannot be undone.</p>
     </ng-template>
   </mat-dialog-content>
+  <div *ngIf="deleteModalError" class="text-danger text-center mb-2">
+    {{ deleteModalError }}
+  </div>
   <mat-dialog-actions>
     <button mat-button (click)="closeDialog()">Cancel</button>
     <button mat-button color="warn" (click)="confirmDeletion()">Delete</button>

--- a/easyfinance.client/src/app/features/user/detail-user/detail-user.component.html
+++ b/easyfinance.client/src/app/features/user/detail-user/detail-user.component.html
@@ -174,6 +174,31 @@
       </form>
       }
       }
+      <hr class="solid"/>
+      <div class="danger-zone rounded bg-danger p-3 mt-4 text-white">
+        <h3 class="text-white">Danger Zone</h3>
+        <p class="text-white-50">Deleting your account is permanent and cannot be undone.</p>
+        <button 
+          class="btn btn-light btn-sm"
+          (click)="openDeleteDialog()">
+          Delete Account
+        </button>
+      </div>    
     </div>
   </div>
 </div>
+
+
+<ng-template #deleteDialog>
+  <h2 mat-dialog-title>Confirm Deletion</h2>
+  <mat-dialog-content>
+    <p *ngIf="confirmationMessage; else defaultMessage" [innerHTML]="sanitizeMessage(confirmationMessage)"></p>
+    <ng-template #defaultMessage>
+      <p>Are you sure you want to delete your account? This action cannot be undone.</p>
+    </ng-template>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <button mat-button (click)="closeDialog()">Cancel</button>
+    <button mat-button color="warn" (click)="confirmDeletion()">Delete</button>
+  </mat-dialog-actions>
+</ng-template>

--- a/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
+++ b/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
@@ -167,7 +167,7 @@ export class DetailUserComponent implements OnInit {
         next: (response) => {
           this.dialog.closeAll(); 
           this.userService.removeUserInfo();
-          this.router.navigate(['/login']);
+          this.router.navigate(['/']);
         },
         error: (err) => {
           console.error('Error deleting user:', err);

--- a/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
+++ b/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
@@ -166,7 +166,6 @@ export class DetailUserComponent implements OnInit {
       this.userService.deleteUser(token).subscribe({
         next: (response) => {
           this.dialog.closeAll(); 
-          this.tokenService.clearToken(); 
           this.userService.removeUserInfo();
           this.router.navigate(['/login']);
         },

--- a/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
+++ b/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, TemplateRef  } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faCheck, faCircleCheck, faCircleXmark, faFloppyDisk, faPenToSquare, faEnvelopeOpenText } from '@fortawesome/free-solid-svg-icons';
@@ -16,6 +16,12 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatOptionModule } from '@angular/material/core';
 import { CurrencyService } from '../../../core/services/currency.service';
 import { MatIcon } from "@angular/material/icon";
+import { MatDialogContent } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialogModule } from '@angular/material/dialog';
+import { Router } from '@angular/router'; 
+import { TokenService } from 'src/app/core/services/token.service';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-detail-user',
@@ -32,6 +38,8 @@ import { MatIcon } from "@angular/material/icon";
     MatSelectModule,
     MatOptionModule,
     MatIcon,
+    MatDialogContent,
+    MatDialogModule,
   ],
   templateUrl: './detail-user.component.html',
   styleUrl: './detail-user.component.css'
@@ -43,6 +51,7 @@ export class DetailUserComponent implements OnInit {
   isPasswordUpdated: boolean = false;
   passwordFormActive: boolean = false;
   
+  isModalOpen: boolean = false; 
   faCheck = faCheck;
   faCircleCheck = faCircleCheck;
   faCircleXmark = faCircleXmark;
@@ -50,6 +59,7 @@ export class DetailUserComponent implements OnInit {
   faPenToSquare = faPenToSquare;
   faEnvelopeOpenText = faEnvelopeOpenText;
   
+  confirmationMessage: string = ''
   passwordForm!: FormGroup;
   userForm!: FormGroup;
   httpErrors = false;
@@ -61,8 +71,9 @@ export class DetailUserComponent implements OnInit {
   hasOneNumber = false;
   hasOneSpecial = false;
   hasMinCharacteres = false;
-
-  constructor(private userService: UserService, private currencyService: CurrencyService, private errorMessageService: ErrorMessageService) {
+  @ViewChild('deleteDialog') deleteDialog!: TemplateRef<any>; // Reference the inline dialog templat
+ 
+  constructor(private userService: UserService,private sanitizer: DomSanitizer, private tokenService: TokenService,  private router:Router, private dialog: MatDialog , private currencyService: CurrencyService, private errorMessageService: ErrorMessageService) {
     this.user$ = this.userService.loggedUser$;
   }
 
@@ -101,6 +112,60 @@ export class DetailUserComponent implements OnInit {
       this.hasOneSpecial = /[\W_]/.test(value.password);
       this.hasMinCharacteres = /^.{8,}$/.test(value.password);
     });
+  }
+
+  sanitizeMessage(message: string): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(message);
+  }
+  
+  openDeleteDialog(): void {
+    const dialogRef: MatDialogRef<any> = this.dialog.open(this.deleteDialog, {
+      width: '400px',
+    });
+    const token = this.tokenService.getToken();
+    
+    if(!token){
+    this.userService.deleteUser().subscribe({
+      next: (response: any) => {
+        if (response?.confirmationToken) {
+          this.confirmationMessage = response.confirmationMessage; 
+          this.tokenService.setToken(response.confirmationToken); 
+        }
+      },
+      error: (err) => {
+        console.error('Error during first deletion attempt:', err);
+       
+      },
+    });
+    }
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result === true) {
+        this.confirmDeletion();
+      }
+    });
+  }
+
+  closeDialog(): void {
+    this.dialog.closeAll();
+  }
+
+  confirmDeletion(): void {
+  
+    const token = this.tokenService.getToken();
+    if (token) {
+      this.userService.deleteUser(token).subscribe({
+        next: (response) => {
+          this.dialog.closeAll(); 
+          this.tokenService.clearToken(); 
+          this.userService.removeUserInfo();
+          this.router.navigate(['/login']);
+        },
+        error: (err) => {
+          console.error('Error deleting user:', err);
+        },
+      });
+    }
   }
 
   changeStatus() {

--- a/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
+++ b/easyfinance.client/src/app/features/user/detail-user/detail-user.component.ts
@@ -128,10 +128,7 @@ export class DetailUserComponent implements OnInit {
     const dialogRef: MatDialogRef<any> = this.dialog.open(this.deleteDialog, {
       width: '400px',
     });
-    const token = this.tokenService.getToken();
-    const confirmationMessage = this.tokenService.getConfirmationMessage();
-    if(confirmationMessage) this.confirmationMessage = confirmationMessage;
-    if(!token){
+    this.tokenService.clearToken();
     this.userService.deleteUser().subscribe({
       next: (response: any) => {
         if (response?.confirmationToken) {
@@ -144,7 +141,6 @@ export class DetailUserComponent implements OnInit {
         this.deleteError = 'Failed to delete account. Please try again later';      
       },
     });
-    }
     
     dialogRef.afterClosed().subscribe(result => {
       if (result === true) {


### PR DESCRIPTION
## Issue #267 
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description
Implemented a frontend feature for account deletion with two 'Delete Account' buttons. When the user clicks the first button, a modal appears with a confirmation message fetched from the backend, along with a confirmation token. A global state is used to store this confirmation message and token, reducing the need for repeated API calls. This also ensures that the token and message persist, even if the user navigates to other pages, preventing them from being reset
