### PR TITLE
fix: break layout when has a expense with a really big name

### DIFF
--- a/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.html
+++ b/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.html
@@ -26,17 +26,19 @@
                 <div class="flex-grow-1">
                   @if(expense.id != this.editingExpense.id) {
                   <div>
-                    <h2 class="mb-1 fw-bold name mb-3">{{ expense.name }}</h2>
-                    @if (canAddOrEdit()){
-                    <div class="btn-group" style="position: absolute; right: 15px; top: 10px;">
-                      <button name="edit" class="btn btn-outline-secondary" (click)="edit(expense); $event.stopPropagation();">
-                        <fa-icon [icon]="faPenToSquare"></fa-icon>
-                      </button>
-                      <button name="delete" class="btn btn-outline-danger" (click)="triggerDelete(expense); $event.stopPropagation();">
-                        <fa-icon [icon]="faTrash"></fa-icon>
-                      </button>
+                    <div class="d-flex justify-content-between align-items-center">
+                      <h2 class="mb-1 fw-bold name mb-3">{{ expense.name }}</h2>
+                      @if (canAddOrEdit()){
+                      <div class="btn-group">
+                        <button name="edit" class="btn btn-outline-secondary" (click)="edit(expense); $event.stopPropagation();">
+                          <fa-icon [icon]="faPenToSquare"></fa-icon>
+                        </button>
+                        <button name="delete" class="btn btn-outline-danger" (click)="triggerDelete(expense); $event.stopPropagation();">
+                          <fa-icon [icon]="faTrash"></fa-icon>
+                        </button>
+                      </div>
+                      }
                     </div>
-                    }
                     <app-budget-bar [spend]="expense.getSpend()"
                                     [budget]="expense.budget"
                                     [overspend]="expense.getOverspend()"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization

## Description

Fixed break layout when has a expense with a really big name

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #423 
- Closes #423 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No, and this is why: just layout
- [ ] I need help with writing tests
