### PR TITLE
fix: improve annual income label with tooltip and updated translation

### DIFF
--- a/easyfinance.client/src/app/features/project/smart-setup/smart-setup.component.html
+++ b/easyfinance.client/src/app/features/project/smart-setup/smart-setup.component.html
@@ -1,9 +1,21 @@
-<div class="container text-center">
+<div class="container text-center"> 
   <div class="row justify-content-md-center" style="max-width: 500px;">
     <p class="text-start">{{ 'PleaseInformUsAverageAnnualIncomeThisProject' | translate }}</p>
+
     <!-- Amount Field -->
     <mat-form-field appearance="fill" class="w-100">
-      <mat-label>{{ 'FieldAnnualIncome' | translate }}</mat-label>
+      <mat-label>
+        {{ 'FieldAnnualIncome' | translate }}
+        <button mat-icon-button
+                matTooltip="We use this to calculate your monthly distribution. Please enter your yearly income."
+                class="p-0 ms-1"
+                style="vertical-align: middle;"
+                tabindex="-1"
+                aria-label="Info">
+          <mat-icon style="font-size: 18px;">info</mat-icon>
+        </button>
+      </mat-label>
+
       <input matInput
              id="annualIncome"
              type="text"
@@ -21,9 +33,6 @@
       <div *ngFor="let category of (categories$ | async); let i = index">
         <div class="d-flex justify-content-between align-items-center">
           <div>{{category.percentage}}% - {{ category.name }} - {{ (annualIncome / 12) * category.percentage / 100 | currencyFormat: true }}</div>
-          <!-- <button mat-icon-button aria-label="Close" type="button" (click)="remove(category)">
-            <mat-icon>close</mat-icon>
-          </button> -->
         </div>
         <mat-slider class="w-100"
                     [max]="100"
@@ -49,10 +58,12 @@
         </div>
       </div>
     </div>
+
     <!-- General Error Display -->
     <div *ngIf="httpErrors && errors['general']">
       <p *ngFor="let error of errors['general']" class="mt-3 mb-2 text-danger text-center">{{ error | translate }}</p>
     </div>
+
     <div class="dialog-footer d-flex justify-content-end mt-4">
       <button mat-stroked-button type="button" class="me-2" (click)="close()">{{ 'ButtonSkipSmartSetup' | translate }}</button>
       <button mat-raised-button color="primary" type="submit" [disabled]="annualIncome < 1 || totalPercentage > 100" (click)="save()">{{ 'ButtonSave' | translate }}</button>

--- a/easyfinance.client/src/assets/i18n/messages.en.json
+++ b/easyfinance.client/src/assets/i18n/messages.en.json
@@ -17,7 +17,7 @@
   "FieldCategoryName": "Category Name",
   "FieldExpenseName": "Expense Name",
   "FieldBudget": "Budget",
-  "FieldAnnualIncome": "Average annual income",
+  "FieldAnnualIncome": "Please enter your average annual income (not monthly)",
   "FieldCompanyProject": "Company Project",
   "FieldClientName": "Name",
   "FieldPhone": "Phone",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Improved the clarity of the "Average annual income" field in the Smart Setup screen by:
- Updating the translation text in `messages.en.json` to:  
  **"Please enter your average annual income (not monthly)"**
- Adding an inline `info` icon tooltip in the HTML to clarify why we ask for annual income.

Although the JSON was updated and the HTML shows the tooltip, the updated translation **does not reflect** in the UI after rebuilding — likely due to a caching or i18n refresh issue.

## Related Tickets & Documents

- Closes #440

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a UI text change and minor template logic addition; no unit tests applicable.
