### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -35,7 +35,7 @@ jobs:
           path: ./EasyFinance.Server/bin/Release/net8.0/publish/
           retention-days: 5
 
-      - name: Substituir valor no appsettings.json
+      - name: Replace values on appsettings.json
         run: |
           sed -i 's|"sourceToken": ".*"|"sourceToken": "${{ secrets.BETTERSTACK_SOURCE_TOKEN }}"|' ${{ github.workspace }}\EasyFinance.Server\bin\Release\net8.0\publish\appsettings.json |
           sed -i 's|"betterStackEndpoint": ".*"|"betterStackEndpoint": "${{ secrets.BETTERSTACK_ENDPOINT }}"|' ${{ github.workspace }}\EasyFinance.Server\bin\Release\net8.0\publish\appsettings.json

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+permissions:
+  contents: read
+  secrets: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/FelipePSoares/EconoFlow/security/code-scanning/10](https://github.com/FelipePSoares/EconoFlow/security/code-scanning/10)

To address the issue, the `permissions` key should be added, specifying the minimal set of permissions required for the workflow to function. Based on the provided workflow, the following permissions are necessary:

1. `contents: read` - The workflow interacts with repository files during the build and deployment processes (e.g., `actions/checkout`, caching, and artifact upload).
2. `secrets: read` - The workflow accesses secrets for deployment operations.
3. If additional permissions are identified later (e.g., for pull requests or issues), they should be explicitly specified.

This fix ensures that only the required permissions are granted, reducing security risks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
