### PR TITLE
Insert `app.UseAuthentication()` before authorization in Program.cs

### DIFF
--- a/EasyFinance.Server/Program.cs
+++ b/EasyFinance.Server/Program.cs
@@ -174,6 +174,7 @@ try
 
     app.UseHttpsRedirection();
 
+    app.UseAuthentication();
     app.UseAuthorization();
     app.UseProjectAuthorization();
 


### PR DESCRIPTION
### Motivation
- Ensure the authentication middleware runs before authorization so the request principal is populated and project-level authorization (`UseProjectAuthorization`) continues to function as intended.

### Description
- Added `app.UseAuthentication();` immediately after `app.UseHttpsRedirection();` in `EasyFinance.Server/Program.cs`, keeping `app.UseAuthorization();` and `app.UseProjectAuthorization();` in the same order; no skills were used for this trivial change.

### Testing
- Attempted an automated build with `dotnet build EasyFinance.Server/EasyFinance.Server.csproj`, which failed because `dotnet` is not available in this environment (build could not be executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918099c0bc832dacc0747ae054a469)