### PR TITLE
Add missing return statements for null-user BadRequest paths in AccessControlController

### DIFF
--- a/EasyFinance.Server/Controllers/AccessControlController.cs
+++ b/EasyFinance.Server/Controllers/AccessControlController.cs
@@ -68,7 +68,7 @@ namespace EasyFinance.Server.Controllers
             var user = await this.userManager.GetUserAsync(this.HttpContext.User);
 
             if (user == null)
-                BadRequest("User not found!");
+                return BadRequest("User not found!");
 
             return Ok(new UserResponseDTO(user));
         }
@@ -406,7 +406,7 @@ namespace EasyFinance.Server.Controllers
             var user = await this.userManager.GetUserAsync(this.HttpContext.User);
 
             if (user == null)
-                BadRequest("User not found!");
+                return BadRequest("User not found!");
 
             user.Enabled = false;
 
@@ -422,7 +422,7 @@ namespace EasyFinance.Server.Controllers
             var user = await this.userManager.GetUserAsync(this.HttpContext.User);
 
             if (user == null)
-                BadRequest("User not found!");
+                return BadRequest("User not found!");
 
             user.Enabled = true;
 


### PR DESCRIPTION
### Motivation
- Ensure controller actions return immediately on null authenticated users so `BadRequest("User not found!")` prevents subsequent null dereferences and incorrect `Ok()` responses.

### Description
- Updated `DeactivateUserAsync` and `ActivateUserAsync` in `EasyFinance.Server/Controllers/AccessControlController.cs` to use `return BadRequest("User not found!");` when `user` is null, keeping early-exit behavior consistent with `GetUserAsync`.

### Testing
- Verified the controller with `rg -n "BadRequest\(" EasyFinance.Server/Controllers/AccessControlController.cs` to confirm the null-user branches now return, and committed the change; `dotnet` build was not run because `dotnet` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699181164434832d9a7601ff7632abff)