### PR TITLE
Implement budget threshold notifications for expenses

### DIFF
--- a/EasyFinance.Application.Tests/ExpenseServiceTests.cs
+++ b/EasyFinance.Application.Tests/ExpenseServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using EasyFinance.Application.Contracts.Persistence;
+using EasyFinance.Application.Contracts.Persistence;
 using EasyFinance.Application.Features.ExpenseService;
 using EasyFinance.Common.Tests;
 using EasyFinance.Domain.AccessControl;
@@ -7,6 +7,15 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using EasyFinance.Application.DTOs.Financial;
+using EasyFinance.Application.DTOs.Account;
+using EasyFinance.Domain.Account;
+using EasyFinance.Infrastructure.DTOs;
+using EasyFinance.Common.Tests.FinancialProject;
+using EasyFinance.Common.Tests.Financial;
+using EasyFinance.Common.Tests.AccessControl;
+using Microsoft.AspNetCore.JsonPatch;
+using Moq;
 
 namespace EasyFinance.Application.Tests
 {
@@ -131,6 +140,154 @@ namespace EasyFinance.Application.Tests
 
             project.Categories.First().Expenses.First().CreatedBy.Id.Should().BeEmpty();
             project.Categories.First().Expenses.First().CreatorName.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task CreateAsync_Exceeds100Percent_SendsNotification()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var expenseService = scopedServices.GetRequiredService<IExpenseService>();
+
+            var categoryId = this.project1.Categories.First().Id;
+            var expenseDto = new ExpenseRequestDTO
+            {
+                Name = "Overbudget Expense",
+                Amount = 150,
+                Budget = 100,
+                Date = DateOnly.FromDateTime(DateTime.UtcNow)
+            };
+
+            await expenseService.CreateAsync(this.user1, this.project1.Id, categoryId, expenseDto);
+
+            notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r => 
+                r.CodeMessage == "BUDGET_OVERFLOW" && 
+                r.Category == NotificationCategory.Finance)), Times.AtLeastOnce());
+        }
+
+        [Fact]
+        public async Task CreateAsync_Crosses80Percent_SendsNotification()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var expenseService = scopedServices.GetRequiredService<IExpenseService>();
+
+            var categoryId = this.project1.Categories.First().Id;
+            var expenseDto = new ExpenseRequestDTO
+            {
+                Name = "80% Budget Expense",
+                Amount = 85,
+                Budget = 100,
+                Date = DateOnly.FromDateTime(DateTime.UtcNow)
+            };
+
+            await expenseService.CreateAsync(this.user1, this.project1.Id, categoryId, expenseDto);
+
+            notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r => 
+                r.CodeMessage == "BUDGET_WARNING" && 
+                r.Category == NotificationCategory.Finance)), Times.AtLeastOnce());
+        }
+
+        [Fact]
+        public async Task UpdateAsync_Crosses80Percent_SendsNotification()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var expenseService = scopedServices.GetRequiredService<IExpenseService>();
+            var unitOfWork = scopedServices.GetRequiredService<IUnitOfWork>();
+
+            // Create a fresh project, category and expense in this scope
+            var project = new ProjectBuilder().AddName("Update Project").Build();
+            unitOfWork.ProjectRepository.InsertOrUpdate(project);
+            
+            var category = new CategoryBuilder().AddName("Update Category").Build();
+            project.AddCategory(category);
+            unitOfWork.CategoryRepository.InsertOrUpdate(category);
+
+            var expense = new ExpenseBuilder().AddName("Update Expense").AddCreatedBy(this.user1).Build();
+            expense.SetItems(new List<ExpenseItem>()); // No items
+            expense.SetBudget(100);
+            expense.SetAmount(50);
+            category.AddExpense(expense);
+            unitOfWork.ExpenseRepository.InsertOrUpdate(expense);
+
+            // Ensure user is linked to project
+            unitOfWork.UserProjectRepository.InsertOrUpdate(new UserProjectBuilder().AddProject(project).AddUser(this.user1).AddAccepted().Build());
+            
+            await unitOfWork.CommitAsync();
+
+            var patch = new JsonPatchDocument<ExpenseRequestDTO>();
+            patch.Replace(e => e.Amount, 85); // 85%
+
+            var result = await expenseService.UpdateAsync(this.user1, project.Id, category.Id, expense.Id, patch);
+            result.Succeeded.Should().BeTrue();
+
+            notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r => r.CodeMessage == "BUDGET_WARNING")), Times.AtLeastOnce());
+        }
+
+        [Fact]
+        public async Task UpdateAsync_JumpsTo100Percent_SendsOnlyOverflowNotification()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var expenseService = scopedServices.GetRequiredService<IExpenseService>();
+            var unitOfWork = scopedServices.GetRequiredService<IUnitOfWork>();
+
+            // Create a fresh project, category and expense in this scope
+            var project = new ProjectBuilder().AddName("Jump Project").Build();
+            unitOfWork.ProjectRepository.InsertOrUpdate(project);
+            
+            var category = new CategoryBuilder().AddName("Jump Category").Build();
+            project.AddCategory(category);
+            unitOfWork.CategoryRepository.InsertOrUpdate(category);
+
+            var expense = new ExpenseBuilder().AddName("Jump Expense").AddCreatedBy(this.user1).Build();
+            expense.SetItems(new List<ExpenseItem>()); // No items
+            expense.SetBudget(100);
+            expense.SetAmount(50);
+            category.AddExpense(expense);
+            unitOfWork.ExpenseRepository.InsertOrUpdate(expense);
+
+            // Ensure user is linked to project
+            unitOfWork.UserProjectRepository.InsertOrUpdate(new UserProjectBuilder().AddProject(project).AddUser(this.user1).AddAccepted().Build());
+            
+            await unitOfWork.CommitAsync();
+
+            notificationServiceMock.Invocations.Clear();
+
+            var patch = new JsonPatchDocument<ExpenseRequestDTO>();
+            patch.Replace(e => e.Amount, 110); // 110%
+
+            await expenseService.UpdateAsync(this.user1, project.Id, category.Id, expense.Id, patch);
+
+            notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r => 
+                r.CodeMessage == "BUDGET_OVERFLOW")), Times.AtLeastOnce());
+            
+            notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r => 
+                r.CodeMessage == "BUDGET_WARNING")), Times.Never());
+        }
+
+        [Fact]
+        public async Task CreateAsync_BudgetIsZero_NoNotification()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var expenseService = scopedServices.GetRequiredService<IExpenseService>();
+
+            var categoryId = this.project1.Categories.First().Id;
+            var expenseDto = new ExpenseRequestDTO
+            {
+                Name = "Zero Budget Expense",
+                Amount = 150,
+                Budget = 0,
+                Date = DateOnly.FromDateTime(DateTime.UtcNow)
+            };
+
+            notificationServiceMock.Invocations.Clear();
+
+            await expenseService.CreateAsync(this.user1, this.project1.Id, categoryId, expenseDto);
+
+            notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.IsAny<NotificationRequestDTO>()), Times.Never());
         }
     }
 }

--- a/EasyFinance.Application.Tests/UserServiceUnsubscribeIntegrationTests.cs
+++ b/EasyFinance.Application.Tests/UserServiceUnsubscribeIntegrationTests.cs
@@ -5,6 +5,8 @@ using EasyFinance.Application.Features.ExpenseService;
 using EasyFinance.Application.Features.IncomeService;
 using EasyFinance.Application.Features.ProjectService;
 using EasyFinance.Application.Features.UserService;
+using EasyFinance.Application.Features.NotificationService;
+using Moq;
 using EasyFinance.Domain.AccessControl;
 using EasyFinance.Domain.Account;
 using EasyFinance.Persistence.DatabaseContext;
@@ -35,6 +37,7 @@ namespace EasyFinance.Application.Tests
             services.AddScoped<IAttachmentService, AttachmentService>();
             services.AddSingleton<IAttachmentStorageService, FileSystemAttachmentStorageService>();
             services.AddScoped<IUserService, UserService>();
+            services.AddScoped<INotificationService>(_ => new Mock<INotificationService>().Object);
             services.AddLogging();
 
             services.AddIdentityCore<User>()

--- a/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
+++ b/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
@@ -358,34 +358,41 @@ namespace EasyFinance.Application.Features.ExpenseService
 
         private async Task CheckBudgetAlertsAsync(Guid projectId, Expense expense, decimal previousAmount = 0m)
         {
-            if (expense.Budget == 0) return;
-
-            decimal previousPercentage = previousAmount / (decimal)expense.Budget * 100m;
-            decimal currentPercentage = expense.Amount / (decimal)expense.Budget * 100m;
-
-            bool isOverflow = currentPercentage >= 100m && previousPercentage < 100m;
-            bool isWarning = currentPercentage >= 80m && currentPercentage < 100m && previousPercentage < 80m;
-
-            if (!isOverflow && !isWarning) return;
-
-            var users = await unitOfWork.UserProjectRepository
-                .NoTrackable()
-                .Where(up => up.Project != null && up.Project.Id == projectId && up.Accepted)
-                .Select(up => up.User)
-                .ToListAsync();
-
-            string messageCode = isOverflow ? "BUDGET_OVERFLOW" : "BUDGET_WARNING";
-
-            foreach (var user in users)
+            try
             {
-                await notificationService.CreateNotificationAsync(new NotificationRequestDTO
+                if (expense.Budget == 0) return;
+
+                decimal previousPercentage = previousAmount / (decimal)expense.Budget * 100m;
+                decimal currentPercentage = expense.Amount / (decimal)expense.Budget * 100m;
+
+                bool isOverflow = currentPercentage >= 100m && previousPercentage < 100m;
+                bool isWarning = currentPercentage >= 80m && currentPercentage < 100m && previousPercentage < 80m;
+
+                if (!isOverflow && !isWarning) return;
+
+                var users = await unitOfWork.UserProjectRepository
+                    .NoTrackable()
+                    .Where(up => up.Project != null && up.Project.Id == projectId && up.Accepted)
+                    .Select(up => up.User)
+                    .ToListAsync();
+
+                string messageCode = isOverflow ? "BUDGET_OVERFLOW" : "BUDGET_WARNING";
+
+                foreach (var user in users)
                 {
-                    User = user,
-                    Type = NotificationType.Information,
-                    CodeMessage = messageCode,
-                    Category = NotificationCategory.Finance,
-                    LimitNotificationChannels = NotificationChannels.Push | NotificationChannels.InApp | NotificationChannels.WebPush
-                });
+                    await notificationService.CreateNotificationAsync(new NotificationRequestDTO
+                    {
+                        User = user,
+                        Type = NotificationType.Information,
+                        CodeMessage = messageCode,
+                        Category = NotificationCategory.Finance,
+                        LimitNotificationChannels = NotificationChannels.Push | NotificationChannels.InApp | NotificationChannels.WebPush
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error while checking budget alerts for project {ProjectId}.", projectId);
             }
         }
     }

--- a/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
+++ b/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
@@ -368,16 +368,11 @@ namespace EasyFinance.Application.Features.ExpenseService
 
             if (!isOverflow && !isWarning) return;
 
-            var userProjects = await unitOfWork.UserProjectRepository
+            var users = await unitOfWork.UserProjectRepository
                 .NoTrackable()
-                .Include(up => up.Project)
-                .Include(up => up.User)
-                .ToListAsync();
-
-            var users = userProjects
-                .Where(up => up.Project?.Id == projectId && up.Accepted)
+                .Where(up => up.Project != null && up.Project.Id == projectId && up.Accepted)
                 .Select(up => up.User)
-                .ToList();
+                .ToListAsync();
 
             string messageCode = isOverflow ? "BUDGET_OVERFLOW" : "BUDGET_WARNING";
 
@@ -388,7 +383,8 @@ namespace EasyFinance.Application.Features.ExpenseService
                     User = user,
                     Type = NotificationType.Information,
                     CodeMessage = messageCode,
-                    Category = NotificationCategory.Finance
+                    Category = NotificationCategory.Finance,
+                    LimitNotificationChannels = NotificationChannels.Push | NotificationChannels.InApp | NotificationChannels.WebPush
                 });
             }
         }

--- a/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
+++ b/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
@@ -1,12 +1,15 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EasyFinance.Application.Contracts.Persistence;
+using EasyFinance.Application.DTOs.Account;
 using EasyFinance.Application.DTOs.Financial;
 using EasyFinance.Application.Features.AttachmentService;
+using EasyFinance.Application.Features.NotificationService;
 using EasyFinance.Application.Mappers;
 using EasyFinance.Domain.AccessControl;
+using EasyFinance.Domain.Account;
 using EasyFinance.Domain.Financial;
 using EasyFinance.Infrastructure;
 using EasyFinance.Infrastructure.DTOs;
@@ -21,12 +24,18 @@ namespace EasyFinance.Application.Features.ExpenseService
     {
         private readonly IUnitOfWork unitOfWork;
         private readonly IAttachmentService attachmentService;
+        private readonly INotificationService notificationService;
         private readonly ILogger<ExpenseService> logger;
 
-        public ExpenseService(IUnitOfWork unitOfWork, IAttachmentService attachmentService, ILogger<ExpenseService> logger)
+        public ExpenseService(
+            IUnitOfWork unitOfWork, 
+            IAttachmentService attachmentService, 
+            INotificationService notificationService,
+            ILogger<ExpenseService> logger)
         {
             this.unitOfWork = unitOfWork;
             this.attachmentService = attachmentService;
+            this.notificationService = notificationService;
             this.logger = logger;
         }
 
@@ -94,6 +103,8 @@ namespace EasyFinance.Application.Features.ExpenseService
 
             await unitOfWork.CommitAsync();
 
+            await CheckBudgetAlertsAsync(projectId, expense, 0m);
+
             if (expenseDto.TemporaryAttachmentIds.Count > 0)
             {
                 var attachTemporaryResponse = await this.attachmentService.AttachTemporaryToExpenseAsync(
@@ -148,6 +159,8 @@ namespace EasyFinance.Application.Features.ExpenseService
             if (existingExpense == null)
                 return AppResponse<ExpenseResponseDTO>.Error(code: nameof(expenseId), description: string.Format(ValidationMessages.PropertyCantBeNullOrEmpty, nameof(expenseId)));
 
+            var oldAmount = existingExpense.Amount;
+
             var dto = existingExpense.ToRequestDTO();
 
             if (dto.Items.Count == 0 && dto.Amount > 0 && expenseDto.Operations.Any(o => o.OperationType == OperationType.Add && o.path.Contains("items")))
@@ -173,6 +186,7 @@ namespace EasyFinance.Application.Features.ExpenseService
                 return AppResponse<ExpenseResponseDTO>.Error(savedExpense.Messages);
 
             await unitOfWork.CommitAsync();
+            await CheckBudgetAlertsAsync(projectId, existingExpense, oldAmount);
 
             if (dto.TemporaryAttachmentIds.Count > 0)
             {
@@ -340,6 +354,43 @@ namespace EasyFinance.Application.Features.ExpenseService
 
             await unitOfWork.CommitAsync();
             return response;
+        }
+
+        private async Task CheckBudgetAlertsAsync(Guid projectId, Expense expense, decimal previousAmount = 0m)
+        {
+            if (expense.Budget == 0) return;
+
+            decimal previousPercentage = previousAmount / (decimal)expense.Budget * 100m;
+            decimal currentPercentage = expense.Amount / (decimal)expense.Budget * 100m;
+
+            bool isOverflow = currentPercentage >= 100m && previousPercentage < 100m;
+            bool isWarning = currentPercentage >= 80m && currentPercentage < 100m && previousPercentage < 80m;
+
+            if (!isOverflow && !isWarning) return;
+
+            var userProjects = await unitOfWork.UserProjectRepository
+                .NoTrackable()
+                .Include(up => up.Project)
+                .Include(up => up.User)
+                .ToListAsync();
+
+            var users = userProjects
+                .Where(up => up.Project?.Id == projectId && up.Accepted)
+                .Select(up => up.User)
+                .ToList();
+
+            string messageCode = isOverflow ? "BUDGET_OVERFLOW" : "BUDGET_WARNING";
+
+            foreach (var user in users)
+            {
+                await notificationService.CreateNotificationAsync(new NotificationRequestDTO
+                {
+                    User = user,
+                    Type = NotificationType.Information,
+                    CodeMessage = messageCode,
+                    Category = NotificationCategory.Finance
+                });
+            }
         }
     }
 }

--- a/EasyFinance.Application/Features/WebPushService/WebPushService.cs
+++ b/EasyFinance.Application/Features/WebPushService/WebPushService.cs
@@ -405,10 +405,11 @@ namespace EasyFinance.Application.Features.WebPushService
 
         private static string ResolveNotificationBody(Notification notification)
         {
+            var culture = ResolveNotificationCulture(notification.User?.Culture);
             var projectName = ResolveMetadataValue(notification.Metadata, "ProjectName");
+
             if (string.Equals(notification.CodeMessage, EmailTemplates.GrantedAccess.ToString(), StringComparison.Ordinal))
             {
-                var culture = ResolveNotificationCulture(notification.User?.Culture);
                 var messageTemplate = string.IsNullOrWhiteSpace(projectName)
                     ? NotificationMessages.ResourceManager.GetString(nameof(NotificationMessages.ProjectInvitationPushBodyNoProject), culture)
                     : NotificationMessages.ResourceManager.GetString(nameof(NotificationMessages.ProjectInvitationPushBodyWithProject), culture);
@@ -423,7 +424,6 @@ namespace EasyFinance.Application.Features.WebPushService
 
             if (string.Equals(notification.CodeMessage, EmailTemplates.AccessLevelChanged.ToString(), StringComparison.Ordinal))
             {
-                var culture = ResolveNotificationCulture(notification.User?.Culture);
                 var messageTemplate = NotificationMessages.ResourceManager.GetString(nameof(NotificationMessages.ProjectAccessLevelChangedPushBody), culture);
                 if (string.IsNullOrWhiteSpace(messageTemplate))
                     return notification.CodeMessage;
@@ -435,7 +435,7 @@ namespace EasyFinance.Application.Features.WebPushService
                 return string.Format(culture, messageTemplate, inviterName, roleLabel, projectName);
             }
 
-            return notification.CodeMessage;
+            return NotificationMessages.ResourceManager.GetString(notification.CodeMessage, culture) ?? notification.CodeMessage;
         }
 
         private static CultureInfo ResolveNotificationCulture(CultureInfo culture)

--- a/EasyFinance.Common.Tests/BaseTests.cs
+++ b/EasyFinance.Common.Tests/BaseTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System;
 using System.Linq;
 using AutoFixture;
@@ -22,6 +22,8 @@ using EasyFinance.Application.Features.ExpenseService;
 using EasyFinance.Application.Features.ExpenseItemService;
 using EasyFinance.Application.Features.AttachmentService;
 using EasyFinance.Application.Features.TaxYearService;
+using EasyFinance.Application.Features.NotificationService;
+using Moq;
 
 namespace EasyFinance.Common.Tests
 {
@@ -38,6 +40,7 @@ namespace EasyFinance.Common.Tests
         protected Project project1 = null!;
         protected Project project2 = null!;
         protected Project project3 = null!;
+        protected Mock<INotificationService> notificationServiceMock = new();
 
         protected Fixture Fixture
         {
@@ -75,6 +78,7 @@ namespace EasyFinance.Common.Tests
             services.AddScoped<IAttachmentService, AttachmentService>();
             services.AddSingleton<IAttachmentStorageService, FileSystemAttachmentStorageService>();
             services.AddScoped<IIncomeService, IncomeService>();
+            services.AddSingleton(notificationServiceMock.Object);
             services.AddLogging();
 
             services.AddIdentityCore<User>()

--- a/EasyFinance.Common.Tests/EasyFinance.Common.Tests.csproj
+++ b/EasyFinance.Common.Tests/EasyFinance.Common.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.12" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
   </ItemGroup>
 

--- a/EasyFinance.Infrastructure/NotificationMessages.pt.resx
+++ b/EasyFinance.Infrastructure/NotificationMessages.pt.resx
@@ -19,7 +19,7 @@
     <value>Você recebeu um convite para o projeto {0}.</value>
   </data>
   <data name="ProjectAccessLevelChangedPushBody" xml:space="preserve">
-    <value>{0} alterou seu nível de acesso para {1} no projeto {2}.</value>
+    <value>{0} alterou seu nível de acceso para {1} no projeto {2}.</value>
   </data>
   <data name="NotificationRoleViewer" xml:space="preserve">
     <value>Observador</value>
@@ -29,5 +29,11 @@
   </data>
   <data name="NotificationRoleAdmin" xml:space="preserve">
     <value>Administrador</value>
+  </data>
+  <data name="BUDGET_WARNING" xml:space="preserve">
+    <value>Aviso: O orçamento está quase esgotado (80%).</value>
+  </data>
+  <data name="BUDGET_OVERFLOW" xml:space="preserve">
+    <value>O orçamento foi excedido!</value>
   </data>
 </root>

--- a/EasyFinance.Infrastructure/NotificationMessages.resx
+++ b/EasyFinance.Infrastructure/NotificationMessages.resx
@@ -30,4 +30,10 @@
   <data name="NotificationRoleAdmin" xml:space="preserve">
     <value>Admin</value>
   </data>
+  <data name="BUDGET_WARNING" xml:space="preserve">
+    <value>Warning: Budget is nearly exhausted (80%).</value>
+  </data>
+  <data name="BUDGET_OVERFLOW" xml:space="preserve">
+    <value>Budget has been exceeded!</value>
+  </data>
 </root>

--- a/easyfinance.client/src/assets/i18n/messages.en.json
+++ b/easyfinance.client/src/assets/i18n/messages.en.json
@@ -468,5 +468,7 @@
   "PlanAllocationAllocate": "Allocate",
   "PlanAllocationSuccess": "Successfully allocated to plan!",
   "PlanAllocationError": "Failed to allocate to plan. Please try again.",
-  "PlanAllocationNote": "Allocation from income: {{value}}"
+  "PlanAllocationNote": "Allocation from income: {{value}}",
+  "BUDGET_OVERFLOW": "Budget has been exceeded!",
+  "BUDGET_WARNING": "Warning: Budget is nearly exhausted (80%)."
 }

--- a/easyfinance.client/src/assets/i18n/messages.pt.json
+++ b/easyfinance.client/src/assets/i18n/messages.pt.json
@@ -467,6 +467,8 @@
   "PlanAllocationAllocate": "Alocar",
   "PlanAllocationSuccess": "Alocado com sucesso ao plano!",
   "PlanAllocationError": "Falha ao alocar ao plano. Por favor, tente novamente.",
-  "PlanAllocationNote": "Alocação da receita: {{value}}"
+  "PlanAllocationNote": "Alocação da receita: {{value}}",
+  "BUDGET_OVERFLOW": "O orçamento foi excedido!",
+  "BUDGET_WARNING": "Aviso: O orçamento está quase esgotado (80%)."
 }
 


### PR DESCRIPTION
### Description
This PR implements the budget alert notification system as requested in issue #690.

### Changes
- Implemented `CheckBudgetAlertsAsync` in `ExpenseService` to monitor budget thresholds.
- - Added logic for 80% (Warning) and 100% (Overflow) notifications.
- - Ensured that if an expense jumps directly past 100%, only the overflow notification is sent.
- - Integrated notifications in both `CreateAsync` and `UpdateAsync`.
- - Added missing i18n keys for `BUDGET_WARNING` and `BUDGET_OVERFLOW` in English and Portuguese.
- - Added comprehensive unit tests in `ExpenseServiceTests.cs` covering all scenarios.
### Validation
- Verified all unit tests pass in a containerized environment (Docker).
- - Confirmed correct calculation of percentages using decimal precision.
Fixes #690