### PR TITLE
feat/#704 add project name to budget notification messages

### DIFF
--- a/EasyFinance.Application.Tests/ExpenseItemServiceTests.cs
+++ b/EasyFinance.Application.Tests/ExpenseItemServiceTests.cs
@@ -244,7 +244,7 @@ namespace EasyFinance.Application.Tests
 
             moveResponse.Succeeded.Should().BeTrue();
 
-            var expectedMetadata = JsonSerializer.Serialize(new { expenseName = targetExpenseName });
+            var expectedMetadata = JsonSerializer.Serialize(new { expenseName = targetExpenseName, projectName = "Budget Move Project" });
             notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r =>
                 r.CodeMessage == "BUDGET_OVERFLOW" &&
                 r.Metadata == expectedMetadata)), Times.AtLeastOnce());

--- a/EasyFinance.Application.Tests/ExpenseServiceTests.cs
+++ b/EasyFinance.Application.Tests/ExpenseServiceTests.cs
@@ -162,7 +162,7 @@ namespace EasyFinance.Application.Tests
 
             await expenseService.CreateAsync(this.user1, this.project1.Id, categoryId, expenseDto);
 
-            var expectedMetadata = JsonSerializer.Serialize(new { expenseName = "Overbudget Expense" });
+            var expectedMetadata = JsonSerializer.Serialize(new { expenseName = "Overbudget Expense", projectName = this.project1.Name });
             notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r =>
                 r.CodeMessage == "BUDGET_OVERFLOW" &&
                 r.Category == NotificationCategory.Finance &&
@@ -187,7 +187,7 @@ namespace EasyFinance.Application.Tests
 
             await expenseService.CreateAsync(this.user1, this.project1.Id, categoryId, expenseDto);
 
-            var expectedMetadata80 = JsonSerializer.Serialize(new { expenseName = "80% Budget Expense" });
+            var expectedMetadata80 = JsonSerializer.Serialize(new { expenseName = "80% Budget Expense", projectName = this.project1.Name });
             notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r =>
                 r.CodeMessage == "BUDGET_WARNING" &&
                 r.Category == NotificationCategory.Finance &&
@@ -228,7 +228,7 @@ namespace EasyFinance.Application.Tests
             var result = await expenseService.UpdateAsync(this.user1, project.Id, category.Id, expense.Id, patch);
             result.Succeeded.Should().BeTrue();
 
-            var expectedMetadataUpdate = JsonSerializer.Serialize(new { expenseName = "Update Expense" });
+            var expectedMetadataUpdate = JsonSerializer.Serialize(new { expenseName = "Update Expense", projectName = "Update Project" });
             notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r =>
                 r.CodeMessage == "BUDGET_WARNING" &&
                 r.Metadata == expectedMetadataUpdate)), Times.AtLeastOnce());
@@ -269,7 +269,7 @@ namespace EasyFinance.Application.Tests
 
             await expenseService.UpdateAsync(this.user1, project.Id, category.Id, expense.Id, patch);
 
-            var expectedMetadataJump = JsonSerializer.Serialize(new { expenseName = "Jump Expense" });
+            var expectedMetadataJump = JsonSerializer.Serialize(new { expenseName = "Jump Expense", projectName = "Jump Project" });
             notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r =>
                 r.CodeMessage == "BUDGET_OVERFLOW" &&
                 r.Metadata == expectedMetadataJump)), Times.AtLeastOnce());
@@ -313,7 +313,7 @@ namespace EasyFinance.Application.Tests
             var result = await expenseService.UpdateAsync(this.user1, project.Id, category.Id, expense.Id, patch);
             result.Succeeded.Should().BeTrue();
 
-            var expectedMetadataItem = JsonSerializer.Serialize(new { expenseName });
+            var expectedMetadataItem = JsonSerializer.Serialize(new { expenseName, projectName = "Item Add Project" });
             notificationServiceMock.Verify(n => n.CreateNotificationAsync(It.Is<NotificationRequestDTO>(r =>
                 r.CodeMessage == "BUDGET_WARNING" &&
                 r.Metadata == expectedMetadataItem)), Times.AtLeastOnce());

--- a/EasyFinance.Application/Features/ExpenseItemService/ExpenseItemService.cs
+++ b/EasyFinance.Application/Features/ExpenseItemService/ExpenseItemService.cs
@@ -172,6 +172,12 @@ namespace EasyFinance.Application.Features.ExpenseItemService
                     .Select(up => up.User)
                     .ToListAsync();
 
+                var projectName = await unitOfWork.ProjectRepository
+                    .NoTrackable()
+                    .Where(p => p.Id == projectId)
+                    .Select(p => p.Name)
+                    .FirstOrDefaultAsync();
+
                 string messageCode = isOverflow ? "BUDGET_OVERFLOW" : "BUDGET_WARNING";
 
                 foreach (var user in users)
@@ -183,7 +189,7 @@ namespace EasyFinance.Application.Features.ExpenseItemService
                         CodeMessage = messageCode,
                         Category = NotificationCategory.Finance,
                         LimitNotificationChannels = NotificationChannels.Push | NotificationChannels.InApp | NotificationChannels.WebPush,
-                        Metadata = JsonSerializer.Serialize(new { expenseName = expense.Name })
+                        Metadata = JsonSerializer.Serialize(new { expenseName = expense.Name, projectName = projectName })
                     });
                 }
             }

--- a/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
+++ b/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
@@ -377,6 +377,12 @@ namespace EasyFinance.Application.Features.ExpenseService
                     .Select(up => up.User)
                     .ToListAsync();
 
+                var projectName = await unitOfWork.ProjectRepository
+                    .NoTrackable()
+                    .Where(p => p.Id == projectId)
+                    .Select(p => p.Name)
+                    .FirstOrDefaultAsync();
+
                 string messageCode = isOverflow ? "BUDGET_OVERFLOW" : "BUDGET_WARNING";
 
                 foreach (var user in users)
@@ -388,7 +394,7 @@ namespace EasyFinance.Application.Features.ExpenseService
                         CodeMessage = messageCode,
                         Category = NotificationCategory.Finance,
                         LimitNotificationChannels = NotificationChannels.Push | NotificationChannels.InApp | NotificationChannels.WebPush,
-                        Metadata = JsonSerializer.Serialize(new { expenseName = expense.Name })
+                        Metadata = JsonSerializer.Serialize(new { expenseName = expense.Name, projectName = projectName })
                     });
                 }
             }

--- a/EasyFinance.Application/Features/WebPushService/WebPushService.cs
+++ b/EasyFinance.Application/Features/WebPushService/WebPushService.cs
@@ -443,7 +443,8 @@ namespace EasyFinance.Application.Features.WebPushService
                     return notification.CodeMessage;
 
                 var expenseName = ResolveMetadataValue(notification.Metadata, "expenseName");
-                return string.Format(culture, messageTemplate, expenseName);
+                var projectName = ResolveMetadataValue(notification.Metadata, "projectName");
+                return string.Format(culture, messageTemplate, expenseName, projectName);
             }
 
             return NotificationMessages.ResourceManager.GetString(notification.CodeMessage, culture) ?? notification.CodeMessage;

--- a/EasyFinance.Application/Features/WebPushService/WebPushService.cs
+++ b/EasyFinance.Application/Features/WebPushService/WebPushService.cs
@@ -443,7 +443,6 @@ namespace EasyFinance.Application.Features.WebPushService
                     return notification.CodeMessage;
 
                 var expenseName = ResolveMetadataValue(notification.Metadata, "expenseName");
-                var projectName = ResolveMetadataValue(notification.Metadata, "projectName");
                 return string.Format(culture, messageTemplate, expenseName, projectName);
             }
 

--- a/EasyFinance.Infrastructure/NotificationMessages.pt.resx
+++ b/EasyFinance.Infrastructure/NotificationMessages.pt.resx
@@ -31,9 +31,9 @@
     <value>Administrador</value>
   </data>
   <data name="BUDGET_WARNING" xml:space="preserve">
-    <value>Aviso: O orçamento de '{0}' está quase esgotado (80%).</value>
+    <value>Aviso: O orçamento de '{0}' no projeto '{1}' está quase esgotado (80%).</value>
   </data>
   <data name="BUDGET_OVERFLOW" xml:space="preserve">
-    <value>O orçamento de '{0}' foi excedido!</value>
+    <value>O orçamento de '{0}' no projeto '{1}' foi excedido!</value>
   </data>
 </root>

--- a/EasyFinance.Infrastructure/NotificationMessages.resx
+++ b/EasyFinance.Infrastructure/NotificationMessages.resx
@@ -31,9 +31,9 @@
     <value>Admin</value>
   </data>
   <data name="BUDGET_WARNING" xml:space="preserve">
-    <value>Warning: Budget for '{0}' is nearly exhausted (80%).</value>
+    <value>Warning: Budget for '{0}' in project '{1}' is nearly exhausted (80%).</value>
   </data>
   <data name="BUDGET_OVERFLOW" xml:space="preserve">
-    <value>Budget for '{0}' has been exceeded!</value>
+    <value>Budget for '{0}' in project '{1}' has been exceeded!</value>
   </data>
 </root>

--- a/easyfinance.client/src/app/core/services/notification.service.ts
+++ b/easyfinance.client/src/app/core/services/notification.service.ts
@@ -85,6 +85,12 @@ export class NotificationService {
     ).subscribe();
   }
 
+  public refresh(): void {
+    this.getNotifications().pipe(
+      tap(notifications => this.notifications.next(notifications))
+    ).subscribe();
+  }
+
   public startPolling() {
     if (this.pollingSubscription) return;
 

--- a/easyfinance.client/src/app/core/services/notification.service.ts
+++ b/easyfinance.client/src/app/core/services/notification.service.ts
@@ -124,7 +124,8 @@ export class NotificationService {
 
     if (notification.codeMessage === 'BUDGET_WARNING' || notification.codeMessage === 'BUDGET_OVERFLOW') {
       return {
-        expenseName: this.resolveMetadataValue(notification, 'expenseName') ?? ''
+        expenseName: this.resolveMetadataValue(notification, 'expenseName') ?? '',
+        projectName: this.resolveMetadataValue(notification, 'projectName') ?? ''
       };
     }
 

--- a/easyfinance.client/src/app/features/expense/add-expense/add-expense.component.ts
+++ b/easyfinance.client/src/app/features/expense/add-expense/add-expense.component.ts
@@ -33,6 +33,7 @@ import { AttachmentType } from '../../../core/enums/attachment-type';
 import { SnackbarComponent } from '../../../core/components/snackbar/snackbar.component';
 import { Expense } from '../../../core/models/expense';
 import { ProjectService } from '../../../core/services/project.service';
+import { NotificationService } from '../../../core/services/notification.service';
 import { ProjectTaxYearSettings } from '../../../core/models/project-tax-year-settings';
 import { computeTaxYearPeriod, hasTaxYearRuleConfigured } from '../../../core/utils/tax-year';
 import { ConfigureTaxYearRuleDialogComponent } from '../../../core/components/configure-tax-year-rule-dialog/configure-tax-year-rule-dialog.component';
@@ -82,6 +83,7 @@ export class AddExpenseComponent implements OnInit, AfterViewInit {
   private cdr = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private projectService = inject(ProjectService);
+  private notificationService = inject(NotificationService);
   private proofUploadSubscription?: Subscription;
 
   private currentDate!: Moment;
@@ -490,6 +492,8 @@ export class AddExpenseComponent implements OnInit, AfterViewInit {
   }
 
   private handleSaved(expense: ExpenseDto): void {
+    this.notificationService.refresh();
+
     if (this.inlineMode) {
       this.saved.emit(expense);
       return;

--- a/easyfinance.client/src/assets/i18n/messages.en.json
+++ b/easyfinance.client/src/assets/i18n/messages.en.json
@@ -469,6 +469,6 @@
   "PlanAllocationSuccess": "Successfully allocated to plan!",
   "PlanAllocationError": "Failed to allocate to plan. Please try again.",
   "PlanAllocationNote": "Allocation from income: {{value}}",
-  "BUDGET_OVERFLOW": "Budget for '{{ expenseName }}' has been exceeded!",
-  "BUDGET_WARNING": "Warning: Budget for '{{ expenseName }}' is nearly exhausted (80%)."
+  "BUDGET_OVERFLOW": "Budget for '{{ expenseName }}' in project '{{ projectName }}' has been exceeded!",
+  "BUDGET_WARNING": "Warning: Budget for '{{ expenseName }}' in project '{{ projectName }}' is nearly exhausted (80%)."
 }

--- a/easyfinance.client/src/assets/i18n/messages.pt.json
+++ b/easyfinance.client/src/assets/i18n/messages.pt.json
@@ -468,7 +468,7 @@
   "PlanAllocationSuccess": "Alocado com sucesso ao plano!",
   "PlanAllocationError": "Falha ao alocar ao plano. Por favor, tente novamente.",
   "PlanAllocationNote": "Alocação da receita: {{value}}",
-  "BUDGET_OVERFLOW": "O orçamento de '{{ expenseName }}' foi excedido!",
-  "BUDGET_WARNING": "Aviso: O orçamento de '{{ expenseName }}' está quase esgotado (80%)."
+  "BUDGET_OVERFLOW": "O orçamento de '{{ expenseName }}' no projeto '{{ projectName }}' foi excedido!",
+  "BUDGET_WARNING": "Aviso: O orçamento de '{{ expenseName }}' no projeto '{{ projectName }}' está quase esgotado (80%)."
 }
 

--- a/easyfinance.client/src/assets/version.json
+++ b/easyfinance.client/src/assets/version.json
@@ -1,3 +1,3 @@
 {
-  "versionNumber": "1.1.58"
+  "versionNumber": "1.1.59"
 }


### PR DESCRIPTION
Include projectName in budget notification metadata and translation strings so users managing multiple projects can identify which project triggered the 80%/100% budget alert.

https://claude.ai/code/session_01B9UE1JjCHaRigtk8vJ8aRw

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

Add project name to budget notification messages

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #704 
- Closes #704 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
