### PR TITLE
docs: strengthen workflow enforcement in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,31 +1,38 @@
 # EconoFlow / EasyFinance
 
-Public name **EconoFlow**, internal codebase name **EasyFinance** — appears in namespaces, project names, and file paths. Three sub-projects in one repo:
+## MANDATORY Development Workflow
 
-| Directory | Stack |
-|-----------|-------|
-| `EasyFinance.*` (6 csproj) | ASP.NET Core 8 Clean Architecture |
-| `easyfinance.client/` | Angular 21 SPA |
-| `econoflow-mobile/` | React Native 0.85 + Expo SDK 56 |
+> **Every code change — no matter how small — must complete all four steps in order. There are no exceptions. A task is not done when the code compiles or looks correct. A task is done only when all four steps below are fully satisfied.**
 
-## Development Workflow
+**Definition of "done":**
+- [ ] Failing tests were written and confirmed red before any implementation code was touched
+- [ ] Implementation is complete
+- [ ] All tests pass and lint is clean
+- [ ] Architecture compliance self-review passed with no violations
 
-**Every code change — no matter how small — must follow these steps in order.**
+Skipping any step means the task is incomplete, regardless of whether the code appears to work.
 
-### 1. Before writing implementation code
+---
+
+### Step 1 — Write failing tests FIRST
+
+**STOP. Do not open any implementation file yet.**
 
 - Identify all existing tests that cover the area you are about to change:
   - Backend: `*.Tests/` projects (xUnit, files ending in `Tests.cs`)
   - Frontend: `*.spec.ts` files alongside the changed component/service
   - Mobile: `*.test.ts` / `*.test.tsx` files in `econoflow-mobile/`
-- Write or update the tests that cover the new or modified behaviour **before** writing implementation code. Run them once to confirm they fail — this proves the tests actually exercise the code path you are about to build.
+- Write or update the tests that cover the new or modified behaviour.
+- Run them and confirm they **fail**. Tests that were never red prove nothing — a green test written after the implementation does not count.
 
-### 2. Implement the change
+Only after you have a failing test may you move to Step 2.
+
+### Step 2 — Implement the change
 
 - Follow all architecture patterns documented in this file.
 - Keep changes focused: do not refactor unrelated code in the same commit.
 
-### 3. Run tests and lint
+### Step 3 — Run tests and lint
 
 Run the full suite for every sub-project that has changed files:
 
@@ -35,23 +42,36 @@ Run the full suite for every sub-project that has changed files:
 | Frontend | `cd easyfinance.client && npm test -- --watch=false --browsers=ChromeHeadless` | `cd easyfinance.client && npm run lint` |
 | Mobile | `cd econoflow-mobile && npm test && npm run typecheck` | `cd econoflow-mobile && npm run lint` |
 
-Fix every test failure and lint error before moving on.
+**STOP. Do not proceed to Step 4 if any test fails or any lint error exists.** Fix every failure first.
 
-### 4. Code review gate
+### Step 4 — Architecture compliance self-review
 
-Once all tests are green and lint is clean, perform an architecture compliance review against the rules in this file before considering the task done. Specifically verify:
+Once all tests are green and lint is clean, perform a self-review against the rules in this file before considering the task done. Verify every item below — quote the offending line when a violation is found:
 
-- No Clean Architecture layer dependency violations
-- Domain entity patterns respected (private setters, `SetXxx()`, `Validate` property)
-- `AppResponse<T>` used for all service return types; no exceptions for business failures
-- `NoTrackable()` used for read queries; single `CommitAsync()` per write path
-- API routes follow the `api/Projects/{projectId}/Categories/{categoryId}/[controller]` pattern
-- No hard-coded user-visible strings (use `.resx` / `react-i18next`)
-- No hard-coded colours in mobile (use `useAppTheme()`)
-- Sensitive data stored via `expo-secure-store`, not `AsyncStorage`
-- `requirements.md`, `architecture.md`, or `AGENTS.md` updated if the change introduces new features, patterns, or configuration
+- [ ] No Clean Architecture layer dependency violations
+- [ ] Domain entity patterns respected (private setters, `SetXxx()`, `Validate` property)
+- [ ] `AppResponse<T>` used for all service return types; no exceptions for business failures
+- [ ] `NoTrackable()` used for read queries; single `CommitAsync()` per write path
+- [ ] API routes follow the `api/Projects/{projectId}/Categories/{categoryId}/[controller]` pattern
+- [ ] No hard-coded user-visible strings (use `.resx` / `react-i18next`)
+- [ ] No hard-coded colours in mobile (use `useAppTheme()`)
+- [ ] Sensitive data stored via `expo-secure-store`, not `AsyncStorage`
+- [ ] `requirements.md`, `architecture.md`, or `AGENTS.md` updated if the change introduces new features, patterns, or configuration
+- [ ] Every new public method or component has a corresponding test
 
-Fix every violation found. Re-run tests after fixes. Only when tests are green and the review is clean is the task complete.
+Fix every violation found. Re-run tests after fixes. **The task is not complete until tests are green, lint is clean, and every checklist item above is confirmed.**
+
+---
+
+## Project Overview
+
+Public name **EconoFlow**, internal codebase name **EasyFinance** — appears in namespaces, project names, and file paths. Three sub-projects in one repo:
+
+| Directory | Stack |
+|-----------|-------|
+| `EasyFinance.*` (6 csproj) | ASP.NET Core 8 Clean Architecture |
+| `easyfinance.client/` | Angular 21 SPA |
+| `econoflow-mobile/` | React Native 0.85 + Expo SDK 56 |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,28 +2,39 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## MANDATORY Development Workflow
 
-EconoFlow (codebase name: EasyFinance) is a personal/company budget tracking application. It uses an ASP.NET Core 8 backend serving an Angular 21 SPA frontend, backed by SQL Server via EF Core.
+> **Every code change — no matter how small — must complete all four steps in order. There are no exceptions. A task is not done when the code compiles or looks correct. A task is done only when all four steps below are fully satisfied.**
 
-## Development Workflow
+**Definition of "done":**
+- [ ] Failing tests were written and confirmed red before any implementation code was touched
+- [ ] Implementation is complete
+- [ ] All tests pass and lint is clean
+- [ ] The `codereview` subagent returns a report with no Action Items
 
-**Every code change — no matter how small — must follow these steps in order.**
+Marking a task complete without a clean `codereview` report is not allowed.
 
-### 1. Before writing implementation code
+---
+
+### Step 1 — Write failing tests FIRST
+
+**STOP. Do not open any implementation file yet.**
 
 - Identify all existing tests that cover the area you are about to change:
   - Backend: `*.Tests/` projects (xUnit, files ending in `Tests.cs`)
   - Frontend: `*.spec.ts` files alongside the changed component/service
   - Mobile: `*.test.ts` / `*.test.tsx` files in `econoflow-mobile/`
-- Write or update the tests that cover the new or modified behaviour **before** writing implementation code. Run them once to confirm they fail — this proves the tests actually exercise the code path you are about to build.
+- Write or update the tests that cover the new or modified behaviour.
+- Run them and confirm they **fail**. Tests that were never red prove nothing — a green test written after the implementation does not count.
 
-### 2. Implement the change
+Only after you have a failing test may you move to Step 2.
+
+### Step 2 — Implement the change
 
 - Follow all architecture patterns described in this file.
 - Keep changes focused: do not refactor unrelated code in the same commit.
 
-### 3. Run tests and lint
+### Step 3 — Run tests and lint
 
 Run the full suite for every sub-project that has changed files:
 
@@ -33,18 +44,24 @@ Run the full suite for every sub-project that has changed files:
 | Frontend | `cd easyfinance.client && npm test -- --watch=false --browsers=ChromeHeadless` | `cd easyfinance.client && npm run lint` |
 | Mobile | `cd econoflow-mobile && npm test && npm run typecheck` | `cd econoflow-mobile && npm run lint` |
 
-Fix every test failure and lint error before moving on.
+**STOP. Do not proceed to Step 4 if any test fails or any lint error exists.** Fix every failure first.
 
-### 4. Code review gate
+### Step 4 — Code review gate
 
 Once all tests are green and lint is clean, spawn the `codereview` subagent (defined in `.claude/agents/codereview.md`). This agent runs in a **fresh, isolated context** — it has no knowledge of your implementation, which makes the review objective.
 
 - Read the report the subagent returns.
-- Fix **every item listed under "Action Items"** (these are blocking).
+- Fix **every item listed under "Action Items"** — these are blocking.
 - Re-run the relevant tests after each fix to confirm nothing regressed.
 - Spawn `codereview` again — repeat until the report shows **no Action Items**.
 
-Only when the `codereview` subagent report is clean is the task complete.
+**The task is not complete until the codereview report has no Action Items.** Do not respond as if the work is done before reaching this state.
+
+---
+
+## Project Overview
+
+EconoFlow (codebase name: EasyFinance) is a personal/company budget tracking application. It uses an ASP.NET Core 8 backend serving an Angular 21 SPA frontend, backed by SQL Server via EF Core.
 
 ---
 

--- a/econoflow-mobile/AGENTS.md
+++ b/econoflow-mobile/AGENTS.md
@@ -1,5 +1,66 @@
 # econoflow-mobile
 
+## MANDATORY Development Workflow
+
+> **Every code change — no matter how small — must complete all four steps in order. There are no exceptions. A task is not done when the code compiles or looks correct. A task is done only when all four steps below are fully satisfied.**
+
+**Definition of "done":**
+- [ ] Failing tests were written and confirmed red before any implementation code was touched
+- [ ] Implementation is complete
+- [ ] All tests pass, typecheck is clean, and lint is clean
+- [ ] Architecture compliance self-review passed with no violations
+
+Skipping any step means the task is incomplete, regardless of whether the code appears to work.
+
+---
+
+### Step 1 — Write failing tests FIRST
+
+**STOP. Do not open any implementation file yet.**
+
+- Find the existing test file alongside the file you are about to change (`*.test.ts` / `*.test.tsx`).
+- Write or update the tests that cover the new or modified behaviour.
+- Run them and confirm they **fail**:
+  ```bash
+  cd econoflow-mobile && npm test
+  ```
+  Tests that were never red prove nothing — a green test written after the implementation does not count.
+
+Only after you have a failing test may you move to Step 2.
+
+### Step 2 — Implement the change
+
+- Follow all architecture patterns documented in this file.
+- Keep changes focused: do not refactor unrelated code in the same commit.
+
+### Step 3 — Run tests, typecheck, and lint
+
+```bash
+cd econoflow-mobile && npm test && npm run typecheck && npm run lint
+```
+
+**STOP. Do not proceed to Step 4 if any test fails, any type error exists, or any lint warning exists** (`--max-warnings 0` is enforced). Fix every failure first.
+
+### Step 4 — Architecture compliance self-review
+
+Verify every item below before marking the task done — quote the offending line when a violation is found:
+
+- [ ] No hard-coded user-visible strings — use `react-i18next` (`useTranslation` / `i18next.t()`); translation keys added to `src/i18n/locales/`
+- [ ] No hard-coded colour values — all colours come from `useAppTheme()` (`theme.colors.*` / `theme.customColors.*`)
+- [ ] Global auth/project state lives in Zustand stores under `src/store/`; remote state uses React Query
+- [ ] All HTTP goes through the Axios instance in `src/api/client.ts`
+- [ ] API URL read from `EXPO_PUBLIC_API_URL` — never hard-coded
+- [ ] New screens registered in `src/navigation/` — no ad-hoc navigation
+- [ ] User-facing errors use `ErrorBanner` (`src/components/common/ErrorBanner.tsx`)
+- [ ] Sensitive data stored via `expo-secure-store`, not `AsyncStorage`
+- [ ] No API keys, tokens, or secrets in source files, `app.json`, or `EXPO_PUBLIC_*` variables
+- [ ] Every new exported function or component has a corresponding Jest test
+- [ ] `econoflow-mobile/AGENTS.md` or repo-root `AGENTS.md` updated if the change introduces new patterns or configuration
+
+**The task is not complete until tests are green, typecheck and lint are clean, and every checklist item above is confirmed.**
+
+---
+
 React Native 0.85 + Expo SDK 56 app. Read the exact versioned docs at https://docs.expo.dev/versions/v56.0.0/ before writing any code.
 
 ## Build (release APK)


### PR DESCRIPTION
Move the mandatory development workflow to the top of every agent/instruction
file so it is the first thing any agent reads. Add explicit "STOP" checkpoints,
a concrete definition-of-done checklist, and language that makes clear a task
is not complete until tests are green, lint is clean, and the code-review gate
is satisfied. Mirrors the same structure across CLAUDE.md, AGENTS.md, and
econoflow-mobile/AGENTS.md for consistency.

https://claude.ai/code/session_01MV4JqdqqdFJxY5bRrfEfSn