### PR TITLE
refactor: centralise chart colours and fix hardcoded locales

### DIFF
--- a/easyfinance.client/src/app/core/components/configure-tax-year-rule-dialog/configure-tax-year-rule-dialog.component.spec.ts
+++ b/easyfinance.client/src/app/core/components/configure-tax-year-rule-dialog/configure-tax-year-rule-dialog.component.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { ConfigureTaxYearRuleDialogComponent } from './configure-tax-year-rule-dialog.component';
+import { ProjectService } from '../../services/project.service';
+import { ErrorMessageService } from '../../services/error-message.service';
+import { GlobalService } from '../../services/global.service';
+
+describe('ConfigureTaxYearRuleDialogComponent - months locale', () => {
+  let fixture: ComponentFixture<ConfigureTaxYearRuleDialogComponent>;
+  let component: ConfigureTaxYearRuleDialogComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ConfigureTaxYearRuleDialogComponent,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        {
+          provide: GlobalService,
+          useValue: { currentLanguage: 'pt' }
+        },
+        {
+          provide: ProjectService,
+          useValue: {
+            upsertTaxYearSettings: jasmine.createSpy('upsertTaxYearSettings').and.returnValue(of({}))
+          }
+        },
+        {
+          provide: ErrorMessageService,
+          useValue: {}
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfigureTaxYearRuleDialogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should use GlobalService language for month labels', () => {
+    const expectedJanuary = new Date(2001, 0, 1).toLocaleString('pt', { month: 'long' });
+    expect(component.months[0].label).toBe(expectedJanuary);
+  });
+
+  it('should generate 12 months', () => {
+    expect(component.months.length).toBe(12);
+  });
+
+  it('should assign correct month values 1-12', () => {
+    for (let i = 0; i < 12; i++) {
+      expect(component.months[i].value).toBe(i + 1);
+    }
+  });
+});

--- a/easyfinance.client/src/app/core/components/configure-tax-year-rule-dialog/configure-tax-year-rule-dialog.component.ts
+++ b/easyfinance.client/src/app/core/components/configure-tax-year-rule-dialog/configure-tax-year-rule-dialog.component.ts
@@ -8,6 +8,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { ProjectService } from '../../services/project.service';
 import { ErrorMessageService } from '../../services/error-message.service';
+import { GlobalService } from '../../services/global.service';
 import { TaxYearType } from '../../enums/tax-year-type';
 import { TaxYearLabeling } from '../../enums/tax-year-labeling';
 import { ProjectTaxYearSettings, ProjectTaxYearSettingsRequest } from '../../models/project-tax-year-settings';
@@ -29,6 +30,7 @@ import { ApiErrorResponse } from '../../models/error';
 export class ConfigureTaxYearRuleDialogComponent implements OnInit {
   private projectService = inject(ProjectService);
   private errorMessageService = inject(ErrorMessageService);
+  private globalService = inject(GlobalService);
 
   @Input({ required: true })
   projectId!: string;
@@ -54,7 +56,7 @@ export class ConfigureTaxYearRuleDialogComponent implements OnInit {
   ];
   months = Array.from({ length: 12 }, (_, index) => ({
     value: index + 1,
-    label: new Date(2001, index, 1).toLocaleString(undefined, { month: 'long' })
+    label: new Date(2001, index, 1).toLocaleString(this.globalService.currentLanguage, { month: 'long' })
   }));
 
   constructor() {

--- a/easyfinance.client/src/app/core/constants/chart-colors.ts
+++ b/easyfinance.client/src/app/core/constants/chart-colors.ts
@@ -1,0 +1,36 @@
+export const ChartColors = {
+  income: '#2ecc71',
+  incomeAlpha15: 'rgba(46, 204, 113, 0.15)',
+
+  expense: '#ff6b6b',
+  expenseAlpha12: 'rgba(255, 107, 107, 0.12)',
+
+  budget: '#5dade2',
+  budgetAlpha15: 'rgba(93, 173, 226, 0.15)',
+
+  chartRed: 'rgb(255, 99, 132)',
+  chartRedAlpha20: 'rgba(255, 99, 132, 0.2)',
+  chartBlue: 'rgb(54, 162, 235)',
+  chartBlueAlpha20: 'rgba(54, 162, 235, 0.2)',
+  budgetExceeded: 'rgb(255, 0, 0)',
+
+  white: '#ffffff',
+
+  categoryPalette: [
+    '#ff6b6b',
+    '#4ecdc4',
+    '#ffe66d',
+    '#5dade2',
+    '#f39c12',
+    '#9b59b6',
+    '#2ecc71',
+    '#e74c3c',
+    '#1abc9c',
+    '#f1c40f'
+  ] as string[]
+} as const;
+
+export const ThemeColors = {
+  lightThemeColor: '#0f76a8',
+  darkThemeColor: '#0f1724'
+} as const;

--- a/easyfinance.client/src/app/core/services/theme.service.ts
+++ b/easyfinance.client/src/app/core/services/theme.service.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { BehaviorSubject, map } from 'rxjs';
+import { ThemeColors } from '../constants/chart-colors';
 
 export type ThemeMode = 'light' | 'dark';
 type AppleStatusBarStyle = 'default' | 'black-translucent';
@@ -20,12 +21,12 @@ export class ThemeService {
   private readonly storageKey = 'theme-mode';
   private readonly themePresentation: Record<ThemeMode, ThemePresentation> = {
     light: {
-      themeColor: '#0f76a8',
+      themeColor: ThemeColors.lightThemeColor,
       manifestHref: '/manifest.webmanifest',
       appleStatusBarStyle: 'default'
     },
     dark: {
-      themeColor: '#0f1724',
+      themeColor: ThemeColors.darkThemeColor,
       manifestHref: '/manifest.dark.webmanifest',
       appleStatusBarStyle: 'black-translucent'
     }

--- a/easyfinance.client/src/app/features/project/add-edit-project/add-edit-project.component.spec.ts
+++ b/easyfinance.client/src/app/features/project/add-edit-project/add-edit-project.component.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+import { AddEditProjectComponent } from './add-edit-project.component';
+import { ProjectService } from '../../../core/services/project.service';
+import { CurrencyService } from '../../../core/services/currency.service';
+import { ErrorMessageService } from '../../../core/services/error-message.service';
+import { GlobalService } from '../../../core/services/global.service';
+import { ProjectDto } from '../models/project-dto';
+
+describe('AddEditProjectComponent - months locale', () => {
+  let fixture: ComponentFixture<AddEditProjectComponent>;
+  let component: AddEditProjectComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        AddEditProjectComponent,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        {
+          provide: GlobalService,
+          useValue: { currentLanguage: 'pt' }
+        },
+        {
+          provide: MatDialogRef,
+          useValue: { close: jasmine.createSpy('close'), afterClosed: () => of(null) }
+        },
+        {
+          provide: ProjectService,
+          useValue: {
+            getEditingProject: () => new ProjectDto(),
+            setEditingProject: jasmine.createSpy('setEditingProject'),
+            upsertTaxYearSettings: jasmine.createSpy('upsertTaxYearSettings').and.returnValue(of({}))
+          }
+        },
+        {
+          provide: CurrencyService,
+          useValue: { getAvailableCurrencies: () => [] }
+        },
+        {
+          provide: Router,
+          useValue: { navigate: jasmine.createSpy('navigate') }
+        },
+        {
+          provide: ErrorMessageService,
+          useValue: {}
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddEditProjectComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should use GlobalService language for month labels', () => {
+    const expectedJanuary = new Date(2001, 0, 1).toLocaleString('pt', { month: 'long' });
+    expect(component.months[0].label).toBe(expectedJanuary);
+  });
+
+  it('should generate 12 months', () => {
+    expect(component.months.length).toBe(12);
+  });
+
+  it('should assign correct month values 1-12', () => {
+    for (let i = 0; i < 12; i++) {
+      expect(component.months[i].value).toBe(i + 1);
+    }
+  });
+});

--- a/easyfinance.client/src/app/features/project/add-edit-project/add-edit-project.component.ts
+++ b/easyfinance.client/src/app/features/project/add-edit-project/add-edit-project.component.ts
@@ -21,6 +21,7 @@ import { PageModalComponent } from '../../../core/components/page-modal/page-mod
 import { TaxYearType } from '../../../core/enums/tax-year-type';
 import { TaxYearLabeling } from '../../../core/enums/tax-year-labeling';
 import { ProjectTaxYearSettings, ProjectTaxYearSettingsRequest } from '../../../core/models/project-tax-year-settings';
+import { GlobalService } from '../../../core/services/global.service';
 
 @Component({
   selector: 'app-add-edit-project',
@@ -43,6 +44,7 @@ export class AddEditProjectComponent implements OnInit {
   private currencyService = inject(CurrencyService);
   private router = inject(Router);
   private errorMessageService = inject(ErrorMessageService);
+  private globalService = inject(GlobalService);
 
   projectForm!: FormGroup;
   httpErrors = false;
@@ -58,7 +60,7 @@ export class AddEditProjectComponent implements OnInit {
   ];
   months = Array.from({ length: 12 }, (_, index) => ({
     value: index + 1,
-    label: new Date(2001, index, 1).toLocaleString(undefined, { month: 'long' })
+    label: new Date(2001, index, 1).toLocaleString(this.globalService.currentLanguage, { month: 'long' })
   }));
 
   ngOnInit(): void {

--- a/easyfinance.client/src/app/features/project/annual-overview/annual-overview.component.ts
+++ b/easyfinance.client/src/app/features/project/annual-overview/annual-overview.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ChartData, ChartOptions, TooltipItem } from 'chart.js';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { BaseChartDirective } from 'ng2-charts';
+import { ChartColors } from '../../../core/constants/chart-colors';
 import { filter, finalize, forkJoin, map, Observable } from 'rxjs';
 import { CurrencyFormatPipe } from '../../../core/utils/pipes/currency-format.pipe';
 import { ProjectService } from '../../../core/services/project.service';
@@ -74,18 +75,7 @@ export class AnnualOverviewComponent implements OnInit, AfterViewInit {
 
   expenseInsights: CategoryInsight[] = [];
 
-  private expenseColors = [
-    '#ff6b6b',
-    '#4ecdc4',
-    '#ffe66d',
-    '#5dade2',
-    '#f39c12',
-    '#9b59b6',
-    '#2ecc71',
-    '#e74c3c',
-    '#1abc9c',
-    '#f1c40f'
-  ];
+  private expenseColors = ChartColors.categoryPalette;
 
   expenseChartData: ChartData<'doughnut'> = this.createEmptyChartData();
   monthlyIncomeExpenseChartData: ChartData<'bar'> = this.createEmptyBarChartData();
@@ -310,7 +300,7 @@ export class AnnualOverviewComponent implements OnInit, AfterViewInit {
         {
           data: data.map(item => this.roundAmount(item.amount)),
           backgroundColor: data.map((_, index) => colors[index % colors.length]),
-          borderColor: '#ffffff',
+          borderColor: ChartColors.white,
           borderWidth: 1
         }
       ]
@@ -349,14 +339,14 @@ export class AnnualOverviewComponent implements OnInit, AfterViewInit {
         {
           label: this.translateService.instant('Income'),
           data: incomes.map(value => this.roundAmount(value)),
-          backgroundColor: '#2ecc71',
+          backgroundColor: ChartColors.income,
           borderRadius: 4,
           maxBarThickness: 26
         },
         {
           label: this.translateService.instant('Expense'),
           data: expenses.map(value => this.roundAmount(value)),
-          backgroundColor: '#ff6b6b',
+          backgroundColor: ChartColors.expense,
           borderRadius: 4,
           maxBarThickness: 26
         }

--- a/easyfinance.client/src/app/features/project/detail-project/monthly-expenses-chart/monthly-expenses-chart.component.ts
+++ b/easyfinance.client/src/app/features/project/detail-project/monthly-expenses-chart/monthly-expenses-chart.component.ts
@@ -8,6 +8,7 @@ import { IncomeDto } from '../../../income/models/income-dto';
 import { CurrentDateService } from '../../../../core/services/current-date.service';
 import { TranslateService } from '@ngx-translate/core';
 import { toLocalDate } from '../../../../core/utils/date';
+import { ChartColors } from '../../../../core/constants/chart-colors';
 
 @Component({
   selector: 'app-monthly-expenses-chart',
@@ -38,34 +39,34 @@ export class MonthlyExpensesChartComponent implements OnInit, OnChanges, AfterVi
         label: this.translateService.instant('Income'),
         fill: true,
         tension: 0.5,
-        borderColor: '#2ecc71',
-        backgroundColor: 'rgba(46, 204, 113, 0.15)'
+        borderColor: ChartColors.income,
+        backgroundColor: ChartColors.incomeAlpha15
       },
       {
         data: [],
         label: this.translateService.instant('Expense'),
         fill: true,
         tension: 0.5,
-        borderColor: 'rgb(255, 99, 132)',
-        backgroundColor: 'rgba(255, 99, 132, 0.2)',
+        borderColor: ChartColors.chartRed,
+        backgroundColor: ChartColors.chartRedAlpha20,
         pointBackgroundColor: (context: { parsed?: { y?: number | null } }) => {
           const raw = context?.parsed?.y;
           const value = typeof raw === 'number' ? raw : 0;
           const budget = typeof this.budget === 'number' ? this.budget : 0;
-          return value > budget ? 'rgb(255, 0, 0)' : 'rgb(255, 99, 132)';
+          return value > budget ? ChartColors.budgetExceeded : ChartColors.chartRed;
         },
         pointBorderColor: (context: { parsed?: { y?: number | null } }) => {
           const raw = context?.parsed?.y;
           const value = typeof raw === 'number' ? raw : 0;
           const budget = typeof this.budget === 'number' ? this.budget : 0;
-          return value > budget ? 'rgb(255, 0, 0)' : 'rgb(255, 99, 132)';
+          return value > budget ? ChartColors.budgetExceeded : ChartColors.chartRed;
         }
       },
       {
         data: [],
         label: this.translateService.instant('Budget'),
-        borderColor: 'rgb(54, 162, 235)',
-        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+        borderColor: ChartColors.chartBlue,
+        backgroundColor: ChartColors.chartBlueAlpha20,
         borderDash: [5, 5],
         fill: false,
         pointRadius: 0

--- a/easyfinance.client/src/app/features/project/monthly-overview/monthly-overview.component.ts
+++ b/easyfinance.client/src/app/features/project/monthly-overview/monthly-overview.component.ts
@@ -319,7 +319,7 @@ export class MonthlyOverviewComponent implements OnInit, AfterViewInit {
         {
           data: data.map(item => this.roundAmount(item.amount)),
           backgroundColor: data.map((_, index) => colors[index % colors.length]),
-          borderColor: '#ffffff',
+          borderColor: ChartColors.white,
           borderWidth: 1
         }
       ]

--- a/easyfinance.client/src/app/features/project/monthly-overview/monthly-overview.component.ts
+++ b/easyfinance.client/src/app/features/project/monthly-overview/monthly-overview.component.ts
@@ -17,6 +17,7 @@ import { toLocalDate } from '../../../core/utils/date';
 import { CurrencyFormatPipe } from '../../../core/utils/pipes/currency-format.pipe';
 import { ProjectDto } from '../models/project-dto';
 import { UserProjectDto } from '../models/user-project-dto';
+import { ChartColors } from '../../../core/constants/chart-colors';
 import { ReturnButtonComponent } from '../../../core/components/return-button/return-button.component';
 import { CurrentDateComponent } from '../../../core/components/current-date/current-date.component';
 import { CurrentDateService } from '../../../core/services/current-date.service';
@@ -77,18 +78,7 @@ export class MonthlyOverviewComponent implements OnInit, AfterViewInit {
 
   expenseInsights: CategoryInsight[] = [];
 
-  private expenseColors = [
-    '#ff6b6b',
-    '#4ecdc4',
-    '#ffe66d',
-    '#5dade2',
-    '#f39c12',
-    '#9b59b6',
-    '#2ecc71',
-    '#e74c3c',
-    '#1abc9c',
-    '#f1c40f'
-  ];
+  private expenseColors = ChartColors.categoryPalette;
 
   dailyIncomeExpenseChartData: ChartData<'line'> = this.createEmptyLineChartData();
   expenseChartData: ChartData<'doughnut'> = this.createEmptyDoughnutChartData();
@@ -269,8 +259,8 @@ export class MonthlyOverviewComponent implements OnInit, AfterViewInit {
         {
           label: this.translateService.instant('Income'),
           data: cumulativeIncome.map(value => this.roundAmount(value)),
-          borderColor: '#2ecc71',
-          backgroundColor: 'rgba(46, 204, 113, 0.15)',
+          borderColor: ChartColors.income,
+          backgroundColor: ChartColors.incomeAlpha15,
           pointRadius: 2,
           tension: 0.3,
           fill: true
@@ -278,8 +268,8 @@ export class MonthlyOverviewComponent implements OnInit, AfterViewInit {
         {
           label: this.translateService.instant('Expense'),
           data: cumulativeExpense.map(value => this.roundAmount(value)),
-          borderColor: '#ff6b6b',
-          backgroundColor: 'rgba(255, 107, 107, 0.12)',
+          borderColor: ChartColors.expense,
+          backgroundColor: ChartColors.expenseAlpha12,
           pointRadius: 2,
           tension: 0.3,
           fill: true
@@ -287,8 +277,8 @@ export class MonthlyOverviewComponent implements OnInit, AfterViewInit {
         {
           label: this.translateService.instant('Budget'),
           data: budgetLine,
-          borderColor: '#5dade2',
-          backgroundColor: 'rgba(93, 173, 226, 0.15)',
+          borderColor: ChartColors.budget,
+          backgroundColor: ChartColors.budgetAlpha15,
           borderDash: [5, 5],
           pointRadius: 0,
           tension: 0,

--- a/easyfinance.client/src/app/features/project/project-overview/project-overview.component.ts
+++ b/easyfinance.client/src/app/features/project/project-overview/project-overview.component.ts
@@ -4,6 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ChartData, ChartOptions, TooltipItem } from 'chart.js';
+import { ChartColors } from '../../../core/constants/chart-colors';
 import { catchError, filter, forkJoin, map, of, switchMap } from 'rxjs';
 import { CurrentDateComponent } from '../../../core/components/current-date/current-date.component';
 import { Category } from '../../../core/models/category';
@@ -336,14 +337,14 @@ export class ProjectOverviewComponent implements OnInit {
         {
           label: this.translateService.instant('Income'),
           data: incomes.map(value => this.roundAmount(value)),
-          backgroundColor: '#2ecc71',
+          backgroundColor: ChartColors.income,
           borderRadius: 4,
           maxBarThickness: 26
         },
         {
           label: this.translateService.instant('Expense'),
           data: expenses.map(value => this.roundAmount(value)),
-          backgroundColor: '#ff6b6b',
+          backgroundColor: ChartColors.expense,
           borderRadius: 4,
           maxBarThickness: 26
         }

--- a/easyfinance.client/src/assets/version.json
+++ b/easyfinance.client/src/assets/version.json
@@ -1,3 +1,3 @@
 {
-  "versionNumber": "1.1.59"
+  "versionNumber": "1.1.60"
 }

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -4,11 +4,11 @@ import pt from '../locales/pt.json';
 type LocaleMap = Record<string, string>;
 
 describe('i18n locale completeness', () => {
-  it('en.json contains LabelCategories', () => {
-    expect((en as LocaleMap)['LabelCategories']).toBeDefined();
+  it('en.json contains LabelCategories with a non-empty value', () => {
+    expect((en as LocaleMap)['LabelCategories']).toBeTruthy();
   });
 
-  it('pt.json contains LabelCategories', () => {
-    expect((pt as LocaleMap)['LabelCategories']).toBeDefined();
+  it('pt.json contains LabelCategories with a non-empty value', () => {
+    expect((pt as LocaleMap)['LabelCategories']).toBeTruthy();
   });
 });

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -1,0 +1,14 @@
+import en from '../locales/en.json';
+import pt from '../locales/pt.json';
+
+type LocaleMap = Record<string, string>;
+
+describe('i18n locale completeness', () => {
+  it('en.json contains LabelCategories', () => {
+    expect((en as LocaleMap)['LabelCategories']).toBeDefined();
+  });
+
+  it('pt.json contains LabelCategories', () => {
+    expect((pt as LocaleMap)['LabelCategories']).toBeDefined();
+  });
+});

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -549,5 +549,6 @@
   "LabelDeductibleHint": "for tax declaration",
   "LabelSelectProject": "Select a project",
   "LabelMyAccount": "My Account",
+  "LabelCategories": "Categories",
   "Optional": "optional"
 }

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -548,6 +548,7 @@
   "LabelDeductibleHint": "para IR / declaração",
   "LabelSelectProject": "Selecionar projeto",
   "LabelMyAccount": "Minha Conta",
+  "LabelCategories": "Categorias",
   "Optional": "opcional"
 }
 

--- a/econoflow-mobile/src/navigation/MainNavigator.tsx
+++ b/econoflow-mobile/src/navigation/MainNavigator.tsx
@@ -37,6 +37,7 @@ export const MainNavigator: React.FC = () => {
   const [quickAddVisible, setQuickAddVisible] = useState(false);
   const quickAddCategoryId = useQuickAddStore(s => s.categoryId);
   const quickAddDefaultType = useQuickAddStore(s => s.defaultType);
+  const quickAddViewedMonth = useQuickAddStore(s => s.viewedMonth);
 
   return (
     <>
@@ -127,7 +128,7 @@ export const MainNavigator: React.FC = () => {
     <QuickAddModal
       visible={quickAddVisible}
       onClose={() => setQuickAddVisible(false)}
-      month={currentMonth()}
+      month={quickAddViewedMonth ?? currentMonth()}
       defaultCategoryId={quickAddCategoryId ?? undefined}
       defaultType={quickAddDefaultType ?? undefined}
     />

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -59,13 +59,18 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
   const projectId = selectedProject?.project.id ?? '';
   const canEdit = selectedProject?.role !== 'Viewer';
 
-  // Publish current category to the global FAB so it can pre-select it
+  // Publish current category and month to the global FAB so it can pre-select them
   const setQuickAddCategoryId = useQuickAddStore(s => s.setCategoryId);
+  const setViewedMonth = useQuickAddStore(s => s.setViewedMonth);
   useFocusEffect(
     useCallback(() => {
       setQuickAddCategoryId(categoryId);
-      return () => setQuickAddCategoryId(null);
-    }, [categoryId, setQuickAddCategoryId])
+      setViewedMonth(month);
+      return () => {
+        setQuickAddCategoryId(null);
+        setViewedMonth(null);
+      };
+    }, [categoryId, setQuickAddCategoryId, setViewedMonth, month])
   );
 
   const { data: expenses, isLoading, isFetching, refetch } =

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -8,6 +8,7 @@ import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
+import i18n from 'i18next';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { OverviewStackParamList } from '../../navigation/OverviewStackNavigator';
 import { useProjectStore } from '../../store/projectStore';
@@ -28,15 +29,13 @@ import { getCategoryColor } from '../../utils/categoryTheme';
 import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { useAppTheme } from '../../theme/useAppTheme';
 import { useQuickAddStore } from '../../store/quickAddStore';
+import { formatAmount } from '../../utils/format';
 import type { TFunction } from 'i18next';
 import type { Expense, ExpenseItem } from '../../api/types';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'ExpenseList'>;
-
-function fmt(n: number): string {
-  return Math.abs(n).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-}
 
 interface QuickAddState {
   visible: boolean;
@@ -47,7 +46,9 @@ interface QuickAddState {
 export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2, hair } = useAuroraSkin();
+  const { colors, customColors } = useAppTheme();
   const insets = useSafeAreaInsets();
+  const fmt = (n: number) => formatAmount(n, i18n.language);
 
   const { categoryId, categoryName, month: initialMonth, categoryIndex = 0 } = route.params;
   const [month, setMonth] = useState(initialMonth);
@@ -201,8 +202,8 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                             : fromDateOnly(expense.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
                         </Text>
                         {expense.isDeductible && (
-                          <View style={styles.deductBadge}>
-                            <Text style={styles.deductBadgeText}>
+                          <View style={[styles.deductBadge, { backgroundColor: colors.primary + '26' }]}>
+                            <Text style={[styles.deductBadgeText, { color: colors.primary }]}>
                               {t('LabelDeductible') ?? 'Deductible'}
                             </Text>
                           </View>
@@ -219,7 +220,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                     </View>
 
                     <View style={styles.groupAmtCol}>
-                      <Text style={[styles.groupAmt, { color: '#e74c3c' }]}>
+                      <Text style={[styles.groupAmt, { color: customColors.expense }]}>
                         −{sym} {fmt(expense.amount)}
                       </Text>
                       {expense.budget > 0 && (
@@ -257,7 +258,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                           hitSlop={6}
                           style={styles.groupAction}
                         >
-                          <MaterialCommunityIcons name="trash-can-outline" size={16} color="#e74c3c" />
+                          <MaterialCommunityIcons name="trash-can-outline" size={16} color={customColors.expense} />
                         </TouchableOpacity>
                       </>
                     )}
@@ -402,8 +403,10 @@ interface ItemRowProps {
 const ExpenseItemRow: React.FC<ItemRowProps> = ({
   item, currency, color, ink, ink2, hair, isLast, canEdit, onDelete,
 }) => {
+  const { customColors } = useAppTheme();
   const date = fromDateOnly(item.date);
   const dateStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const fmt = (n: number) => formatAmount(n, i18n.language);
 
   return (
     <View style={[styles.itemRow, { borderBottomColor: isLast ? 'transparent' : hair }]}>
@@ -416,13 +419,13 @@ const ExpenseItemRow: React.FC<ItemRowProps> = ({
         <Text style={[styles.itemDate, { color: ink2 }]}>{dateStr}</Text>
       </View>
 
-      <Text style={[styles.itemAmt, { color: '#e74c3c' }]}>
+      <Text style={[styles.itemAmt, { color: customColors.expense }]}>
         −{currency} {fmt(item.amount)}
       </Text>
 
       {canEdit && (
         <TouchableOpacity onPress={onDelete} hitSlop={8} style={styles.itemDelete}>
-          <MaterialCommunityIcons name="trash-can-outline" size={15} color="#e74c3c" />
+          <MaterialCommunityIcons name="trash-can-outline" size={15} color={customColors.expense} />
         </TouchableOpacity>
       )}
     </View>
@@ -483,10 +486,10 @@ const styles = StyleSheet.create({
   groupAction:  { padding: 4 },
 
   deductBadge: {
-    backgroundColor: '#0f76a826', borderRadius: 999,
+    borderRadius: 999,
     paddingHorizontal: 6, paddingVertical: 1,
   },
-  deductBadgeText: { fontSize: 10, fontWeight: '700', color: '#0f76a8' },
+  deductBadgeText: { fontSize: 10, fontWeight: '700' },
   proofBadge: {
     flexDirection: 'row', alignItems: 'center', gap: 3,
     borderRadius: 999, paddingHorizontal: 6, paddingVertical: 1,

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import {
   StyleSheet, TouchableOpacity, View,
   ScrollView, RefreshControl,
 } from 'react-native';
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
@@ -65,13 +65,13 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
   useFocusEffect(
     useCallback(() => {
       setQuickAddCategoryId(categoryId);
-      setViewedMonth(month);
-      return () => {
-        setQuickAddCategoryId(null);
-        setViewedMonth(null);
-      };
-    }, [categoryId, setQuickAddCategoryId, setViewedMonth, month])
+      return () => setQuickAddCategoryId(null);
+    }, [categoryId, setQuickAddCategoryId])
   );
+  const isFocused = useIsFocused();
+  useEffect(() => {
+    setViewedMonth(isFocused ? month : null);
+  }, [month, isFocused, setViewedMonth]);
 
   const { data: expenses, isLoading, isFetching, refetch } =
     useExpensesForMonth(projectId, categoryId, month);

--- a/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
@@ -55,11 +55,16 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
   const canEdit = selectedProject?.role !== 'Viewer';
 
   const setDefaultType = useQuickAddStore(s => s.setDefaultType);
+  const setViewedMonth = useQuickAddStore(s => s.setViewedMonth);
   useFocusEffect(
     useCallback(() => {
       setDefaultType('income');
-      return () => setDefaultType(null);
-    }, [setDefaultType])
+      setViewedMonth(month);
+      return () => {
+        setDefaultType(null);
+        setViewedMonth(null);
+      };
+    }, [setDefaultType, setViewedMonth, month])
   );
 
   const { data: incomes, isLoading, isFetching, isError, refetch } = useIncomesForMonth(projectId, month);

--- a/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
@@ -8,6 +8,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
+import i18n from 'i18next';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { OverviewStackParamList } from '../../navigation/OverviewStackNavigator';
 import { useProjectStore } from '../../store/projectStore';
@@ -21,16 +22,14 @@ import { GlassCard } from '../../components/common/GlassCard';
 import { QuickAddModal } from '../quick-add/QuickAddModal';
 import type { QuickAddEditMode } from '../quick-add/QuickAddModal';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { useAppTheme } from '../../theme/useAppTheme';
 import { getCurrencySymbol } from '../../utils/currency';
 import { getCategoryIcon } from '../../utils/categoryIcon';
 import { fromDateOnly, formatMonthLabel } from '../../utils/date';
+import { formatAmount } from '../../utils/format';
 import { MonthNavigator } from '../../components/common/MonthNavigator';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'IncomeList'>;
-
-function fmt(n: number): string {
-  return Math.abs(n).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-}
 
 interface EditState {
   visible: boolean;
@@ -40,6 +39,7 @@ interface EditState {
 export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2 } = useAuroraSkin();
+  const { customColors } = useAppTheme();
   const insets = useSafeAreaInsets();
 
   const [month, setMonth] = useState(route.params.month);
@@ -70,6 +70,8 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
     await refetch();
     setRefreshing(false);
   };
+
+  const fmt = (n: number) => formatAmount(n, i18n.language);
 
   if (isLoading && !incomes) return <LoadingIndicator />;
 
@@ -118,8 +120,8 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
         {/* ── Summary card ──────────────────────────────────────────── */}
         <GlassCard dark={dark} radius={26} style={styles.summaryCard}>
           <View style={styles.summaryInner}>
-            <View style={styles.summaryIconWrap}>
-              <MaterialCommunityIcons name="arrow-up-circle" size={32} color="#2ecc71" />
+            <View style={[styles.summaryIconWrap, { backgroundColor: customColors.income + '26' }]}>
+              <MaterialCommunityIcons name="arrow-up-circle" size={32} color={customColors.income} />
             </View>
             <View style={styles.summaryMeta}>
               <Text style={[styles.summaryMonthLabel, { color: ink2 }]}>
@@ -159,8 +161,8 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
               return (
                 <GlassCard key={item.id} dark={dark} radius={18} style={styles.groupCard}>
                   <View style={styles.groupHeader}>
-                    <View style={[styles.groupIcon, { backgroundColor: '#2ecc7122' }]}>
-                      <MaterialCommunityIcons name={icon as never} size={20} color="#2ecc71" />
+                    <View style={[styles.groupIcon, { backgroundColor: customColors.income + '22' }]}>
+                      <MaterialCommunityIcons name={icon as never} size={20} color={customColors.income} />
                     </View>
 
                     <View style={styles.groupInfo}>
@@ -168,7 +170,7 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
                       <Text style={[styles.groupSub, { color: ink2 }]}>{dateStr}</Text>
                     </View>
 
-                    <Text style={[styles.groupAmt, { color: '#2ecc71' }]}>
+                    <Text style={[styles.groupAmt, { color: customColors.income }]}>
                       +{sym} {fmt(item.amount)}
                     </Text>
 
@@ -197,7 +199,7 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
                           hitSlop={6}
                           style={styles.groupAction}
                         >
-                          <MaterialCommunityIcons name="trash-can-outline" size={16} color="#e74c3c" />
+                          <MaterialCommunityIcons name="trash-can-outline" size={16} color={customColors.expense} />
                         </TouchableOpacity>
                       </>
                     )}
@@ -255,7 +257,6 @@ const styles = StyleSheet.create({
   summaryInner: { flexDirection: 'row', alignItems: 'center', gap: 16, padding: 18 },
   summaryIconWrap: {
     width: 56, height: 56, borderRadius: 18,
-    backgroundColor: '#2ecc7126',
     alignItems: 'center', justifyContent: 'center', flexShrink: 0,
   },
   summaryMeta:       { flex: 1 },

--- a/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import {
   StyleSheet, TouchableOpacity, View,
   ScrollView, RefreshControl,
@@ -6,7 +6,7 @@ import {
 import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -59,13 +59,13 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
   useFocusEffect(
     useCallback(() => {
       setDefaultType('income');
-      setViewedMonth(month);
-      return () => {
-        setDefaultType(null);
-        setViewedMonth(null);
-      };
-    }, [setDefaultType, setViewedMonth, month])
+      return () => setDefaultType(null);
+    }, [setDefaultType])
   );
+  const isFocused = useIsFocused();
+  useEffect(() => {
+    setViewedMonth(isFocused ? month : null);
+  }, [month, isFocused, setViewedMonth]);
 
   const { data: incomes, isLoading, isFetching, isError, refetch } = useIncomesForMonth(projectId, month);
   const deleteIncome = useDeleteIncome(projectId, month);

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -674,15 +674,15 @@ const styles = StyleSheet.create({
     fontSize: 11, fontWeight: '700', letterSpacing: 0.8,
     textTransform: 'uppercase', marginBottom: 6,
   },
-  amountHeroRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 5 },
-  amountHeroSym: { fontSize: 24, fontWeight: '600', paddingBottom: 10, includeFontPadding: false } as never,
+  amountHeroRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 2 },
+  amountHeroSym: { fontSize: 24, fontWeight: '600', paddingBottom: 6, includeFontPadding: false } as never,
   amountHeroInt: {
     fontSize: 52, fontWeight: '800', letterSpacing: -1,
     padding: 0, includeFontPadding: false, minWidth: 30,
   } as never,
   amountHeroDec: {
     fontSize: 26, fontWeight: '700', letterSpacing: -0.5,
-    paddingBottom: 10, includeFontPadding: false,
+    paddingBottom: 0, includeFontPadding: false,
   } as never,
   hiddenAmountInput: {
     position: 'absolute', width: 1, height: 1, opacity: 0,

--- a/econoflow-mobile/src/store/__tests__/quickAddStore.test.ts
+++ b/econoflow-mobile/src/store/__tests__/quickAddStore.test.ts
@@ -1,0 +1,23 @@
+import { useQuickAddStore } from '../quickAddStore';
+
+describe('quickAddStore – viewedMonth', () => {
+  beforeEach(() => {
+    // Reset slice of state that these tests care about
+    useQuickAddStore.setState({ viewedMonth: null });
+  });
+
+  it('starts with viewedMonth as null', () => {
+    expect(useQuickAddStore.getState().viewedMonth).toBeNull();
+  });
+
+  it('setViewedMonth updates viewedMonth to a month string', () => {
+    useQuickAddStore.getState().setViewedMonth('2024-01');
+    expect(useQuickAddStore.getState().viewedMonth).toBe('2024-01');
+  });
+
+  it('setViewedMonth can reset viewedMonth back to null', () => {
+    useQuickAddStore.getState().setViewedMonth('2024-06');
+    useQuickAddStore.getState().setViewedMonth(null);
+    expect(useQuickAddStore.getState().viewedMonth).toBeNull();
+  });
+});

--- a/econoflow-mobile/src/store/quickAddStore.ts
+++ b/econoflow-mobile/src/store/quickAddStore.ts
@@ -7,13 +7,18 @@ interface QuickAddState {
   categoryId: string | null;
   /** Entry type to pre-select when the global FAB is pressed. Set by IncomeListScreen on focus. */
   defaultType: EntryType | null;
-  setCategoryId:  (id: string | null) => void;
-  setDefaultType: (type: EntryType | null) => void;
+  /** Month currently viewed in a list screen (YYYY-MM). Null when no list screen is focused. */
+  viewedMonth: string | null;
+  setCategoryId:   (id: string | null) => void;
+  setDefaultType:  (type: EntryType | null) => void;
+  setViewedMonth:  (month: string | null) => void;
 }
 
 export const useQuickAddStore = create<QuickAddState>()((set) => ({
   categoryId:  null,
   defaultType: null,
-  setCategoryId:  (id)   => set({ categoryId: id }),
-  setDefaultType: (type) => set({ defaultType: type }),
+  viewedMonth: null,
+  setCategoryId:   (id)    => set({ categoryId: id }),
+  setDefaultType:  (type)  => set({ defaultType: type }),
+  setViewedMonth:  (month) => set({ viewedMonth: month }),
 }));

--- a/econoflow-mobile/src/utils/__tests__/format.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/format.test.ts
@@ -1,0 +1,23 @@
+import { formatAmount } from '../format';
+
+describe('formatAmount', () => {
+  it('uses en locale - period as decimal separator', () => {
+    const result = formatAmount(1.5, 'en');
+    expect(result).toBe('1.50');
+  });
+
+  it('uses pt locale - comma as decimal separator', () => {
+    const result = formatAmount(1.5, 'pt');
+    expect(result).toBe('1,50');
+  });
+
+  it('returns absolute value', () => {
+    const pos = formatAmount(42.5, 'en');
+    const neg = formatAmount(-42.5, 'en');
+    expect(pos).toBe(neg);
+  });
+
+  it('formats 2 decimal places', () => {
+    expect(formatAmount(10, 'en')).toBe('10.00');
+  });
+});

--- a/econoflow-mobile/src/utils/format.ts
+++ b/econoflow-mobile/src/utils/format.ts
@@ -1,0 +1,6 @@
+export function formatAmount(n: number, locale?: string): string {
+  return Math.abs(n).toLocaleString(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}


### PR DESCRIPTION
Web (easyfinance.client):
- Add core/constants/chart-colors.ts with ChartColors and ThemeColors
  constants; all chart components and theme.service now import from
  there instead of scattering literal hex strings
- Fix add-edit-project and configure-tax-year-rule-dialog to use
  GlobalService.currentLanguage for month-name formatting instead of
  the undefined (browser) locale
- Add spec files for both components covering the locale behaviour

Mobile (econoflow-mobile):
- Add utils/format.ts with formatAmount(n, locale?) utility and tests
- Replace toLocaleString('pt-BR', ...) in IncomeListScreen and
  ExpenseListScreen with formatAmount(n, i18n.language)
- Replace hardcoded #2ecc71 / #e74c3c / #0f76a8 colour literals in
  both screens with theme.customColors.income / .expense and
  theme.colors.primary from useAppTheme()

https://claude.ai/code/session_01Eks6k3UrwhTX1w9v5DLvts