### PR TITLE
fix(frontend): prevent duplicate category save requests with isSaving guard

### DIFF
--- a/easyfinance.client/src/app/features/category/add-category/add-category.component.html
+++ b/easyfinance.client/src/app/features/category/add-category/add-category.component.html
@@ -37,7 +37,7 @@
 
       <!-- Submit Button -->
       <div class="float-end">
-        <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid">
+        <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
           {{ 'ButtonCreate' | translate }}
         </button>
       </div>

--- a/easyfinance.client/src/app/features/category/add-category/add-category.component.spec.ts
+++ b/easyfinance.client/src/app/features/category/add-category/add-category.component.spec.ts
@@ -1,0 +1,117 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Subject, of } from 'rxjs';
+import { Router, ActivatedRoute } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { AddCategoryComponent } from './add-category.component';
+import { CategoryService } from '../../../core/services/category.service';
+import { ErrorMessageService } from '../../../core/services/error-message.service';
+import { Category } from '../../../core/models/category';
+
+describe('AddCategoryComponent', () => {
+  let fixture: ComponentFixture<AddCategoryComponent>;
+  let component: AddCategoryComponent;
+  let categoryServiceMock: jasmine.SpyObj<CategoryService>;
+
+  const makeCategory = (): Category => {
+    const cat = new Category();
+    cat.id = 'cat-1';
+    cat.name = 'Food';
+    cat.expenses = [];
+    cat.isArchived = false;
+    return cat;
+  };
+
+  beforeEach(async () => {
+    categoryServiceMock = jasmine.createSpyObj<CategoryService>('CategoryService', ['add', 'getDefaultCategories']);
+    categoryServiceMock.add.and.returnValue(of(makeCategory()));
+    categoryServiceMock.getDefaultCategories.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [
+        AddCategoryComponent,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        { provide: CategoryService, useValue: categoryServiceMock },
+        { provide: Router, useValue: { navigate: jasmine.createSpy('navigate') } },
+        { provide: ActivatedRoute, useValue: {} },
+        {
+          provide: ErrorMessageService,
+          useValue: {
+            getFormFieldErrors: () => [],
+            setFormErrors: jasmine.createSpy('setFormErrors')
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddCategoryComponent);
+    component = fixture.componentInstance;
+    component.projectId = 'project-1';
+    spyOn(HTMLElement.prototype, 'focus'); // prevent focus-triggered autocomplete NG0100
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should have isSaving false initially', () => {
+    expect((component as any).isSaving).toBeFalse();
+  });
+
+  it('should set isSaving to true while add request is in-flight', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.add.and.returnValue(subject.asObservable());
+
+    component.categoryForm.setValue({ name: 'Food' });
+    component.save();
+
+    expect((component as any).isSaving).toBeTrue();
+
+    subject.next(makeCategory());
+    subject.complete();
+  });
+
+  it('should set isSaving to false after successful save', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.add.and.returnValue(subject.asObservable());
+
+    component.categoryForm.setValue({ name: 'Food' });
+    component.save();
+    subject.next(makeCategory());
+    subject.complete();
+
+    expect((component as any).isSaving).toBeFalse();
+  });
+
+  it('should disable submit button while isSaving is true', fakeAsync(() => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.add.and.returnValue(subject.asObservable());
+
+    component.categoryForm.setValue({ name: 'Food' });
+    component.save();
+    fixture.detectChanges();
+    tick();
+
+    const submitButton = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submitButton.disabled).toBeTrue();
+
+    subject.next(makeCategory());
+    subject.complete();
+  }));
+
+  it('should not call add service on second save while first is still in-flight', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.add.and.returnValue(subject.asObservable());
+
+    component.categoryForm.setValue({ name: 'Food' });
+    component.save();
+    component.save();
+
+    expect(categoryServiceMock.add).toHaveBeenCalledTimes(1);
+
+    subject.next(makeCategory());
+    subject.complete();
+  });
+});

--- a/easyfinance.client/src/app/features/category/add-category/add-category.component.spec.ts
+++ b/easyfinance.client/src/app/features/category/add-category/add-category.component.spec.ts
@@ -114,4 +114,15 @@ describe('AddCategoryComponent', () => {
     subject.next(makeCategory());
     subject.complete();
   });
+
+  it('should set isSaving to false after a failed save', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.add.and.returnValue(subject.asObservable());
+
+    component.categoryForm.setValue({ name: 'Food' });
+    component.save();
+    subject.error({ errors: { general: ['ServerError'] } });
+
+    expect((component as any).isSaving).toBeFalse();
+  });
 });

--- a/easyfinance.client/src/app/features/category/add-category/add-category.component.ts
+++ b/easyfinance.client/src/app/features/category/add-category/add-category.component.ts
@@ -37,6 +37,7 @@ export class AddCategoryComponent implements OnInit, AfterViewInit {
   private errorMessageService = inject(ErrorMessageService);
 
   categoryForm!: FormGroup;
+  isSaving = false;
   httpErrors = false;
   errors!: Record<string, string[]>;
 
@@ -84,22 +85,26 @@ export class AddCategoryComponent implements OnInit, AfterViewInit {
   }
 
   save() {
-    if (this.categoryForm.valid) {
-      const name = this.name?.value;
-
-      const newCategory = { name: name } as CategoryDto;
-
-      this.categoryService.add(this.projectId, newCategory).subscribe({
-        next: () => {
-          this.router.navigate([{ outlets: { modal: ['projects', this.projectId, 'categories'] } }]);
-        },
-        error: (response: ApiErrorResponse) => {
-          this.httpErrors = true;
-          this.errors = response.errors;
-          this.errorMessageService.setFormErrors(this.categoryForm, this.errors);
-        }
-      });
+    if (!this.categoryForm.valid || this.isSaving) {
+      return;
     }
+
+    const name = this.name?.value;
+    const newCategory = { name: name } as CategoryDto;
+
+    this.isSaving = true;
+    this.categoryService.add(this.projectId, newCategory).subscribe({
+      next: () => {
+        this.isSaving = false;
+        this.router.navigate([{ outlets: { modal: ['projects', this.projectId, 'categories'] } }]);
+      },
+      error: (response: ApiErrorResponse) => {
+        this.isSaving = false;
+        this.httpErrors = true;
+        this.errors = response.errors;
+        this.errorMessageService.setFormErrors(this.categoryForm, this.errors);
+      }
+    });
   }
 
   getFormFieldErrors(fieldName: string): string[] {

--- a/easyfinance.client/src/app/features/category/add-category/add-category.component.ts
+++ b/easyfinance.client/src/app/features/category/add-category/add-category.component.ts
@@ -92,9 +92,9 @@ export class AddCategoryComponent implements OnInit, AfterViewInit {
     const name = this.name?.value;
     const newCategory = { name: name } as CategoryDto;
 
-    this.isSaving = true;
     this.httpErrors = false;
     this.errors = {};
+    this.isSaving = true;
     this.categoryService.add(this.projectId, newCategory).subscribe({
       next: () => {
         this.isSaving = false;

--- a/easyfinance.client/src/app/features/category/add-category/add-category.component.ts
+++ b/easyfinance.client/src/app/features/category/add-category/add-category.component.ts
@@ -93,6 +93,8 @@ export class AddCategoryComponent implements OnInit, AfterViewInit {
     const newCategory = { name: name } as CategoryDto;
 
     this.isSaving = true;
+    this.httpErrors = false;
+    this.errors = {};
     this.categoryService.add(this.projectId, newCategory).subscribe({
       next: () => {
         this.isSaving = false;

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.html
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.html
@@ -56,7 +56,7 @@
 
                 <div class="d-flex justify-content-end">
                   <button mat-stroked-button class="me-2" type="button" (click)="cancelEdit()">{{ 'ButtonCancel' | translate }}</button>
-                  <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid">
+                  <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
                     {{ 'ButtonSave' | translate }}
                   </button>
                 </div>

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Subject, of, BehaviorSubject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -145,6 +145,24 @@ describe('ListCategoriesComponent', () => {
     subject.next(makeCategory('cat-1', 'Updated Food'));
     subject.complete();
   });
+
+  it('should disable submit button while isSaving is true', fakeAsync(() => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.update.and.returnValue(subject.asObservable());
+
+    component.edit(makeCategoryDto('cat-1', 'Food'));
+    component.categoryForm.patchValue({ name: 'Updated Food' });
+    component.save();
+    fixture.detectChanges();
+    tick();
+
+    const submitButton = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submitButton).not.toBeNull();
+    expect(submitButton.disabled).toBeTrue();
+
+    subject.next(makeCategory('cat-1', 'Updated Food'));
+    subject.complete();
+  }));
 
   it('should reset isSaving when cancelEdit is called while save is in-flight', () => {
     const subject = new Subject<Category>();

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
@@ -145,4 +145,38 @@ describe('ListCategoriesComponent', () => {
     subject.next(makeCategory('cat-1', 'Updated Food'));
     subject.complete();
   });
+
+  it('should reset isSaving when cancelEdit is called while save is in-flight', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.update.and.returnValue(subject.asObservable());
+
+    component.edit(makeCategoryDto());
+    component.categoryForm.patchValue({ name: 'Updated Food' });
+    component.save();
+
+    expect((component as any).isSaving).toBeTrue();
+    component.cancelEdit();
+
+    expect((component as any).isSaving).toBeFalse();
+
+    subject.next(makeCategory('cat-1', 'Updated Food'));
+    subject.complete();
+  });
+
+  it('should reset isSaving when edit is called while save is in-flight', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.update.and.returnValue(subject.asObservable());
+
+    component.edit(makeCategoryDto());
+    component.categoryForm.patchValue({ name: 'Updated Food' });
+    component.save();
+
+    expect((component as any).isSaving).toBeTrue();
+    component.edit(makeCategoryDto('cat-2', 'Rent'));
+
+    expect((component as any).isSaving).toBeFalse();
+
+    subject.next(makeCategory('cat-1', 'Updated Food'));
+    subject.complete();
+  });
 });

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
@@ -1,0 +1,148 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject, of, BehaviorSubject } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ListCategoriesComponent } from './list-categories.component';
+import { CategoryService } from '../../../core/services/category.service';
+import { ErrorMessageService } from '../../../core/services/error-message.service';
+import { ProjectService } from '../../../core/services/project.service';
+import { UserProjectDto } from '../../project/models/user-project-dto';
+import { Role } from '../../../core/enums/Role';
+import { Category } from '../../../core/models/category';
+import { CategoryDto } from '../models/category-dto';
+
+describe('ListCategoriesComponent', () => {
+  let fixture: ComponentFixture<ListCategoriesComponent>;
+  let component: ListCategoriesComponent;
+  let categoryServiceMock: jasmine.SpyObj<CategoryService>;
+
+  const makeCategory = (id = 'cat-1', name = 'Food'): Category => {
+    const cat = new Category();
+    cat.id = id;
+    cat.name = name;
+    cat.expenses = [];
+    cat.isArchived = false;
+    return cat;
+  };
+
+  const makeUserProject = (): UserProjectDto => {
+    const dto = new UserProjectDto();
+    dto.id = 'up-1';
+    dto.role = Role.Manager;
+    return dto;
+  };
+
+  const makeCategoryDto = (id = 'cat-1', name = 'Food'): CategoryDto => {
+    const dto = new CategoryDto();
+    dto.id = id;
+    dto.name = name;
+    dto.expenses = [];
+    dto.isArchived = false;
+    dto.displayOrder = 0;
+    return dto;
+  };
+
+  beforeEach(async () => {
+    categoryServiceMock = jasmine.createSpyObj<CategoryService>('CategoryService', [
+      'get', 'getDefaultCategories', 'update'
+    ]);
+    categoryServiceMock.get.and.returnValue(of([makeCategory()]));
+    categoryServiceMock.getDefaultCategories.and.returnValue(of([]));
+    categoryServiceMock.update.and.returnValue(of(makeCategory()));
+
+    const selectedUserProject$ = new BehaviorSubject<UserProjectDto>(makeUserProject());
+    const projectServiceMock = jasmine.createSpyObj<ProjectService>('ProjectService', ['getUserProject', 'selectUserProject']);
+    (projectServiceMock as any).selectedUserProject$ = selectedUserProject$.asObservable();
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ListCategoriesComponent,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        { provide: CategoryService, useValue: categoryServiceMock },
+        { provide: ProjectService, useValue: projectServiceMock },
+        { provide: Router, useValue: { navigate: jasmine.createSpy('navigate') } },
+        { provide: ActivatedRoute, useValue: {} },
+        {
+          provide: MatDialog,
+          useValue: { open: jasmine.createSpy('open').and.returnValue({ afterClosed: () => of(false) }) }
+        },
+        {
+          provide: ErrorMessageService,
+          useValue: {
+            getFormFieldErrors: () => [],
+            setFormErrors: jasmine.createSpy('setFormErrors')
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ListCategoriesComponent);
+    component = fixture.componentInstance;
+    component.projectId = 'project-1';
+    fixture.detectChanges();
+  });
+
+  it('should have isSaving false initially', () => {
+    expect((component as any).isSaving).toBeFalse();
+  });
+
+  it('should set isSaving to true while update request is in-flight', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.update.and.returnValue(subject.asObservable());
+
+    component.edit(makeCategoryDto());
+    component.categoryForm.patchValue({ name: 'Updated Food' });
+    component.save();
+
+    expect((component as any).isSaving).toBeTrue();
+
+    subject.next(makeCategory('cat-1', 'Updated Food'));
+    subject.complete();
+  });
+
+  it('should set isSaving to false after successful update', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.update.and.returnValue(subject.asObservable());
+
+    component.edit(makeCategoryDto());
+    component.categoryForm.patchValue({ name: 'Updated Food' });
+    component.save();
+    subject.next(makeCategory('cat-1', 'Updated Food'));
+    subject.complete();
+
+    expect((component as any).isSaving).toBeFalse();
+  });
+
+  it('should set isSaving to false after a failed update', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.update.and.returnValue(subject.asObservable());
+
+    component.edit(makeCategoryDto());
+    component.categoryForm.patchValue({ name: 'Updated Food' });
+    component.save();
+    subject.error({ errors: { general: ['ServerError'] } });
+
+    expect((component as any).isSaving).toBeFalse();
+  });
+
+  it('should not call update service on second save while first is still in-flight', () => {
+    const subject = new Subject<Category>();
+    categoryServiceMock.update.and.returnValue(subject.asObservable());
+
+    component.edit(makeCategoryDto());
+    component.categoryForm.patchValue({ name: 'Updated Food' });
+    component.save();
+    component.save();
+
+    expect(categoryServiceMock.update).toHaveBeenCalledTimes(1);
+
+    subject.next(makeCategory('cat-1', 'Updated Food'));
+    subject.complete();
+  });
+});

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
@@ -134,9 +134,9 @@ export class ListCategoriesComponent implements OnInit {
     }) as CategoryDto;
     const patch = compare(this.editingCategory, newCategory);
 
-    this.isSaving = true;
     this.httpErrors = false;
     this.errors = {};
+    this.isSaving = true;
     this.categoryService.update(this.projectId, id, patch).subscribe({
       next: response => {
         this.isSaving = false;

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
@@ -65,6 +65,7 @@ export class ListCategoriesComponent implements OnInit {
   httpErrors = false;
   errors!: Record<string, string[]>;
   userProject!: UserProjectDto;
+  isSaving = false;
   isSavingOrder = false;
 
   @Input({ required: true })
@@ -117,32 +118,36 @@ export class ListCategoriesComponent implements OnInit {
   }
 
   save(): void {
-    if (this.categoryForm.valid) {
-      const id = this.id?.value;
-      const name = this.name?.value;
-
-      const newCategory = ({
-        id: id,
-        name: name,
-        expenses: this.editingCategory.expenses,
-        isArchived: this.editingCategory.isArchived,
-        displayOrder: this.editingCategory.displayOrder
-      }) as CategoryDto;
-      const patch = compare(this.editingCategory, newCategory);
-
-      this.categoryService.update(this.projectId, id, patch).subscribe({
-        next: response => {
-          this.editingCategory.name = response.name;
-          this.editingCategory = new CategoryDto();
-        },
-        error: (response: ApiErrorResponse) => {
-          this.httpErrors = true;
-          this.errors = response.errors;
-
-          this.errorMessageService.setFormErrors(this.categoryForm, this.errors);
-        }
-      });
+    if (!this.categoryForm.valid || this.isSaving) {
+      return;
     }
+
+    const id = this.id?.value;
+    const name = this.name?.value;
+
+    const newCategory = ({
+      id: id,
+      name: name,
+      expenses: this.editingCategory.expenses,
+      isArchived: this.editingCategory.isArchived,
+      displayOrder: this.editingCategory.displayOrder
+    }) as CategoryDto;
+    const patch = compare(this.editingCategory, newCategory);
+
+    this.isSaving = true;
+    this.categoryService.update(this.projectId, id, patch).subscribe({
+      next: response => {
+        this.isSaving = false;
+        this.editingCategory.name = response.name;
+        this.editingCategory = new CategoryDto();
+      },
+      error: (response: ApiErrorResponse) => {
+        this.isSaving = false;
+        this.httpErrors = true;
+        this.errors = response.errors;
+        this.errorMessageService.setFormErrors(this.categoryForm, this.errors);
+      }
+    });
   }
 
   add() {

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
@@ -135,6 +135,8 @@ export class ListCategoriesComponent implements OnInit {
     const patch = compare(this.editingCategory, newCategory);
 
     this.isSaving = true;
+    this.httpErrors = false;
+    this.errors = {};
     this.categoryService.update(this.projectId, id, patch).subscribe({
       next: response => {
         this.isSaving = false;
@@ -162,6 +164,7 @@ export class ListCategoriesComponent implements OnInit {
   }
 
   edit(category: CategoryDto): void {
+    this.isSaving = false;
     this.editingCategory = category;
     this.categoryForm = new FormGroup({
       id: new FormControl(category.id),
@@ -177,6 +180,7 @@ export class ListCategoriesComponent implements OnInit {
   }
 
   cancelEdit(): void {
+    this.isSaving = false;
     this.editingCategory = new CategoryDto();
   }
 

--- a/easyfinance.client/src/assets/version.json
+++ b/easyfinance.client/src/assets/version.json
@@ -1,3 +1,3 @@
 {
-  "versionNumber": "1.1.60"
+  "versionNumber": "1.1.61"
 }


### PR DESCRIPTION
Add isSaving flag to AddCategoryComponent and ListCategoriesComponent so
the submit button is disabled and the save method returns early while a
request is in-flight, matching the pattern already used in income and plan
components.

https://claude.ai/code/session_01E8NS7xecxrssZpWqnsgKwi