### PR TITLE
fix(mobile): expense/income edit fixes — items timeline, silent income edit, amount validation

### DIFF
--- a/econoflow-mobile/src/api/types.ts
+++ b/econoflow-mobile/src/api/types.ts
@@ -81,6 +81,7 @@ export interface ExpenseItem {
   name: string;
   date: string;
   amount: number;
+  isDeductible: boolean;
 }
 
 export interface ExpenseAttachment {

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -11,4 +11,12 @@ describe('i18n locale completeness', () => {
   it('pt.json contains LabelCategories with a non-empty value', () => {
     expect((pt as LocaleMap)['LabelCategories']).toBeTruthy();
   });
+
+  it('en.json contains LabelEditExpenseItem', () => {
+    expect((en as LocaleMap)['LabelEditExpenseItem']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelEditExpenseItem', () => {
+    expect((pt as LocaleMap)['LabelEditExpenseItem']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -529,6 +529,7 @@
   "LabelForgotPasswordDescription": "Enter your email and we'll send you a reset link.",
   "LabelPasswordResetSent": "If that email is registered, we sent reset instructions.",
   "LabelEditExpense": "Edit expense",
+  "LabelEditExpenseItem": "Edit item",
   "LabelAddExpense": "Add expense",
   "ButtonBackToLogin": "Back to login",
   "ButtonSendResetLink": "Send reset link",

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -528,6 +528,7 @@
   "LabelForgotPasswordDescription": "Informe seu e-mail e enviaremos um link de redefinição.",
   "LabelPasswordResetSent": "Se esse e-mail estiver cadastrado, enviamos as instruções.",
   "LabelEditExpense": "Editar despesa",
+  "LabelEditExpenseItem": "Editar item",
   "LabelAddExpense": "Adicionar despesa",
   "ButtonBackToLogin": "Voltar para login",
   "ButtonSendResetLink": "Enviar link de redefinição",

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -244,6 +244,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                               type: 'expense',
                               id: expense.id,
                               categoryId,
+                              hasItems: (expense.items?.length ?? 0) > 0,
                               initialValues: {
                                 name: expense.name,
                                 amount: expense.amount,
@@ -295,6 +296,20 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                       onDeleteItem={(expenseItemId) =>
                         setPendingDeleteItem({ expenseId: expense.id, expenseItemId })
                       }
+                      onEditItem={(item, itemIndex) => setQuickAdd({
+                        visible: true,
+                        editMode: {
+                          type: 'expenseItem',
+                          id: expense.id,
+                          categoryId,
+                          itemIndex,
+                          initialValues: {
+                            name: item.name,
+                            amount: item.amount,
+                            date: item.date,
+                          },
+                        },
+                      })}
                     />
                   )}
                 </GlassCard>
@@ -354,12 +369,14 @@ interface ItemsSectionProps {
   t: TFunction;
   onAddItemPressed: () => void;
   onDeleteItem: (id: string) => void;
+  onEditItem: (item: ExpenseItem, itemIndex: number) => void;
 }
 
 const ExpenseItemsSection: React.FC<ItemsSectionProps> = ({
-  expense, currency, color, dark, ink, ink2, hair, canEdit, t, onAddItemPressed, onDeleteItem,
+  expense, currency, color, dark, ink, ink2, hair, canEdit, t, onAddItemPressed, onDeleteItem, onEditItem,
 }) => {
   const tintBg = dark ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.3)';
+  const itemCount = expense.items?.length ?? 0;
 
   return (
     <View style={[styles.itemsSection, { borderTopColor: hair, backgroundColor: tintBg }]}>
@@ -372,9 +389,12 @@ const ExpenseItemsSection: React.FC<ItemsSectionProps> = ({
           ink={ink}
           ink2={ink2}
           hair={hair}
-          isLast={i === (expense.items?.length ?? 0) - 1 && !canEdit}
+          isFirst={i === 0}
+          isLast={i === itemCount - 1}
+          showBottomBorder={!(i === itemCount - 1 && !canEdit)}
           canEdit={canEdit}
           onDelete={() => onDeleteItem(item.id)}
+          onEdit={() => onEditItem(item, i)}
         />
       ))}
 
@@ -400,13 +420,16 @@ interface ItemRowProps {
   currency: string;
   color: string;
   ink: string; ink2: string; hair: string;
+  isFirst: boolean;
   isLast: boolean;
+  showBottomBorder: boolean;
   canEdit: boolean;
   onDelete: () => void;
+  onEdit: () => void;
 }
 
 const ExpenseItemRow: React.FC<ItemRowProps> = ({
-  item, currency, color, ink, ink2, hair, isLast, canEdit, onDelete,
+  item, currency, color, ink, ink2, hair, isFirst, isLast, showBottomBorder, canEdit, onDelete, onEdit,
 }) => {
   const { customColors } = useAppTheme();
   const date = fromDateOnly(item.date);
@@ -414,8 +437,17 @@ const ExpenseItemRow: React.FC<ItemRowProps> = ({
   const fmt = (n: number) => formatAmount(n, i18n.language);
 
   return (
-    <View style={[styles.itemRow, { borderBottomColor: isLast ? 'transparent' : hair }]}>
-      <View style={[styles.itemBullet, { backgroundColor: color }]} />
+    <TouchableOpacity
+      onPress={onEdit}
+      activeOpacity={0.72}
+      style={[styles.itemRow, { borderBottomColor: showBottomBorder ? hair : 'transparent' }]}
+    >
+      {/* Timeline column: vertical line + dot */}
+      <View style={styles.timelineCol}>
+        <View style={[styles.timelineLineTop, { backgroundColor: isFirst ? 'transparent' : color + '55' }]} />
+        <View style={[styles.timelineDot, { backgroundColor: color }]} />
+        <View style={[styles.timelineLineBottom, { backgroundColor: isLast ? 'transparent' : color + '55' }]} />
+      </View>
 
       <View style={styles.itemLeft}>
         <Text style={[styles.itemName, { color: ink }]} numberOfLines={1}>
@@ -433,7 +465,7 @@ const ExpenseItemRow: React.FC<ItemRowProps> = ({
           <MaterialCommunityIcons name="trash-can-outline" size={15} color={customColors.expense} />
         </TouchableOpacity>
       )}
-    </View>
+    </TouchableOpacity>
   );
 };
 
@@ -513,7 +545,10 @@ const styles = StyleSheet.create({
     paddingVertical: 9,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  itemBullet: { width: 7, height: 7, borderRadius: 4, flexShrink: 0 },
+  timelineCol:        { width: 16, alignItems: 'center', alignSelf: 'stretch', flexShrink: 0 },
+  timelineLineTop:    { flex: 1, width: 2, borderRadius: 1 },
+  timelineDot:        { width: 8, height: 8, borderRadius: 4 },
+  timelineLineBottom: { flex: 1, width: 2, borderRadius: 1 },
   itemLeft:   { flex: 1, gap: 2 },
   itemName:   { fontSize: 13.5, fontWeight: '600' },
   itemDate:   { fontSize: 11 },

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -307,6 +307,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                             name: item.name,
                             amount: item.amount,
                             date: item.date,
+                            isDeductible: item.isDeductible,
                           },
                         },
                       })}

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -290,7 +290,10 @@ export const QuickAddModal: React.FC<Props> = ({
     if (editMode) {
       if (editMode.type === 'expenseItem') {
         const idx = editMode.itemIndex ?? 0;
-        patchExpense.mutate(buildExpenseItemPatch(idx, { name, amount, date: dateStr }), { onSuccess: onClose });
+        patchExpense.mutate(
+          buildExpenseItemPatch(idx, { name, amount, date: dateStr, isDeductible: modal.isDeductible }),
+          { onSuccess: onClose },
+        );
         return;
       }
       if (editMode.type === 'expense') {
@@ -623,7 +626,7 @@ export const QuickAddModal: React.FC<Props> = ({
             )}
 
             {/* Deductible toggle */}
-            {(modal.entryType === 'expense' || isEditMode) && editMode?.type !== 'income' && editMode?.type !== 'expenseItem' && (
+            {(modal.entryType === 'expense' || isEditMode) && editMode?.type !== 'income' && (
               <TouchableOpacity
                 onPress={() => dispatch({ kind: 'toggle_deductible' })}
                 activeOpacity={0.8}

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -19,15 +19,19 @@ import { getCategoryColor } from '../../utils/categoryTheme';
 import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
 import { currentMonth, toDateOnly, fromDateOnly, dateToMonth, defaultDateForMonth } from '../../utils/date';
-import { buildPatch } from '../../utils/patch';
+import { buildPatch, buildExpenseItemPatch } from '../../utils/patch';
 import { auroraTokens } from '../../theme/useAuroraSkin';
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
 export interface QuickAddEditMode {
-  type: 'expense' | 'income';
+  type: 'expense' | 'income' | 'expenseItem';
   id: string;
+  /** For expenseItem: 0-based index of the item in the parent expense's items array */
+  itemIndex?: number;
   categoryId?: string;
+  /** True when the expense has child items — amount is derived and read-only */
+  hasItems?: boolean;
   initialValues: {
     name: string;
     amount: number;
@@ -255,8 +259,8 @@ export const QuickAddModal: React.FC<Props> = ({
 
   const patchExpense = usePatchExpense(
     projectId,
-    editMode?.type === 'expense' ? (editMode.categoryId ?? '') : (modal.selectedCategoryId ?? ''),
-    editMode?.type === 'expense' ? editMode.id : '',
+    (editMode?.type === 'expense' || editMode?.type === 'expenseItem') ? (editMode.categoryId ?? '') : (modal.selectedCategoryId ?? ''),
+    (editMode?.type === 'expense' || editMode?.type === 'expenseItem') ? editMode.id : '',
     selectedMonth,
   );
   const patchIncome = usePatchIncome(
@@ -276,18 +280,26 @@ export const QuickAddModal: React.FC<Props> = ({
     const dateStr = toDateOnly(modal.date);
     const name    = values.name.trim();
 
-    if (amount <= 0) {
+    // Skip amount validation when editing an expense whose amount is derived from items
+    if (!editMode?.hasItems && amount <= 0) {
       dispatch({ kind: 'set_amount_error', error: true });
       return;
     }
     dispatch({ kind: 'set_amount_error', error: false });
 
     if (editMode) {
-      const patch = buildPatch({ name, amount, date: dateStr, isDeductible: modal.isDeductible, budget } as Record<string, unknown>);
+      if (editMode.type === 'expenseItem') {
+        const idx = editMode.itemIndex ?? 0;
+        patchExpense.mutate(buildExpenseItemPatch(idx, { name, amount, date: dateStr }), { onSuccess: onClose });
+        return;
+      }
       if (editMode.type === 'expense') {
-        patchExpense.mutate(patch, { onSuccess: onClose });
+        const fields: Record<string, unknown> = { name, date: dateStr, isDeductible: modal.isDeductible, budget };
+        if (!editMode.hasItems) fields.amount = amount;
+        patchExpense.mutate(buildPatch(fields), { onSuccess: onClose });
       } else {
-        patchIncome.mutate(patch, { onSuccess: onClose });
+        // income: only patch name, amount, date — no isDeductible or budget
+        patchIncome.mutate(buildPatch({ name, amount, date: dateStr } as Record<string, unknown>), { onSuccess: onClose });
       }
       return;
     }
@@ -333,11 +345,16 @@ export const QuickAddModal: React.FC<Props> = ({
   const isEditMode = !!editMode;
   const isLocked   = isEditMode || !!defaultCategoryId || !!defaultExpenseId;
   const canSubmit  = isEditMode || modal.entryType === 'income' || !!modal.selectedCategoryId;
+  const amountIsReadonly = isEditMode && editMode.hasItems;
 
   const amountColor = modal.entryType === 'income' ? '#14c08a' : '#e74c3c';
 
   const title = isEditMode
-    ? (editMode.type === 'income' ? (t('LabelEditIncome') ?? 'Edit income') : (t('LabelEditExpense') ?? 'Edit expense'))
+    ? (() => {
+        if (editMode.type === 'income') return t('LabelEditIncome') ?? 'Edit income';
+        if (editMode.type === 'expenseItem') return t('LabelEditExpenseItem') ?? 'Edit item';
+        return t('LabelEditExpense') ?? 'Edit expense';
+      })()
     : (t('LabelQuickAdd') ?? 'New entry');
 
   return (
@@ -430,8 +447,8 @@ export const QuickAddModal: React.FC<Props> = ({
 
             {/* Amount hero — integer + smaller decimal, hidden input */}
             <Pressable
-              style={styles.amountHero}
-              onPress={() => amountInputRef.current?.focus()}
+              style={[styles.amountHero, amountIsReadonly && { opacity: 0.6 }]}
+              onPress={() => !amountIsReadonly && amountInputRef.current?.focus()}
             >
               <Text style={[styles.amountHeroLabel, { color: ink2 }]}>
                 {t('FieldAmount') ?? 'Amount'}
@@ -447,16 +464,18 @@ export const QuickAddModal: React.FC<Props> = ({
                   {amountDecPart}
                 </Text>
               </View>
-              <TextInput
-                ref={amountInputRef}
-                value={modal.amountText}
-                onChangeText={handleAmountChange}
-                keyboardType="number-pad"
-                caretHidden
-                accessible={false}
-                importantForAccessibility="no"
-                style={styles.hiddenAmountInput}
-              />
+              {!amountIsReadonly && (
+                <TextInput
+                  ref={amountInputRef}
+                  value={modal.amountText}
+                  onChangeText={handleAmountChange}
+                  keyboardType="number-pad"
+                  caretHidden
+                  accessible={false}
+                  importantForAccessibility="no"
+                  style={styles.hiddenAmountInput}
+                />
+              )}
               {modal.amountError && (
                 <HelperText type="error" style={styles.amountHeroError}>
                   {t('RequiredField') ?? 'Required'}
@@ -565,8 +584,8 @@ export const QuickAddModal: React.FC<Props> = ({
             />
             {errors.name && <HelperText type="error" style={styles.helperText}>{errors.name.message}</HelperText>}
 
-            {/* Budget — expense only, not when adding an item */}
-            {(modal.entryType === 'expense' || isEditMode) && editMode?.type !== 'income' && !modal.selectedExpenseId && (
+            {/* Budget — expense only, not when adding an item or editing an expense item */}
+            {(modal.entryType === 'expense' || isEditMode) && editMode?.type !== 'income' && editMode?.type !== 'expenseItem' && !modal.selectedExpenseId && (
               <Controller control={control} name="budget"
                 render={({ field: { onChange, value } }) => (
                   <AuroraField dark={dark} icon="bullseye-arrow" textPrefix={sym || undefined}
@@ -604,7 +623,7 @@ export const QuickAddModal: React.FC<Props> = ({
             )}
 
             {/* Deductible toggle */}
-            {(modal.entryType === 'expense' || isEditMode) && editMode?.type !== 'income' && (
+            {(modal.entryType === 'expense' || isEditMode) && editMode?.type !== 'income' && editMode?.type !== 'expenseItem' && (
               <TouchableOpacity
                 onPress={() => dispatch({ kind: 'toggle_deductible' })}
                 activeOpacity={0.8}
@@ -674,7 +693,7 @@ const styles = StyleSheet.create({
     fontSize: 11, fontWeight: '700', letterSpacing: 0.8,
     textTransform: 'uppercase', marginBottom: 6,
   },
-  amountHeroRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 2 },
+  amountHeroRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 1 },
   amountHeroSym: { fontSize: 24, fontWeight: '600', paddingBottom: 6, includeFontPadding: false } as never,
   amountHeroInt: {
     fontSize: 52, fontWeight: '800', letterSpacing: -1,

--- a/econoflow-mobile/src/utils/__tests__/patch.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/patch.test.ts
@@ -47,22 +47,29 @@ describe('buildPatch', () => {
 
 describe('buildExpenseItemPatch', () => {
   it('creates replace operations targeting the correct item index', () => {
-    const ops = buildExpenseItemPatch(2, { name: 'Coffee', amount: 3.5, date: '2024-01-15' });
-    expect(ops).toHaveLength(3);
+    const ops = buildExpenseItemPatch(2, { name: 'Coffee', amount: 3.5, date: '2024-01-15', isDeductible: false });
+    expect(ops).toHaveLength(4);
     expect(ops).toContainEqual({ op: 'replace', path: '/items/2/name', value: 'Coffee' });
     expect(ops).toContainEqual({ op: 'replace', path: '/items/2/amount', value: 3.5 });
     expect(ops).toContainEqual({ op: 'replace', path: '/items/2/date', value: '2024-01-15' });
+    expect(ops).toContainEqual({ op: 'replace', path: '/items/2/isDeductible', value: false });
+  });
+
+  it('includes isDeductible: true when flagged', () => {
+    const ops = buildExpenseItemPatch(0, { name: 'Receipt', amount: 50, date: '2024-06-01', isDeductible: true });
+    expect(ops).toContainEqual({ op: 'replace', path: '/items/0/isDeductible', value: true });
   });
 
   it('uses index 0 correctly', () => {
-    const ops = buildExpenseItemPatch(0, { name: 'Tea', amount: 2.0, date: '2024-01-10' });
+    const ops = buildExpenseItemPatch(0, { name: 'Tea', amount: 2.0, date: '2024-01-10', isDeductible: false });
     expect(ops[0].path).toBe('/items/0/name');
     expect(ops[1].path).toBe('/items/0/amount');
     expect(ops[2].path).toBe('/items/0/date');
+    expect(ops[3].path).toBe('/items/0/isDeductible');
   });
 
-  it('returns exactly 3 operations (name, amount, date)', () => {
-    const ops = buildExpenseItemPatch(1, { name: 'Milk', amount: 1.2, date: '2024-03-05' });
-    expect(ops).toHaveLength(3);
+  it('returns exactly 4 operations (name, amount, date, isDeductible)', () => {
+    const ops = buildExpenseItemPatch(1, { name: 'Milk', amount: 1.2, date: '2024-03-05', isDeductible: false });
+    expect(ops).toHaveLength(4);
   });
 });

--- a/econoflow-mobile/src/utils/__tests__/patch.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/patch.test.ts
@@ -1,4 +1,4 @@
-import { buildPatch, buildReplace } from '../patch';
+import { buildPatch, buildReplace, buildExpenseItemPatch } from '../patch';
 
 describe('buildReplace', () => {
   it('creates a replace operation with leading slash on path', () => {
@@ -34,5 +34,35 @@ describe('buildPatch', () => {
     expect(ops).toContainEqual({ op: 'replace', path: '/flag', value: true });
     expect(ops).toContainEqual({ op: 'replace', path: '/count', value: 0 });
     expect(ops).toContainEqual({ op: 'replace', path: '/label', value: '' });
+  });
+
+  it('income patch excludes isDeductible and budget when only name/amount/date are passed', () => {
+    const ops = buildPatch({ name: 'Salary', amount: 1500, date: '2024-06-01' });
+    expect(ops).toHaveLength(3);
+    const paths = ops.map(o => o.path);
+    expect(paths).not.toContain('/isDeductible');
+    expect(paths).not.toContain('/budget');
+  });
+});
+
+describe('buildExpenseItemPatch', () => {
+  it('creates replace operations targeting the correct item index', () => {
+    const ops = buildExpenseItemPatch(2, { name: 'Coffee', amount: 3.5, date: '2024-01-15' });
+    expect(ops).toHaveLength(3);
+    expect(ops).toContainEqual({ op: 'replace', path: '/items/2/name', value: 'Coffee' });
+    expect(ops).toContainEqual({ op: 'replace', path: '/items/2/amount', value: 3.5 });
+    expect(ops).toContainEqual({ op: 'replace', path: '/items/2/date', value: '2024-01-15' });
+  });
+
+  it('uses index 0 correctly', () => {
+    const ops = buildExpenseItemPatch(0, { name: 'Tea', amount: 2.0, date: '2024-01-10' });
+    expect(ops[0].path).toBe('/items/0/name');
+    expect(ops[1].path).toBe('/items/0/amount');
+    expect(ops[2].path).toBe('/items/0/date');
+  });
+
+  it('returns exactly 3 operations (name, amount, date)', () => {
+    const ops = buildExpenseItemPatch(1, { name: 'Milk', amount: 1.2, date: '2024-03-05' });
+    expect(ops).toHaveLength(3);
   });
 });

--- a/econoflow-mobile/src/utils/patch.ts
+++ b/econoflow-mobile/src/utils/patch.ts
@@ -11,9 +11,10 @@ export const buildPatch = (fields: Record<string, unknown>): PatchOperation[] =>
 
 export const buildExpenseItemPatch = (
   itemIndex: number,
-  fields: { name: string; amount: number; date: string },
+  fields: { name: string; amount: number; date: string; isDeductible: boolean },
 ): PatchOperation[] => [
   buildReplace(`items/${itemIndex}/name`, fields.name),
   buildReplace(`items/${itemIndex}/amount`, fields.amount),
   buildReplace(`items/${itemIndex}/date`, fields.date),
+  buildReplace(`items/${itemIndex}/isDeductible`, fields.isDeductible),
 ];

--- a/econoflow-mobile/src/utils/patch.ts
+++ b/econoflow-mobile/src/utils/patch.ts
@@ -8,3 +8,12 @@ export const buildReplace = (path: string, value: unknown): PatchOperation => ({
 
 export const buildPatch = (fields: Record<string, unknown>): PatchOperation[] =>
   Object.entries(fields).map(([key, value]) => buildReplace(key, value));
+
+export const buildExpenseItemPatch = (
+  itemIndex: number,
+  fields: { name: string; amount: number; date: string },
+): PatchOperation[] => [
+  buildReplace(`items/${itemIndex}/name`, fields.name),
+  buildReplace(`items/${itemIndex}/amount`, fields.amount),
+  buildReplace(`items/${itemIndex}/date`, fields.date),
+];


### PR DESCRIPTION
- Expense with child items: amount field is now read-only in edit modal (hasItems flag),
  amount excluded from PATCH payload, amount validation skipped to prevent spurious error
- Tapping an expense item opens an edit modal via new expenseItem edit mode; uses
  buildExpenseItemPatch to target the correct item by index via JSON Patch
- Expense item rows now render as a timeline with connecting vertical lines between dots
- Income edit silent failure fixed: patch now only sends name/amount/date, excluding
  isDeductible and budget which caused server-side rejection with no visible error
- QuickAddModal: gap between integer and decimal parts reduced from 2 to 1

https://claude.ai/code/session_01K7wmUcCPA1dsvPW63Z1NnW