### PR TITLE
fix(mobile): timeline continuity, item badges, income card touch

### DIFF
--- a/econoflow-mobile/src/api/__tests__/types.test.ts
+++ b/econoflow-mobile/src/api/__tests__/types.test.ts
@@ -1,0 +1,31 @@
+import type { ExpenseItem, ExpenseAttachment } from '../types';
+
+describe('ExpenseItem type', () => {
+  it('includes isDeductible field', () => {
+    const item: ExpenseItem = {
+      id: 'i1', name: 'Test', date: '2024-01-01', amount: 10,
+      isDeductible: true, attachments: [],
+    };
+    expect(item.isDeductible).toBe(true);
+  });
+
+  it('includes attachments field compatible with ExpenseAttachment[]', () => {
+    const attachment: ExpenseAttachment = {
+      id: 'a1', name: 'receipt.pdf', contentType: 'application/pdf', size: 1024,
+    };
+    const item: ExpenseItem = {
+      id: 'i2', name: 'Proof item', date: '2024-01-01', amount: 25,
+      isDeductible: true, attachments: [attachment],
+    };
+    expect(item.attachments).toHaveLength(1);
+    expect(item.attachments![0].contentType).toBe('application/pdf');
+  });
+
+  it('attachments defaults to empty when absent', () => {
+    const item: ExpenseItem = {
+      id: 'i3', name: 'No proof', date: '2024-01-01', amount: 5,
+      isDeductible: false, attachments: [],
+    };
+    expect(item.attachments).toHaveLength(0);
+  });
+});

--- a/econoflow-mobile/src/api/types.ts
+++ b/econoflow-mobile/src/api/types.ts
@@ -82,6 +82,7 @@ export interface ExpenseItem {
   date: string;
   amount: number;
   isDeductible: boolean;
+  attachments: ExpenseAttachment[];
 }
 
 export interface ExpenseAttachment {

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -19,4 +19,20 @@ describe('i18n locale completeness', () => {
   it('pt.json contains LabelEditExpenseItem', () => {
     expect((pt as LocaleMap)['LabelEditExpenseItem']).toBeTruthy();
   });
+
+  it('en.json contains LabelDeductible', () => {
+    expect((en as LocaleMap)['LabelDeductible']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelDeductible', () => {
+    expect((pt as LocaleMap)['LabelDeductible']).toBeTruthy();
+  });
+
+  it('en.json contains LabelProofAttached', () => {
+    expect((en as LocaleMap)['LabelProofAttached']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelProofAttached', () => {
+    expect((pt as LocaleMap)['LabelProofAttached']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -437,7 +437,7 @@ const ExpenseItemRow: React.FC<ItemRowProps> = ({
   const date = fromDateOnly(item.date);
   const dateStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   const fmt = (n: number) => formatAmount(n, i18n.language);
-  const hasProof = (item.attachments?.length ?? 0) > 0;
+  const hasProof = item.attachments.length > 0;
 
   return (
     <TouchableOpacity

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -432,10 +432,12 @@ interface ItemRowProps {
 const ExpenseItemRow: React.FC<ItemRowProps> = ({
   item, currency, color, ink, ink2, hair, isFirst, isLast, showBottomBorder, canEdit, onDelete, onEdit,
 }) => {
-  const { customColors } = useAppTheme();
+  const { customColors, colors } = useAppTheme();
+  const { t } = useTranslation();
   const date = fromDateOnly(item.date);
   const dateStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   const fmt = (n: number) => formatAmount(n, i18n.language);
+  const hasProof = (item.attachments?.length ?? 0) > 0;
 
   return (
     <TouchableOpacity
@@ -443,29 +445,49 @@ const ExpenseItemRow: React.FC<ItemRowProps> = ({
       activeOpacity={0.72}
       style={[styles.itemRow, { borderBottomColor: showBottomBorder ? hair : 'transparent' }]}
     >
-      {/* Timeline column: vertical line + dot */}
+      {/* Timeline column — no padding so it fills the full row height, making lines connect between rows */}
       <View style={styles.timelineCol}>
         <View style={[styles.timelineLineTop, { backgroundColor: isFirst ? 'transparent' : color + '55' }]} />
         <View style={[styles.timelineDot, { backgroundColor: color }]} />
         <View style={[styles.timelineLineBottom, { backgroundColor: isLast ? 'transparent' : color + '55' }]} />
       </View>
 
-      <View style={styles.itemLeft}>
-        <Text style={[styles.itemName, { color: ink }]} numberOfLines={1}>
-          {item.name?.trim() || '—'}
+      {/* Body — paddingVertical lives here so the timeline column spans the full row height */}
+      <View style={styles.itemBody}>
+        <View style={styles.itemLeft}>
+          <Text style={[styles.itemName, { color: ink }]} numberOfLines={1}>
+            {item.name?.trim() || '—'}
+          </Text>
+          <View style={styles.itemSubRow}>
+            <Text style={[styles.itemDate, { color: ink2 }]}>{dateStr}</Text>
+            {item.isDeductible && (
+              <View style={[styles.deductBadge, { backgroundColor: colors.primary + '26' }]}>
+                <Text style={[styles.deductBadgeText, { color: colors.primary }]}>
+                  {t('LabelDeductible')}
+                </Text>
+              </View>
+            )}
+            {hasProof && (
+              <View style={[styles.proofBadge, { backgroundColor: ink2 + '22' }]}>
+                <MaterialCommunityIcons name="paperclip" size={9} color={ink2} />
+                <Text style={[styles.proofBadgeText, { color: ink2 }]}>
+                  {t('LabelProofAttached')}
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
+
+        <Text style={[styles.itemAmt, { color: customColors.expense }]}>
+          −{currency} {fmt(item.amount)}
         </Text>
-        <Text style={[styles.itemDate, { color: ink2 }]}>{dateStr}</Text>
+
+        {canEdit && (
+          <TouchableOpacity onPress={onDelete} hitSlop={8} style={styles.itemDelete}>
+            <MaterialCommunityIcons name="trash-can-outline" size={15} color={customColors.expense} />
+          </TouchableOpacity>
+        )}
       </View>
-
-      <Text style={[styles.itemAmt, { color: customColors.expense }]}>
-        −{currency} {fmt(item.amount)}
-      </Text>
-
-      {canEdit && (
-        <TouchableOpacity onPress={onDelete} hitSlop={8} style={styles.itemDelete}>
-          <MaterialCommunityIcons name="trash-can-outline" size={15} color={customColors.expense} />
-        </TouchableOpacity>
-      )}
     </TouchableOpacity>
   );
 };
@@ -539,18 +561,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 6,
   },
+  // paddingVertical intentionally removed — lives in itemBody so timelineCol fills full row height
   itemRow: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingVertical: 9,
+    alignItems: 'stretch',
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   timelineCol:        { width: 16, alignItems: 'center', alignSelf: 'stretch', flexShrink: 0 },
-  timelineLineTop:    { flex: 1, width: 2, borderRadius: 1 },
+  timelineLineTop:    { flex: 1, width: 2 },
   timelineDot:        { width: 8, height: 8, borderRadius: 4 },
-  timelineLineBottom: { flex: 1, width: 2, borderRadius: 1 },
-  itemLeft:   { flex: 1, gap: 2 },
+  timelineLineBottom: { flex: 1, width: 2 },
+  itemBody:    { flex: 1, flexDirection: 'row', alignItems: 'center', paddingVertical: 9, paddingLeft: 10, gap: 10 },
+  itemLeft:    { flex: 1, gap: 2 },
+  itemSubRow:  { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 4 },
   itemName:   { fontSize: 13.5, fontWeight: '600' },
   itemDate:   { fontSize: 11 },
   itemAmt:    { fontSize: 13.5, fontWeight: '700' },

--- a/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
@@ -165,7 +165,22 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
               const icon = getCategoryIcon(item.name);
               return (
                 <GlassCard key={item.id} dark={dark} radius={18} style={styles.groupCard}>
-                  <View style={styles.groupHeader}>
+                  <TouchableOpacity
+                    onPress={() => canEdit && setEditState({
+                      visible: true,
+                      editMode: {
+                        type: 'income',
+                        id: item.id,
+                        initialValues: {
+                          name: item.name,
+                          amount: item.amount,
+                          date: item.date,
+                        },
+                      },
+                    })}
+                    activeOpacity={canEdit ? 0.75 : 1}
+                    style={styles.groupHeader}
+                  >
                     <View style={[styles.groupIcon, { backgroundColor: customColors.income + '22' }]}>
                       <MaterialCommunityIcons name={icon as never} size={20} color={customColors.income} />
                     </View>
@@ -180,35 +195,15 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
                     </Text>
 
                     {canEdit && (
-                      <>
-                        <TouchableOpacity
-                          onPress={() => setEditState({
-                            visible: true,
-                            editMode: {
-                              type: 'income',
-                              id: item.id,
-                              initialValues: {
-                                name: item.name,
-                                amount: item.amount,
-                                date: item.date,
-                              },
-                            },
-                          })}
-                          hitSlop={6}
-                          style={styles.groupAction}
-                        >
-                          <MaterialCommunityIcons name="pencil-outline" size={16} color={ink2} />
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                          onPress={() => setPendingDeleteId(item.id)}
-                          hitSlop={6}
-                          style={styles.groupAction}
-                        >
-                          <MaterialCommunityIcons name="trash-can-outline" size={16} color={customColors.expense} />
-                        </TouchableOpacity>
-                      </>
+                      <TouchableOpacity
+                        onPress={() => setPendingDeleteId(item.id)}
+                        hitSlop={6}
+                        style={styles.groupAction}
+                      >
+                        <MaterialCommunityIcons name="trash-can-outline" size={16} color={customColors.expense} />
+                      </TouchableOpacity>
                     )}
-                  </View>
+                  </TouchableOpacity>
                 </GlassCard>
               );
             })}

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -281,7 +281,7 @@ export const QuickAddModal: React.FC<Props> = ({
     const dateStr = toDateOnly(modal.date);
     const name    = values.name.trim();
 
-    if (shouldShowAmountError(editMode?.hasItems, editMode, amount)) {
+    if (shouldShowAmountError(editMode, amount)) {
       dispatch({ kind: 'set_amount_error', error: true });
       return;
     }

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -20,6 +20,7 @@ import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
 import { currentMonth, toDateOnly, fromDateOnly, dateToMonth, defaultDateForMonth } from '../../utils/date';
 import { buildPatch, buildExpenseItemPatch } from '../../utils/patch';
+import { shouldShowAmountError } from '../../utils/amountValidation';
 import { auroraTokens } from '../../theme/useAuroraSkin';
 
 // ── Public types ─────────────────────────────────────────────────────────────
@@ -280,8 +281,7 @@ export const QuickAddModal: React.FC<Props> = ({
     const dateStr = toDateOnly(modal.date);
     const name    = values.name.trim();
 
-    // Skip amount validation when editing an expense whose amount is derived from items
-    if (!editMode?.hasItems && amount <= 0) {
+    if (shouldShowAmountError(editMode?.hasItems, editMode, amount)) {
       dispatch({ kind: 'set_amount_error', error: true });
       return;
     }

--- a/econoflow-mobile/src/utils/__tests__/amountValidation.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/amountValidation.test.ts
@@ -1,0 +1,50 @@
+import { shouldShowAmountError } from '../amountValidation';
+
+describe('shouldShowAmountError', () => {
+  describe('creating a new entry (no editMode)', () => {
+    it('returns true when amount is 0', () => {
+      expect(shouldShowAmountError(undefined, undefined, 0)).toBe(true);
+    });
+
+    it('returns true when amount is negative', () => {
+      expect(shouldShowAmountError(undefined, undefined, -5)).toBe(true);
+    });
+
+    it('returns false when amount is positive', () => {
+      expect(shouldShowAmountError(undefined, undefined, 10)).toBe(false);
+    });
+  });
+
+  describe('editing an expense that has child items (hasItems)', () => {
+    it('returns false regardless of amount — amount is derived from items', () => {
+      expect(shouldShowAmountError(true, { type: 'expense' }, 0)).toBe(false);
+      expect(shouldShowAmountError(true, { type: 'expense' }, -1)).toBe(false);
+    });
+  });
+
+  describe('editing an existing expense with amount 0 (no items)', () => {
+    it('returns false so the user is not blocked from saving', () => {
+      expect(shouldShowAmountError(false, { type: 'expense' }, 0)).toBe(false);
+    });
+
+    it('returns false for a positive amount too', () => {
+      expect(shouldShowAmountError(false, { type: 'expense' }, 22)).toBe(false);
+    });
+  });
+
+  describe('editing an existing income with amount 0', () => {
+    it('returns false so the user is not blocked from saving', () => {
+      expect(shouldShowAmountError(false, { type: 'income' }, 0)).toBe(false);
+    });
+  });
+
+  describe('editing an expense item', () => {
+    it('returns true when amount is 0 — items must carry a value', () => {
+      expect(shouldShowAmountError(false, { type: 'expenseItem' }, 0)).toBe(true);
+    });
+
+    it('returns false when amount is positive', () => {
+      expect(shouldShowAmountError(false, { type: 'expenseItem' }, 5)).toBe(false);
+    });
+  });
+});

--- a/econoflow-mobile/src/utils/__tests__/amountValidation.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/amountValidation.test.ts
@@ -3,48 +3,52 @@ import { shouldShowAmountError } from '../amountValidation';
 describe('shouldShowAmountError', () => {
   describe('creating a new entry (no editMode)', () => {
     it('returns true when amount is 0', () => {
-      expect(shouldShowAmountError(undefined, undefined, 0)).toBe(true);
+      expect(shouldShowAmountError(undefined, 0)).toBe(true);
     });
 
     it('returns true when amount is negative', () => {
-      expect(shouldShowAmountError(undefined, undefined, -5)).toBe(true);
+      expect(shouldShowAmountError(undefined, -5)).toBe(true);
     });
 
     it('returns false when amount is positive', () => {
-      expect(shouldShowAmountError(undefined, undefined, 10)).toBe(false);
+      expect(shouldShowAmountError(undefined, 10)).toBe(false);
     });
   });
 
   describe('editing an expense that has child items (hasItems)', () => {
     it('returns false regardless of amount — amount is derived from items', () => {
-      expect(shouldShowAmountError(true, { type: 'expense' }, 0)).toBe(false);
-      expect(shouldShowAmountError(true, { type: 'expense' }, -1)).toBe(false);
+      expect(shouldShowAmountError({ type: 'expense', hasItems: true }, 0)).toBe(false);
+      expect(shouldShowAmountError({ type: 'expense', hasItems: true }, -1)).toBe(false);
     });
   });
 
   describe('editing an existing expense with amount 0 (no items)', () => {
     it('returns false so the user is not blocked from saving', () => {
-      expect(shouldShowAmountError(false, { type: 'expense' }, 0)).toBe(false);
+      expect(shouldShowAmountError({ type: 'expense' }, 0)).toBe(false);
     });
 
     it('returns false for a positive amount too', () => {
-      expect(shouldShowAmountError(false, { type: 'expense' }, 22)).toBe(false);
+      expect(shouldShowAmountError({ type: 'expense' }, 22)).toBe(false);
     });
   });
 
   describe('editing an existing income with amount 0', () => {
     it('returns false so the user is not blocked from saving', () => {
-      expect(shouldShowAmountError(false, { type: 'income' }, 0)).toBe(false);
+      expect(shouldShowAmountError({ type: 'income' }, 0)).toBe(false);
     });
   });
 
   describe('editing an expense item', () => {
     it('returns true when amount is 0 — items must carry a value', () => {
-      expect(shouldShowAmountError(false, { type: 'expenseItem' }, 0)).toBe(true);
+      expect(shouldShowAmountError({ type: 'expenseItem' }, 0)).toBe(true);
     });
 
     it('returns false when amount is positive', () => {
-      expect(shouldShowAmountError(false, { type: 'expenseItem' }, 5)).toBe(false);
+      expect(shouldShowAmountError({ type: 'expenseItem' }, 5)).toBe(false);
+    });
+
+    it('expenseItem rule takes priority over hasItems — amount > 0 still required', () => {
+      expect(shouldShowAmountError({ type: 'expenseItem', hasItems: true }, 0)).toBe(true);
     });
   });
 });

--- a/econoflow-mobile/src/utils/amountValidation.ts
+++ b/econoflow-mobile/src/utils/amountValidation.ts
@@ -1,19 +1,20 @@
 /**
  * Returns true when the amount field must be > 0 and the user should see an error.
  *
- * Rules:
+ * Rules (checked in priority order):
+ * - Editing an expense item: the item carries its own amount — must be > 0,
+ *   regardless of whether the parent expense has hasItems set.
  * - Expense with hasItems: amount is derived from child items — never an error.
  * - Editing an existing expense or income: the stored amount (even 0) is valid;
  *   the user should not be blocked from saving without changing the amount.
- * - Editing an expense item: the item carries its own amount — must be > 0.
  * - Creating a new entry: amount must be > 0.
  */
 export function shouldShowAmountError(
-  hasItems: boolean | undefined,
-  editMode: { type: string } | undefined,
+  editMode: { type: string; hasItems?: boolean } | undefined,
   amount: number,
 ): boolean {
-  if (hasItems) return false;
-  if (editMode && editMode.type !== 'expenseItem') return false;
+  if (editMode?.type === 'expenseItem') return amount <= 0;
+  if (editMode?.hasItems) return false;
+  if (editMode) return false;
   return amount <= 0;
 }

--- a/econoflow-mobile/src/utils/amountValidation.ts
+++ b/econoflow-mobile/src/utils/amountValidation.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns true when the amount field must be > 0 and the user should see an error.
+ *
+ * Rules:
+ * - Expense with hasItems: amount is derived from child items — never an error.
+ * - Editing an existing expense or income: the stored amount (even 0) is valid;
+ *   the user should not be blocked from saving without changing the amount.
+ * - Editing an expense item: the item carries its own amount — must be > 0.
+ * - Creating a new entry: amount must be > 0.
+ */
+export function shouldShowAmountError(
+  hasItems: boolean | undefined,
+  editMode: { type: string } | undefined,
+  amount: number,
+): boolean {
+  if (hasItems) return false;
+  if (editMode && editMode.type !== 'expenseItem') return false;
+  return amount <= 0;
+}


### PR DESCRIPTION
- Fix timeline lines not connecting between rows: moved paddingVertical
  from itemRow into new itemBody wrapper so timelineCol fills the full
  row height; removed borderRadius from line segments so they meet dots
  without gaps
- Add isDeductible and proof-attachment badges to ExpenseItemRow,
  matching the style used on the expense group header; add missing
  attachments field to ExpenseItem type
- Make the entire income card row a TouchableOpacity that opens the edit
  modal; remove the pencil icon; keep the trash button as a nested
  TouchableOpacity so it still triggers delete independently

https://claude.ai/code/session_01K7wmUcCPA1dsvPW63Z1NnW