### PR TITLE
fix(mobile): surface backend validation errors in expense form

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -502,6 +502,10 @@ AppNavigator
               + QuickAddModal (global bottom-sheet overlay)
 ```
 
+### API validation error handling
+
+Backend 400 responses carry field-level errors as `{ errors: { FieldName: string[] } }`. Use `extractApiErrors(error)` from `src/utils/apiErrors.ts` in mutation `onError` callbacks. Map known field names to react-hook-form via `setError('fieldName', { type: 'server', message })` and render with `<HelperText type="error">`. Map the `Date` field (not controlled by react-hook-form) to a separate `useState`. Show unmapped or generic errors via `<ErrorBanner>`.
+
 ---
 
 ## 13. Configuration Reference

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -35,4 +35,28 @@ describe('i18n locale completeness', () => {
   it('pt.json contains LabelProofAttached', () => {
     expect((pt as LocaleMap)['LabelProofAttached']).toBeTruthy();
   });
+
+  it('en.json contains LabelOfBudget', () => {
+    expect((en as LocaleMap)['LabelOfBudget']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelOfBudget', () => {
+    expect((pt as LocaleMap)['LabelOfBudget']).toBeTruthy();
+  });
+
+  it('en.json contains ErrorGeneric', () => {
+    expect((en as LocaleMap)['ErrorGeneric']).toBeTruthy();
+  });
+
+  it('pt.json contains ErrorGeneric', () => {
+    expect((pt as LocaleMap)['ErrorGeneric']).toBeTruthy();
+  });
+
+  it('en.json contains ButtonDismiss', () => {
+    expect((en as LocaleMap)['ButtonDismiss']).toBeTruthy();
+  });
+
+  it('pt.json contains ButtonDismiss', () => {
+    expect((pt as LocaleMap)['ButtonDismiss']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -524,6 +524,7 @@
   "LabelCommonCurrencies": "Common: EUR, USD, GBP, BRL, JPY, CAD, AUD, CHF",
 
   "LabelOver": "over",
+  "LabelOfBudget": "of budget",
   "LabelRemaining": "remaining",
   "LabelForgotPassword": "Forgot password?",
   "LabelForgotPasswordDescription": "Enter your email and we'll send you a reset link.",

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -523,6 +523,7 @@
   "LabelCommonCurrencies": "Comuns: EUR, USD, GBP, BRL, JPY, CAD, AUD, CHF",
 
   "LabelOver": "acima",
+  "LabelOfBudget": "do orçamento",
   "LabelRemaining": "restante",
   "LabelForgotPassword": "Esqueceu a senha?",
   "LabelForgotPasswordDescription": "Informe seu e-mail e enviaremos um link de redefinição.",

--- a/econoflow-mobile/src/screens/expenses/ExpenseFormScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseFormScreen.tsx
@@ -10,6 +10,8 @@ import { useProjectStore } from '../../store/projectStore';
 import { useCreateExpense, usePatchExpense } from '../../hooks/useExpenses';
 import { toDateOnly, fromDateOnly } from '../../utils/date';
 import { buildPatch } from '../../utils/patch';
+import { extractApiErrors } from '../../utils/apiErrors';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'ExpenseForm'>;
 
@@ -31,11 +33,13 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
     initialValues?.date ? fromDateOnly(initialValues.date) : new Date()
   );
   const [showDatePicker, setShowDatePicker] = useState(false);
+  const [dateError, setDateError] = useState<string | undefined>();
+  const [apiError, setApiError] = useState<string | undefined>();
 
   const createExpense = useCreateExpense(projectId, categoryId, month);
   const patchExpense = usePatchExpense(projectId, categoryId, expenseId ?? '', month);
 
-  const { control, handleSubmit, formState: { errors } } = useForm<FormValues>({
+  const { control, handleSubmit, setError, formState: { errors } } = useForm<FormValues>({
     defaultValues: {
       name: initialValues?.name ?? '',
       amount: initialValues?.amount?.toString() ?? '',
@@ -44,7 +48,44 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
     },
   });
 
+  const handleApiError = (error: unknown) => {
+    const fieldErrors = extractApiErrors(error);
+    const unmapped: string[] = [];
+
+    setDateError(undefined);
+    setApiError(undefined);
+
+    for (const [key, messages] of Object.entries(fieldErrors)) {
+      const first = messages[0];
+      switch (key.toLowerCase()) {
+        case 'name':
+          setError('name', { type: 'server', message: first });
+          break;
+        case 'amount':
+          setError('amount', { type: 'server', message: first });
+          break;
+        case 'budget':
+          setError('budget', { type: 'server', message: first });
+          break;
+        case 'date':
+          setDateError(first);
+          break;
+        default:
+          unmapped.push(first);
+      }
+    }
+
+    if (unmapped.length > 0) {
+      setApiError(unmapped.join(' '));
+    } else if (Object.keys(fieldErrors).length === 0) {
+      setApiError(t('ErrorGeneric') ?? 'Something went wrong. Please try again.');
+    }
+  };
+
   const onSubmit = (values: FormValues) => {
+    setDateError(undefined);
+    setApiError(undefined);
+
     const parsed = {
       name: values.name,
       amount: parseFloat(values.amount) || 0,
@@ -56,10 +97,12 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
     if (isEdit) {
       patchExpense.mutate(buildPatch(parsed as Record<string, unknown>), {
         onSuccess: () => navigation.goBack(),
+        onError: handleApiError,
       });
     } else {
       createExpense.mutate(parsed, {
         onSuccess: () => navigation.goBack(),
+        onError: handleApiError,
       });
     }
   };
@@ -68,6 +111,11 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
+      <ErrorBanner
+        visible={!!apiError}
+        message={apiError}
+        onDismiss={() => setApiError(undefined)}
+      />
       <Text variant="headlineSmall" style={styles.title}>
         {isEdit ? (t('LabelEditExpense') ?? 'Edit expense') : (t('LabelAddExpense') ?? 'Add expense')}
       </Text>
@@ -96,9 +144,10 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
         control={control}
         name="budget"
         render={({ field: { onChange, value } }) => (
-          <TextInput label={t('FieldBudget') ?? 'Budget'} value={value} onChangeText={onChange} keyboardType="decimal-pad" style={styles.input} />
+          <TextInput label={t('FieldBudget') ?? 'Budget'} value={value} onChangeText={onChange} keyboardType="decimal-pad" style={styles.input} error={!!errors.budget} />
         )}
       />
+      {errors.budget && <HelperText type="error">{errors.budget.message}</HelperText>}
 
       <Button mode="outlined" onPress={() => setShowDatePicker(true)} style={styles.input}>
         {t('FieldDate') ?? 'Date'}: {toDateOnly(date)}
@@ -110,10 +159,14 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
           maximumDate={new Date()}
           onChange={(_e, selected) => {
             setShowDatePicker(false);
-            if (selected) setDate(selected);
+            if (selected) {
+              setDate(selected);
+              setDateError(undefined);
+            }
           }}
         />
       )}
+      {dateError && <HelperText type="error">{dateError}</HelperText>}
 
       <Controller
         control={control}

--- a/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
@@ -196,7 +196,7 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
 
                     {canEdit && (
                       <TouchableOpacity
-                        onPress={() => setPendingDeleteId(item.id)}
+                        onPress={(e) => { e.stopPropagation(); setPendingDeleteId(item.id); }}
                         hitSlop={6}
                         style={styles.groupAction}
                       >

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -21,6 +21,8 @@ import { getCurrencySymbol } from '../../utils/currency';
 import { currentMonth, toDateOnly, fromDateOnly, dateToMonth, defaultDateForMonth } from '../../utils/date';
 import { buildPatch, buildExpenseItemPatch } from '../../utils/patch';
 import { shouldShowAmountError } from '../../utils/amountValidation';
+import { extractApiErrors } from '../../utils/apiErrors';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { auroraTokens } from '../../theme/useAuroraSkin';
 
 // ── Public types ─────────────────────────────────────────────────────────────
@@ -73,6 +75,9 @@ type ModalState = {
   isDeductible: boolean;
   amountText: string;
   amountError: boolean;
+  dateApiError: string | undefined;
+  amountApiError: string | undefined;
+  apiError: string | undefined;
 };
 
 type ModalAction =
@@ -86,7 +91,8 @@ type ModalAction =
   | { kind: 'close_date_picker' }
   | { kind: 'toggle_deductible' }
   | { kind: 'set_amount_text'; text: string }
-  | { kind: 'set_amount_error'; error: boolean };
+  | { kind: 'set_amount_error'; error: boolean }
+  | { kind: 'set_api_errors'; dateApiError: string | undefined; amountApiError: string | undefined; apiError: string | undefined };
 
 const initState: ModalState = {
   entryType: 'expense',
@@ -97,6 +103,9 @@ const initState: ModalState = {
   isDeductible: false,
   amountText: '',
   amountError: false,
+  dateApiError: undefined,
+  amountApiError: undefined,
+  apiError: undefined,
 };
 
 function modalReducer(state: ModalState, action: ModalAction): ModalState {
@@ -111,6 +120,9 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
         showDatePicker: false,
         amountText: action.editMode.initialValues.amount > 0 ? String(Math.round(action.editMode.initialValues.amount * 100)) : '',
         amountError: false,
+        dateApiError: undefined,
+        amountApiError: undefined,
+        apiError: undefined,
       };
     case 'open_add':
       return {
@@ -122,6 +134,9 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
         showDatePicker: false,
         amountText: '',
         amountError: false,
+        dateApiError: undefined,
+        amountApiError: undefined,
+        apiError: undefined,
       };
     case 'set_type':
       return { ...state, entryType: action.entryType, selectedCategoryId: null, selectedExpenseId: null };
@@ -141,6 +156,8 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
       return { ...state, amountText: action.text };
     case 'set_amount_error':
       return { ...state, amountError: action.error };
+    case 'set_api_errors':
+      return { ...state, dateApiError: action.dateApiError, amountApiError: action.amountApiError, apiError: action.apiError };
     default:
       return state;
   }
@@ -214,7 +231,7 @@ export const QuickAddModal: React.FC<Props> = ({
   // ── Reset form when modal opens / closes ──────────────────────────────────
   // dispatch (useReducer) is NOT a useState setter — the react-hooks/set-state-
   // in-effect rule only flags useState setters, so using dispatch here is safe.
-  const { control, handleSubmit, reset, setValue, formState: { errors } } = useForm<FormValues>({
+  const { control, handleSubmit, reset, setError, formState: { errors } } = useForm<FormValues>({
     defaultValues: { name: '', budget: '' },
   });
 
@@ -227,8 +244,7 @@ export const QuickAddModal: React.FC<Props> = ({
     Animated.spring(dragY, { toValue: 0, useNativeDriver: true, tension: 68, friction: 12 }).start();
 
     if (editMode) {
-      setValue('name',   editMode.initialValues.name);
-      setValue('budget', editMode.initialValues.budget ? String(editMode.initialValues.budget) : '');
+      reset({ name: editMode.initialValues.name, budget: editMode.initialValues.budget ? String(editMode.initialValues.budget) : '' });
       dispatch({ kind: 'open_edit', editMode });
     } else {
       reset({ name: '', budget: '' });
@@ -275,11 +291,49 @@ export const QuickAddModal: React.FC<Props> = ({
     addExpenseItem.isPending || patchExpense.isPending || patchIncome.isPending;
 
   // ── Submit ────────────────────────────────────────────────────────────────
+  const handleApiError = (error: unknown) => {
+    const fieldErrors = extractApiErrors(error);
+    const unmapped: string[] = [];
+    let dateApiError: string | undefined;
+    let amountApiError: string | undefined;
+
+    for (const [key, messages] of Object.entries(fieldErrors)) {
+      const first = messages[0];
+      switch (key.toLowerCase()) {
+        case 'name':
+          setError('name', { type: 'server', message: first });
+          break;
+        case 'budget':
+          setError('budget', { type: 'server', message: first });
+          break;
+        case 'date':
+          dateApiError = first;
+          break;
+        case 'amount':
+          amountApiError = first;
+          break;
+        default:
+          unmapped.push(first);
+      }
+    }
+
+    let apiError: string | undefined;
+    if (unmapped.length > 0) {
+      apiError = unmapped.join(' ');
+    } else if (Object.keys(fieldErrors).length === 0) {
+      apiError = t('ErrorGeneric') ?? 'Something went wrong. Please try again.';
+    }
+
+    dispatch({ kind: 'set_api_errors', dateApiError, amountApiError, apiError });
+  };
+
   const onSubmit = (values: FormValues) => {
     const amount  = (parseInt(modal.amountText || '0', 10) / 100);
     const budget  = parseFloat(values.budget) || 0;
     const dateStr = toDateOnly(modal.date);
     const name    = values.name.trim();
+
+    dispatch({ kind: 'set_api_errors', dateApiError: undefined, amountApiError: undefined, apiError: undefined });
 
     if (shouldShowAmountError(editMode, amount)) {
       dispatch({ kind: 'set_amount_error', error: true });
@@ -292,33 +346,33 @@ export const QuickAddModal: React.FC<Props> = ({
         const idx = editMode.itemIndex ?? 0;
         patchExpense.mutate(
           buildExpenseItemPatch(idx, { name, amount, date: dateStr, isDeductible: modal.isDeductible }),
-          { onSuccess: onClose },
+          { onSuccess: onClose, onError: handleApiError },
         );
         return;
       }
       if (editMode.type === 'expense') {
         const fields: Record<string, unknown> = { name, date: dateStr, isDeductible: modal.isDeductible, budget };
         if (!editMode.hasItems) fields.amount = amount;
-        patchExpense.mutate(buildPatch(fields), { onSuccess: onClose });
+        patchExpense.mutate(buildPatch(fields), { onSuccess: onClose, onError: handleApiError });
       } else {
         // income: only patch name, amount, date — no isDeductible or budget
-        patchIncome.mutate(buildPatch({ name, amount, date: dateStr } as Record<string, unknown>), { onSuccess: onClose });
+        patchIncome.mutate(buildPatch({ name, amount, date: dateStr } as Record<string, unknown>), { onSuccess: onClose, onError: handleApiError });
       }
       return;
     }
 
     if (modal.entryType === 'income') {
-      createIncome.mutate({ name, amount, date: dateStr }, { onSuccess: onClose });
+      createIncome.mutate({ name, amount, date: dateStr }, { onSuccess: onClose, onError: handleApiError });
     } else if (modal.selectedExpenseId) {
       addExpenseItem.mutate(
         { expenseId: modal.selectedExpenseId, item: { name, amount, date: dateStr, isDeductible: modal.isDeductible } as never },
-        { onSuccess: onClose },
+        { onSuccess: onClose, onError: handleApiError },
       );
     } else {
       if (!modal.selectedCategoryId) return;
       createExpense.mutate(
         { name, amount, budget, isDeductible: modal.isDeductible, date: dateStr },
-        { onSuccess: onClose },
+        { onSuccess: onClose, onError: handleApiError },
       );
     }
   };
@@ -400,6 +454,13 @@ export const QuickAddModal: React.FC<Props> = ({
             automaticallyAdjustKeyboardInsets
             contentContainerStyle={styles.scrollContent}
           >
+            {/* API error banner */}
+            <ErrorBanner
+              visible={!!modal.apiError}
+              message={modal.apiError}
+              onDismiss={() => dispatch({ kind: 'set_api_errors', dateApiError: modal.dateApiError, amountApiError: modal.amountApiError, apiError: undefined })}
+            />
+
             {/* Header */}
             <Text style={[styles.title, { color: ink }]}>{title}</Text>
 
@@ -482,6 +543,11 @@ export const QuickAddModal: React.FC<Props> = ({
               {modal.amountError && (
                 <HelperText type="error" style={styles.amountHeroError}>
                   {t('RequiredField') ?? 'Required'}
+                </HelperText>
+              )}
+              {modal.amountApiError && (
+                <HelperText type="error" style={styles.amountHeroError}>
+                  {modal.amountApiError}
                 </HelperText>
               )}
             </Pressable>
@@ -589,13 +655,16 @@ export const QuickAddModal: React.FC<Props> = ({
 
             {/* Budget — expense only, not when adding an item or editing an expense item */}
             {(modal.entryType === 'expense' || isEditMode) && editMode?.type !== 'income' && editMode?.type !== 'expenseItem' && !modal.selectedExpenseId && (
-              <Controller control={control} name="budget"
-                render={({ field: { onChange, value } }) => (
-                  <AuroraField dark={dark} icon="bullseye-arrow" textPrefix={sym || undefined}
-                    placeholder={`${t('FieldBudget') ?? 'Budget'} (${t('Optional') ?? 'optional'})`}
-                    value={value} onChangeText={onChange} keyboardType="decimal-pad" />
-                )}
-              />
+              <>
+                <Controller control={control} name="budget"
+                  render={({ field: { onChange, value } }) => (
+                    <AuroraField dark={dark} icon="bullseye-arrow" textPrefix={sym || undefined}
+                      placeholder={`${t('FieldBudget') ?? 'Budget'} (${t('Optional') ?? 'optional'})`}
+                      value={value} onChangeText={onChange} keyboardType="decimal-pad" hasError={!!errors.budget} />
+                  )}
+                />
+                {errors.budget && <HelperText type="error" style={styles.helperText}>{errors.budget.message}</HelperText>}
+              </>
             )}
 
             {/* Date picker */}
@@ -618,11 +687,15 @@ export const QuickAddModal: React.FC<Props> = ({
                 onChange={(_e, selected) => {
                   if (selected) {
                     dispatch({ kind: 'set_date', date: selected });
+                    dispatch({ kind: 'set_api_errors', dateApiError: undefined, amountApiError: modal.amountApiError, apiError: modal.apiError });
                   } else {
                     dispatch({ kind: 'close_date_picker' });
                   }
                 }}
               />
+            )}
+            {modal.dateApiError && (
+              <HelperText type="error" style={styles.helperText}>{modal.dateApiError}</HelperText>
             )}
 
             {/* Deductible toggle */}

--- a/econoflow-mobile/src/utils/__tests__/apiErrors.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/apiErrors.test.ts
@@ -1,0 +1,67 @@
+import { extractApiErrors } from '../apiErrors';
+
+describe('extractApiErrors', () => {
+  it('returns empty record for a generic JS Error', () => {
+    expect(extractApiErrors(new Error('generic'))).toEqual({});
+  });
+
+  it('returns empty record when response has no data', () => {
+    expect(extractApiErrors({ response: {} })).toEqual({});
+  });
+
+  it('returns empty record when response data has no errors property', () => {
+    expect(extractApiErrors({ response: { data: {} } })).toEqual({});
+  });
+
+  it('returns the errors record from a well-formed API 400 response', () => {
+    const error = {
+      response: {
+        data: {
+          errors: { Date: ["A future expense can't have an amount"] },
+        },
+      },
+    };
+    expect(extractApiErrors(error)).toEqual({
+      Date: ["A future expense can't have an amount"],
+    });
+  });
+
+  it('handles multiple field errors in one response', () => {
+    const error = {
+      response: {
+        data: {
+          errors: {
+            Date: ["A future expense can't have an amount"],
+            Amount: ["Amount can't be less than zero"],
+          },
+        },
+      },
+    };
+    const result = extractApiErrors(error);
+    expect(result.Date).toEqual(["A future expense can't have an amount"]);
+    expect(result.Amount).toEqual(["Amount can't be less than zero"]);
+  });
+
+  it('returns empty record for null', () => {
+    expect(extractApiErrors(null)).toEqual({});
+  });
+
+  it('returns empty record for undefined', () => {
+    expect(extractApiErrors(undefined)).toEqual({});
+  });
+
+  it('returns empty record for a string', () => {
+    expect(extractApiErrors('network error')).toEqual({});
+  });
+
+  it('returns all messages for a field when the backend sends multiple', () => {
+    const error = {
+      response: {
+        data: {
+          errors: { Name: ['Name is required', 'Name too long'] },
+        },
+      },
+    };
+    expect(extractApiErrors(error).Name).toHaveLength(2);
+  });
+});

--- a/econoflow-mobile/src/utils/apiErrors.ts
+++ b/econoflow-mobile/src/utils/apiErrors.ts
@@ -1,0 +1,6 @@
+type RawErrorResponse = { response?: { data?: { errors?: Record<string, string[]> } } };
+
+export function extractApiErrors(error: unknown): Record<string, string[]> {
+  const e = error as RawErrorResponse;
+  return e?.response?.data?.errors ?? {};
+}


### PR DESCRIPTION
Backend 400 responses with field-level errors (e.g. future-date or
negative-amount rejections) were silently ignored — mutations had no
onError callback so users saw nothing when the API rejected their input.

- Add extractApiErrors() utility that pulls errors record from Axios responses
- Wire onError to both createExpense and patchExpense mutations
- Map Date errors to a local useState shown below the date picker
- Map Name/Amount/Budget errors to react-hook-form setError (HelperText)
- Show unmapped or generic errors via ErrorBanner
- Document the pattern in architecture.md §12

https://claude.ai/code/session_01R4U7VU5j9dfYK8KZhsqbaZ