### PR TITLE
fix: correct overspend calculation in mobile to include unplanned expenses

### DIFF
--- a/econoflow-mobile/src/components/budget/CategoryCard.tsx
+++ b/econoflow-mobile/src/components/budget/CategoryCard.tsx
@@ -10,6 +10,7 @@ import { getCurrencySymbol } from '../../utils/currency';
 import { GlassCard } from '../common/GlassCard';
 import { DonutRing } from '../common/DonutRing';
 import { auroraTokens } from '../../theme/useAuroraSkin';
+import { useAppTheme } from '../../theme/useAppTheme';
 
 interface Props {
   category: Category;
@@ -29,9 +30,11 @@ export const CategoryCard: React.FC<Props> = ({
 }) => {
   const { t }  = useTranslation();
   const { ink, ink2 } = auroraTokens(!!dark);
+  const { colors } = useAppTheme();
   const spent  = getTotalSpend(category);
   const budget = getTotalBudget(category);
-  const pct    = budget > 0 ? Math.min(spent / budget, 1) : 0;
+  const pct    = budget > 0 ? spent / budget : 0;
+  const isOver = pct > 1;
   const color  = getCategoryColor(index);
   const sym    = getCurrencySymbol(currency);
   const icon   = getCategoryIcon(category.name);
@@ -44,15 +47,15 @@ export const CategoryCard: React.FC<Props> = ({
             size={46}
             strokeWidth={6}
             progress={pct}
-            color={color}
+            color={isOver ? colors.error : color}
             trackColor={dark ? color + '33' : color + '28'}
           >
-            <MaterialCommunityIcons name={icon as never} size={17} color={color} />
+            <MaterialCommunityIcons name={icon as never} size={17} color={isOver ? colors.error : color} />
           </DonutRing>
 
           <View style={styles.info}>
             <Text style={[styles.name, { color: ink }]}>{category.name}</Text>
-            <Text style={[styles.sub, { color: ink2 }]}>
+            <Text style={[styles.sub, { color: isOver ? colors.error : ink2 }]}>
               {category.expenses.length} {t('LabelExpenseItems')} · {Math.round(pct * 100)}%
             </Text>
           </View>

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -24,7 +24,7 @@ import { QuickAddModal } from '../quick-add/QuickAddModal';
 import type { QuickAddEditMode } from '../quick-add/QuickAddModal';
 import { fromDateOnly, formatMonthLabel } from '../../utils/date';
 import { MonthNavigator } from '../../components/common/MonthNavigator';
-import { toggleSetItem } from '../../utils/budget';
+import { toggleSetItem, calculateExpensesOverspend } from '../../utils/budget';
 import { getCategoryColor } from '../../utils/categoryTheme';
 import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
@@ -93,9 +93,10 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
   if (isLoading && !expenses) return <LoadingIndicator />;
 
   const list = expenses ?? [];
-  const totalSpent  = list.reduce((s, e) => s + e.amount, 0);
-  const totalBudget = list.reduce((s, e) => s + e.budget, 0);
-  const pct = totalBudget > 0 ? Math.min((totalSpent / totalBudget), 1) : 0;
+  const totalSpent     = list.reduce((s, e) => s + e.amount, 0);
+  const totalBudget    = list.reduce((s, e) => s + e.budget, 0);
+  const totalOverspend = calculateExpensesOverspend(list);
+  const pct = totalBudget > 0 ? totalSpent / totalBudget : 0;
 
   return (
     <GlassScreen dark={dark}>
@@ -135,10 +136,10 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
               size={72}
               strokeWidth={8}
               progress={pct}
-              color={color}
+              color={totalOverspend > 0 ? colors.error : color}
               trackColor={color + '33'}
             >
-              <MaterialCommunityIcons name={getCategoryIcon(categoryName) as never} size={24} color={color} />
+              <MaterialCommunityIcons name={getCategoryIcon(categoryName) as never} size={24} color={totalOverspend > 0 ? colors.error : color} />
             </DonutRing>
 
             <View style={styles.summaryMeta}>
@@ -149,14 +150,15 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                 {sym} {fmt(totalSpent)}
               </Text>
               {totalBudget > 0 && (
-                <Text style={[styles.summaryBudget, { color: ink2 }]}>
+                <Text style={[styles.summaryBudget, { color: totalOverspend > 0 ? colors.error : ink2 }]}>
                   {t('Budget') ?? 'Budget'} {sym} {fmt(totalBudget)} · {Math.round(pct * 100)}%
+                  {totalOverspend > 0 ? ` · ${fmt(totalOverspend)} ${t('LabelOver') ?? 'over'}` : ''}
                 </Text>
               )}
               <View style={[styles.summaryBar, { backgroundColor: color + '22' }]}>
                 <View style={[
                   styles.summaryBarFill,
-                  { width: `${Math.round(pct * 100)}%` as `${number}%`, backgroundColor: color },
+                  { width: `${Math.min(Math.round(pct * 100), 100)}%` as `${number}%`, backgroundColor: totalOverspend > 0 ? colors.error : color },
                 ]} />
               </View>
             </View>

--- a/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
+++ b/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
@@ -28,11 +28,13 @@ import {
   calculateTotalBudget,
   calculateTotalExpenses,
   calculateTotalIncome,
+  calculateTotalOverspend,
 } from '../../utils/budget';
 import { getCategoryColor } from '../../utils/categoryTheme';
 import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { useAppTheme } from '../../theme/useAppTheme';
 import { DonutRing } from '../../components/common/DonutRing';
 
 type Props = {
@@ -46,6 +48,7 @@ function fmtCompact(n: number): string {
 export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2, hair } = useAuroraSkin();
+  const { colors } = useAppTheme();
   const insets = useSafeAreaInsets();
   const [month, setMonth] = useState(currentMonth());
   const [refreshing, setRefreshing] = useState(false);
@@ -105,14 +108,15 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
 
   const isFetchingData = fetchingCats || fetchingIncs;
 
-  const totalIncome   = calculateTotalIncome(incomes ?? []);
-  const totalExpenses = calculateTotalExpenses(categories ?? []);
-  const totalBudget   = calculateTotalBudget(categories ?? []);
-  const balance       = totalIncome - totalExpenses;
-  const budgetPct     = totalBudget > 0
-    ? Math.min(Math.round((totalExpenses / totalBudget) * 100), 100)
+  const totalIncome    = calculateTotalIncome(incomes ?? []);
+  const totalExpenses  = calculateTotalExpenses(categories ?? []);
+  const totalBudget    = calculateTotalBudget(categories ?? []);
+  const totalOverspend = calculateTotalOverspend(categories ?? []);
+  const balance        = totalIncome - totalExpenses;
+  const budgetPct      = totalBudget > 0
+    ? Math.round((totalExpenses / totalBudget) * 100)
     : 0;
-  const remaining     = Math.max(totalBudget - totalExpenses, 0);
+  const remaining      = Math.max(totalBudget - (totalExpenses - totalOverspend), 0);
   const activeCategories = (categories ?? []).filter(c => !c.isArchived);
   const sym = getCurrencySymbol(currency);
 
@@ -238,11 +242,11 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
 
               <View style={styles.budgetMeta}>
                 <Text style={[styles.budgetMetaLabel, { color: ink2 }]}>{t('Budget')}</Text>
-                <Text style={[styles.budgetMetaAmt, { color: ink }]}>
-                  {sym} {fmtCompact(remaining)}
+                <Text style={[styles.budgetMetaAmt, { color: totalOverspend > 0 ? colors.error : ink }]}>
+                  {sym} {fmtCompact(totalOverspend > 0 ? totalOverspend : remaining)}
                 </Text>
-                <Text style={[styles.budgetMetaSub, { color: ink2 }]}>
-                  {t('Remaining') ?? 'remaining'}
+                <Text style={[styles.budgetMetaSub, { color: totalOverspend > 0 ? colors.error : ink2 }]}>
+                  {totalOverspend > 0 ? (t('LabelOver') ?? 'over') : (t('Remaining') ?? 'remaining')}
                 </Text>
               </View>
             </View>
@@ -287,7 +291,7 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
               {activeCategories.map((cat, idx) => {
                 const spent  = cat.expenses.reduce((s, e) => s + e.amount, 0);
                 const budget = cat.expenses.reduce((s, e) => s + e.budget, 0);
-                const pct    = budget > 0 ? Math.min(spent / budget, 1) : 0;
+                const pct    = budget > 0 ? spent / budget : 0;
                 const color  = getCategoryColor(idx);
 
                 return (

--- a/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
+++ b/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
@@ -234,10 +234,10 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
                 size={58}
                 strokeWidth={8}
                 progress={budgetPct / 100}
-                color="#0f76a8"
-                trackColor={dark ? 'rgba(255,255,255,0.14)' : 'rgba(15,74,106,0.14)'}
+                color={totalOverspend > 0 ? colors.error : colors.primary}
+                trackColor={totalOverspend > 0 ? colors.error + '24' : colors.primary + '24'}
               >
-                <Text style={[styles.ringPct, { color: ink }]}>{budgetPct}%</Text>
+                <Text style={[styles.ringPct, { color: totalOverspend > 0 ? colors.error : ink }]}>{budgetPct}%</Text>
               </DonutRing>
 
               <View style={styles.budgetMeta}>

--- a/econoflow-mobile/src/utils/__tests__/budget.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/budget.test.ts
@@ -1,5 +1,5 @@
-import { calculateTotalIncome, calculateTotalExpenses, calculateTotalBudget, toggleSetItem } from '../budget';
-import type { Category, Income } from '../../api/types';
+import { calculateTotalIncome, calculateTotalExpenses, calculateTotalBudget, calculateTotalOverspend, calculateExpensesOverspend, toggleSetItem } from '../budget';
+import type { Category, Expense, Income } from '../../api/types';
 
 const makeIncome = (amount: number): Income =>
   ({ id: '1', name: 'i', amount, date: '2024-01-01' } as Income);
@@ -19,6 +19,31 @@ const makeCategory = (expenses: { amount: number; budget: number }[]): Category 
       attachments: [],
     })),
   } as unknown as Category);
+
+const makeExpense = (amount: number, budget: number): Expense =>
+  ({ id: '1', name: 'e', amount, budget, date: '2024-01-01', isDeductible: false, items: [], attachments: [] } as Expense);
+
+describe('calculateExpensesOverspend', () => {
+  it('returns 0 when all expenses are within budget', () => {
+    expect(calculateExpensesOverspend([makeExpense(50, 100)])).toBe(0);
+  });
+
+  it('returns 0 for an empty array', () => {
+    expect(calculateExpensesOverspend([])).toBe(0);
+  });
+
+  it('counts an unplanned expense (budget=0) as full overspend', () => {
+    expect(calculateExpensesOverspend([makeExpense(100, 100), makeExpense(100, 0)])).toBe(100);
+  });
+
+  it('does not net underspend against overspend', () => {
+    expect(calculateExpensesOverspend([makeExpense(50, 100), makeExpense(100, 0)])).toBe(100);
+  });
+
+  it('handles a partially over-budget expense', () => {
+    expect(calculateExpensesOverspend([makeExpense(120, 100)])).toBe(20);
+  });
+});
 
 describe('calculateTotalIncome', () => {
   it('sums all income amounts', () => {
@@ -75,6 +100,52 @@ describe('calculateTotalBudget', () => {
 
   it('handles zero-budget expenses', () => {
     expect(calculateTotalBudget([makeCategory([{ amount: 50, budget: 0 }])])).toBe(0);
+  });
+});
+
+describe('calculateTotalOverspend', () => {
+  it('returns 0 when all expenses are within budget', () => {
+    expect(calculateTotalOverspend([makeCategory([{ amount: 50, budget: 100 }])])).toBe(0);
+  });
+
+  it('returns 0 for empty categories', () => {
+    expect(calculateTotalOverspend([])).toBe(0);
+  });
+
+  it('counts an unplanned expense (budget=0) as full overspend', () => {
+    expect(
+      calculateTotalOverspend([
+        makeCategory([
+          { amount: 100, budget: 100 },
+          { amount: 100, budget: 0 },
+        ]),
+      ])
+    ).toBe(100);
+  });
+
+  it('does not net underspend against overspend across expenses', () => {
+    // E1 underspends by 50, E2 overspends by 100 — net would be 50 but correct is 100
+    expect(
+      calculateTotalOverspend([
+        makeCategory([
+          { amount: 50, budget: 100 },
+          { amount: 100, budget: 0 },
+        ]),
+      ])
+    ).toBe(100);
+  });
+
+  it('sums overspend across multiple categories', () => {
+    expect(
+      calculateTotalOverspend([
+        makeCategory([{ amount: 150, budget: 100 }]),
+        makeCategory([{ amount: 100, budget: 0 }]),
+      ])
+    ).toBe(150);
+  });
+
+  it('handles partially over-budget expense', () => {
+    expect(calculateTotalOverspend([makeCategory([{ amount: 120, budget: 100 }])])).toBe(20);
   });
 });
 

--- a/econoflow-mobile/src/utils/budget.ts
+++ b/econoflow-mobile/src/utils/budget.ts
@@ -1,4 +1,4 @@
-import type { Category, Income } from '../api/types';
+import type { Category, Expense, Income } from '../api/types';
 
 export const calculateTotalIncome = (incomes: Income[]): number =>
   incomes.reduce((sum, i) => sum + i.amount, 0);
@@ -12,6 +12,18 @@ export const calculateTotalExpenses = (categories: Category[]): number =>
 export const calculateTotalBudget = (categories: Category[]): number =>
   categories.reduce(
     (sum, cat) => sum + cat.expenses.reduce((s, e) => s + e.budget, 0),
+    0
+  );
+
+export const calculateExpensesOverspend = (expenses: Expense[]): number =>
+  expenses.reduce((s, e) => {
+    const overspend = e.amount - e.budget;
+    return s + (overspend > 0 ? overspend : 0);
+  }, 0);
+
+export const calculateTotalOverspend = (categories: Category[]): number =>
+  categories.reduce(
+    (sum, cat) => sum + calculateExpensesOverspend(cat.expenses),
     0
   );
 


### PR DESCRIPTION
An expense with budget=0 and amount=100 represents a fully unplanned
spend; the full amount must count as overspend. Previously the app used
Math.min(spent/budget, 1) everywhere, capping at 100% and silently
hiding any overspend from unplanned expenses.

- Add calculateExpensesOverspend(Expense[]) with the per-expense formula
  max(0, amount - budget), matching the web's ExpenseDto.getOverspend()
- Refactor calculateTotalOverspend to delegate to the new helper
- MonthlyOverviewScreen: remove 100% cap on budgetPct; show "X over"
  in error colour instead of "0 remaining" when overspend > 0
- ExpenseListScreen: use calculateExpensesOverspend; DonutRing, bar,
  and budget label all switch to error colour when overspent
- CategoryCard: remove Math.min cap; ring and sub-text switch to
  error colour when pct > 1

https://claude.ai/code/session_01RyMspAk8zHUh1zv9w6gtkE