### PR TITLE
feat(mobile): budget overspend UX improvements

### DIFF
--- a/econoflow-mobile/src/components/budget/CategoryCard.tsx
+++ b/econoflow-mobile/src/components/budget/CategoryCard.tsx
@@ -7,6 +7,7 @@ import type { Category } from '../../api/types';
 import { getCategoryColor } from '../../utils/categoryTheme';
 import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
+import { calculateExpensesOverspend } from '../../utils/budget';
 import { GlassCard } from '../common/GlassCard';
 import { DonutRing } from '../common/DonutRing';
 import { auroraTokens } from '../../theme/useAuroraSkin';
@@ -31,13 +32,14 @@ export const CategoryCard: React.FC<Props> = ({
   const { t }  = useTranslation();
   const { ink, ink2 } = auroraTokens(!!dark);
   const { colors } = useAppTheme();
-  const spent  = getTotalSpend(category);
-  const budget = getTotalBudget(category);
-  const pct    = budget > 0 ? spent / budget : 0;
-  const isOver = pct > 1;
-  const color  = getCategoryColor(index);
-  const sym    = getCurrencySymbol(currency);
-  const icon   = getCategoryIcon(category.name);
+  const spent       = getTotalSpend(category);
+  const budget      = getTotalBudget(category);
+  const pct         = budget > 0 ? spent / budget : 0;
+  const isOver      = pct > 1;
+  const catOverspend = calculateExpensesOverspend(category.expenses);
+  const color       = getCategoryColor(index);
+  const sym         = getCurrencySymbol(currency);
+  const icon        = getCategoryIcon(category.name);
 
   return (
     <TouchableOpacity onPress={onPress} activeOpacity={0.78} style={styles.wrapper}>
@@ -58,6 +60,11 @@ export const CategoryCard: React.FC<Props> = ({
             <Text style={[styles.sub, { color: isOver ? colors.error : ink2 }]}>
               {category.expenses.length} {t('LabelExpenseItems')} · {Math.round(pct * 100)}%
             </Text>
+            {catOverspend > 0 && (
+              <Text style={[styles.overspend, { color: colors.error }]}>
+                +{sym} {Math.round(catOverspend).toLocaleString()} {t('LabelOver') ?? 'over'}
+              </Text>
+            )}
           </View>
 
           <Text style={[styles.amount, { color: ink }]}>
@@ -73,8 +80,9 @@ export const CategoryCard: React.FC<Props> = ({
 const styles = StyleSheet.create({
   wrapper: { marginHorizontal: 16, marginVertical: 5 },
   row: { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 12 },
-  info:   { flex: 1, gap: 3 },
-  name:   { fontSize: 14.5, fontWeight: '700' },
-  sub:    { fontSize: 11.5 },
-  amount: { fontSize: 14, fontWeight: 'bold' },
+  info:     { flex: 1, gap: 3 },
+  name:     { fontSize: 14.5, fontWeight: '700' },
+  sub:      { fontSize: 11.5 },
+  overspend:{ fontSize: 11.5, fontWeight: '700' },
+  amount:   { fontSize: 14, fontWeight: 'bold' },
 });

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -59,4 +59,28 @@ describe('i18n locale completeness', () => {
   it('pt.json contains ButtonDismiss', () => {
     expect((pt as LocaleMap)['ButtonDismiss']).toBeTruthy();
   });
+
+  it('en.json contains LabelSpent', () => {
+    expect((en as LocaleMap)['LabelSpent']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelSpent', () => {
+    expect((pt as LocaleMap)['LabelSpent']).toBeTruthy();
+  });
+
+  it('en.json contains LabelBudgetSummary', () => {
+    expect((en as LocaleMap)['LabelBudgetSummary']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelBudgetSummary', () => {
+    expect((pt as LocaleMap)['LabelBudgetSummary']).toBeTruthy();
+  });
+
+  it('en.json contains LabelLeft', () => {
+    expect((en as LocaleMap)['LabelLeft']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelLeft', () => {
+    expect((pt as LocaleMap)['LabelLeft']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -552,5 +552,8 @@
   "LabelSelectProject": "Select a project",
   "LabelMyAccount": "My Account",
   "LabelCategories": "Categories",
+  "LabelSpent": "spent",
+  "LabelBudgetSummary": "Budget Summary",
+  "LabelLeft": "left",
   "Optional": "optional"
 }

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -551,6 +551,9 @@
   "LabelSelectProject": "Selecionar projeto",
   "LabelMyAccount": "Minha Conta",
   "LabelCategories": "Categorias",
+  "LabelSpent": "gasto",
+  "LabelBudgetSummary": "Resumo do Orçamento",
+  "LabelLeft": "restante",
   "Optional": "opcional"
 }
 

--- a/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
@@ -15,13 +15,23 @@ import { LoadingIndicator } from '../../components/common/LoadingIndicator';
 import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { MonthNavigator } from '../../components/common/MonthNavigator';
 import { GlassScreen } from '../../components/common/GlassScreen';
+import { GlassCard } from '../../components/common/GlassCard';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { useAppTheme } from '../../theme/useAppTheme';
+import {
+  calculateTotalBudget,
+  calculateTotalExpenses,
+  calculateTotalOverspend,
+  calculateRemainingBudget,
+} from '../../utils/budget';
+import { getCurrencySymbol } from '../../utils/currency';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'CategoryList'>;
 
 export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2 } = useAuroraSkin();
+  const { colors } = useAppTheme();
   const insets = useSafeAreaInsets();
   const [month, setMonth] = useState(route.params.month);
   const [dismissedError, setDismissedError] = useState(false);
@@ -47,6 +57,12 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
   if (isLoading) return <LoadingIndicator />;
 
   const activeCategories = categories?.filter(c => !c.isArchived) ?? [];
+  const sym              = getCurrencySymbol(currency);
+  const totalBudget      = calculateTotalBudget(activeCategories);
+  const totalSpent       = calculateTotalExpenses(activeCategories);
+  const totalOverspend   = calculateTotalOverspend(activeCategories);
+  const remaining        = calculateRemainingBudget(activeCategories);
+  const spentPct         = totalBudget > 0 ? Math.round((totalSpent / totalBudget) * 100) : 0;
 
   return (
     <GlassScreen dark={dark}>
@@ -78,6 +94,44 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
         style={{ opacity: isFetching && !!categories ? 0.55 : 1 }}
         data={activeCategories}
         keyExtractor={item => item.id}
+        ListHeaderComponent={
+          activeCategories.length > 0 ? (
+            <GlassCard dark={!!dark} radius={18} intensity={30} style={styles.summaryCard}>
+              <View style={styles.summaryInner}>
+                <Text style={[styles.summaryTitle, { color: ink2 }]}>{t('LabelBudgetSummary') ?? 'Budget Summary'}</Text>
+                <View style={styles.summaryRow}>
+                  <View style={styles.summaryStat}>
+                    <Text style={[styles.summaryStatLabel, { color: ink2 }]}>{t('Budget')}</Text>
+                    <Text style={[styles.summaryStatAmt, { color: ink }]}>
+                      {sym} {Math.round(totalBudget).toLocaleString()}
+                    </Text>
+                  </View>
+                  <View style={[styles.summaryDivider, { backgroundColor: ink2 + '33' }]} />
+                  <View style={styles.summaryStat}>
+                    <Text style={[styles.summaryStatLabel, { color: ink2 }]}>
+                      {t('LabelSpent') ?? 'spent'} · {spentPct}%
+                    </Text>
+                    <Text style={[styles.summaryStatAmt, { color: ink }]}>
+                      {sym} {Math.round(totalSpent).toLocaleString()}
+                    </Text>
+                  </View>
+                  <View style={[styles.summaryDivider, { backgroundColor: ink2 + '33' }]} />
+                  <View style={styles.summaryStat}>
+                    <Text style={[styles.summaryStatLabel, { color: ink2 }]}>{t('Remaining') ?? 'remaining'}</Text>
+                    <Text style={[styles.summaryStatAmt, { color: ink }]}>
+                      {sym} {Math.round(remaining).toLocaleString()}
+                    </Text>
+                    {totalOverspend > 0 && (
+                      <Text style={[styles.summaryOverspend, { color: colors.error }]}>
+                        +{sym} {Math.round(totalOverspend).toLocaleString()} {t('LabelOver') ?? 'over'}
+                      </Text>
+                    )}
+                  </View>
+                </View>
+              </View>
+            </GlassCard>
+          ) : null
+        }
         renderItem={({ item, index }) => (
           <CategoryCard
             category={item}
@@ -122,4 +176,14 @@ const styles = StyleSheet.create({
   headerName: { fontSize: 17, fontWeight: '800' },
   list: { paddingTop: 8, paddingBottom: 24 },
   empty: { textAlign: 'center', marginTop: 48, fontSize: 14, opacity: 0.6 },
+
+  summaryCard:       { marginHorizontal: 16, marginTop: 4, marginBottom: 8 },
+  summaryInner:      { padding: 14, gap: 8 },
+  summaryTitle:      { fontSize: 11.5, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.5 },
+  summaryRow:        { flexDirection: 'row', alignItems: 'flex-start' },
+  summaryStat:       { flex: 1, gap: 2 },
+  summaryDivider:    { width: 1, marginHorizontal: 12, alignSelf: 'stretch' },
+  summaryStatLabel:  { fontSize: 11, fontWeight: '600' },
+  summaryStatAmt:    { fontSize: 15, fontWeight: 'bold' },
+  summaryOverspend:  { fontSize: 11.5, fontWeight: '700' },
 });

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -136,10 +136,10 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
               size={72}
               strokeWidth={8}
               progress={pct}
-              color={totalOverspend > 0 ? colors.error : color}
+              color={pct > 1 ? colors.error : color}
               trackColor={color + '33'}
             >
-              <MaterialCommunityIcons name={getCategoryIcon(categoryName) as never} size={24} color={totalOverspend > 0 ? colors.error : color} />
+              <MaterialCommunityIcons name={getCategoryIcon(categoryName) as never} size={24} color={pct > 1 ? colors.error : color} />
             </DonutRing>
 
             <View style={styles.summaryMeta}>
@@ -150,7 +150,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                 {sym} {fmt(totalSpent)}
               </Text>
               {totalBudget > 0 && (
-                <Text style={[styles.summaryBudget, { color: totalOverspend > 0 ? colors.error : ink2 }]}>
+                <Text style={[styles.summaryBudget, { color: pct > 1 ? colors.error : ink2 }]}>
                   {t('Budget') ?? 'Budget'} {sym} {fmt(totalBudget)} · {Math.round(pct * 100)}%
                   {totalOverspend > 0 ? ` · ${fmt(totalOverspend)} ${t('LabelOver') ?? 'over'}` : ''}
                 </Text>
@@ -158,7 +158,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
               <View style={[styles.summaryBar, { backgroundColor: color + '22' }]}>
                 <View style={[
                   styles.summaryBarFill,
-                  { width: `${Math.min(Math.round(pct * 100), 100)}%` as `${number}%`, backgroundColor: totalOverspend > 0 ? colors.error : color },
+                  { width: `${Math.min(Math.round(pct * 100), 100)}%` as `${number}%`, backgroundColor: pct > 1 ? colors.error : color },
                 ]} />
               </View>
             </View>
@@ -186,10 +186,15 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
         ) : (
           <View style={styles.groupList}>
             {list.map((expense) => {
-              const isOpen = expandedIds.has(expense.id);
-              const expIcon = getCategoryIcon(expense.name);
+              const isOpen      = expandedIds.has(expense.id);
+              const expIcon     = getCategoryIcon(expense.name);
+              const expOverspend = calculateExpensesOverspend([expense]);
+              const isExpOver   = expOverspend > 0;
               return (
                 <GlassCard key={expense.id} dark={dark} radius={18} style={styles.groupCard}>
+                  {isExpOver && (
+                    <View style={[styles.overspendAccent, { backgroundColor: colors.error }]} />
+                  )}
                   {/* ── Group header ──────────────────────────────────── */}
                   <TouchableOpacity
                     onPress={() => setExpandedIds(prev => toggleSetItem(prev, expense.id))}
@@ -227,12 +232,14 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                     </View>
 
                     <View style={styles.groupAmtCol}>
-                      <Text style={[styles.groupAmt, { color: customColors.expense }]}>
+                      <Text style={[styles.groupAmt, { color: isExpOver ? colors.error : customColors.expense }]}>
                         −{sym} {fmt(expense.amount)}
                       </Text>
                       {expense.budget > 0 && (
-                        <Text style={[styles.groupBudget, { color: ink2 }]}>
-                          {t('Of') ?? 'of'} {sym} {fmt(expense.budget)}
+                        <Text style={[styles.groupBudget, { color: isExpOver ? colors.error : ink2 }]}>
+                          {isExpOver
+                            ? `+${sym} ${fmt(expOverspend)} ${t('LabelOver') ?? 'over'}`
+                            : `${t('Of') ?? 'of'} ${sym} ${fmt(expense.budget)}`}
                         </Text>
                       )}
                     </View>
@@ -531,6 +538,10 @@ const styles = StyleSheet.create({
 
   groupList: { paddingHorizontal: 18, gap: 10 },
   groupCard: {},
+  overspendAccent: {
+    position: 'absolute', left: 0, top: 0, bottom: 0, width: 3,
+    borderTopLeftRadius: 18, borderBottomLeftRadius: 18,
+  },
   groupHeader: {
     flexDirection: 'row', alignItems: 'center', gap: 10, padding: 13,
   },

--- a/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
+++ b/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
@@ -23,16 +23,17 @@ import { MonthNavigator } from '../../components/common/MonthNavigator';
 import { LoadingIndicator } from '../../components/common/LoadingIndicator';
 import { GlassCard } from '../../components/common/GlassCard';
 import { GlassScreen } from '../../components/common/GlassScreen';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { currentMonth } from '../../utils/date';
 import {
   calculateTotalBudget,
   calculateTotalExpenses,
   calculateTotalIncome,
   calculateTotalOverspend,
+  calculateRemainingBudget,
 } from '../../utils/budget';
-import { getCategoryColor } from '../../utils/categoryTheme';
-import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
+import { CategoryCard } from '../../components/budget/CategoryCard';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
 import { DonutRing } from '../../components/common/DonutRing';
@@ -52,6 +53,7 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
   const insets = useSafeAreaInsets();
   const [month, setMonth] = useState(currentMonth());
   const [refreshing, setRefreshing] = useState(false);
+  const [dismissedForMonth, setDismissedForMonth] = useState<string | null>(null);
 
   const setViewedMonth = useQuickAddStore(s => s.setViewedMonth);
   const isFocused = useIsFocused();
@@ -116,7 +118,7 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
   const budgetPct      = totalBudget > 0
     ? Math.round((totalExpenses / totalBudget) * 100)
     : 0;
-  const remaining      = Math.max(totalBudget - (totalExpenses - totalOverspend), 0);
+  const remaining      = calculateRemainingBudget(categories ?? []);
   const activeCategories = (categories ?? []).filter(c => !c.isArchived);
   const sym = getCurrencySymbol(currency);
 
@@ -175,12 +177,11 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
         <MonthNavigator month={month} onChange={setMonth} dark={dark} />
 
         {/* ── Error ────────────────────────────────────────────────────────── */}
-        {(catsError || incError) && (
-          <View style={styles.errorBanner}>
-            <MaterialCommunityIcons name="alert-circle-outline" size={15} color="#e74c3c" />
-            <Text style={styles.errorText}>{t('ErrorGeneric')}</Text>
-          </View>
-        )}
+        <ErrorBanner
+          visible={(catsError || incError) && dismissedForMonth !== month}
+          message={t('ErrorGeneric')}
+          onDismiss={() => setDismissedForMonth(month)}
+        />
 
         {/* ── Balance hero ─────────────────────────────────────────────────── */}
         <GlassCard dark={dark} radius={28} intensity={55} style={styles.heroCard}>
@@ -228,29 +229,39 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
 
         {/* ── Budget + Saved row ───────────────────────────────────────────── */}
         <View style={styles.summaryRow}>
-          <GlassCard dark={dark} radius={22} intensity={40} style={styles.budgetCard}>
-            <View style={styles.budgetInner}>
-              <DonutRing
-                size={58}
-                strokeWidth={8}
-                progress={budgetPct / 100}
-                color={totalOverspend > 0 ? colors.error : colors.primary}
-                trackColor={totalOverspend > 0 ? colors.error + '24' : colors.primary + '24'}
-              >
-                <Text style={[styles.ringPct, { color: totalOverspend > 0 ? colors.error : ink }]}>{budgetPct}%</Text>
-              </DonutRing>
+          <TouchableOpacity
+            style={styles.budgetCard}
+            onPress={() => navigation.navigate('CategoryList', { month })}
+            activeOpacity={0.75}
+          >
+            <GlassCard dark={dark} radius={22} intensity={40} style={styles.budgetCardInner}>
+              <View style={styles.budgetInner}>
+                <DonutRing
+                  size={58}
+                  strokeWidth={8}
+                  progress={budgetPct / 100}
+                  color={budgetPct > 100 ? colors.error : colors.primary}
+                  trackColor={budgetPct > 100 ? colors.error + '24' : colors.primary + '24'}
+                >
+                  <Text style={[styles.ringPct, { color: budgetPct > 100 ? colors.error : ink }]}>{budgetPct}%</Text>
+                </DonutRing>
 
-              <View style={styles.budgetMeta}>
-                <Text style={[styles.budgetMetaLabel, { color: ink2 }]}>{t('Budget')}</Text>
-                <Text style={[styles.budgetMetaAmt, { color: totalOverspend > 0 ? colors.error : ink }]}>
-                  {sym} {fmtCompact(totalOverspend > 0 ? totalOverspend : remaining)}
-                </Text>
-                <Text style={[styles.budgetMetaSub, { color: totalOverspend > 0 ? colors.error : ink2 }]}>
-                  {totalOverspend > 0 ? (t('LabelOver') ?? 'over') : (t('Remaining') ?? 'remaining')}
-                </Text>
+                <View style={styles.budgetMeta}>
+                  <Text style={[styles.budgetMetaLabel, { color: ink2 }]}>{t('Budget')}</Text>
+                  <Text style={[styles.budgetMetaAmt, { color: ink }]}>
+                    {sym} {fmtCompact(remaining)}{' '}
+                    <Text style={[styles.budgetMetaSub, { color: ink2 }]}>{t('Remaining') ?? 'remaining'}</Text>
+                  </Text>
+                  {totalOverspend > 0 && (
+                    <Text style={[styles.budgetMetaOver, { color: colors.error }]}>
+                      +{sym} {fmtCompact(totalOverspend)}{' '}
+                      <Text style={[styles.budgetMetaSub, { color: colors.error }]}>{t('LabelOver') ?? 'over'}</Text>
+                    </Text>
+                  )}
+                </View>
               </View>
-            </View>
-          </GlassCard>
+            </GlassCard>
+          </TouchableOpacity>
 
           <GlassCard
             dark={dark}
@@ -288,47 +299,18 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
             </View>
 
             <View style={styles.catList}>
-              {activeCategories.map((cat, idx) => {
-                const spent  = cat.expenses.reduce((s, e) => s + e.amount, 0);
-                const budget = cat.expenses.reduce((s, e) => s + e.budget, 0);
-                const pct    = budget > 0 ? spent / budget : 0;
-                const isOver = pct > 1;
-                const color  = getCategoryColor(idx);
-
-                return (
-                  <TouchableOpacity
-                    key={cat.id}
-                    onPress={() => navigation.navigate('ExpenseList', {
-                      categoryId: cat.id, categoryName: cat.name, month, categoryIndex: idx,
-                    })}
-                    activeOpacity={0.78}
-                  >
-                    <GlassCard dark={dark} radius={18} intensity={30} style={styles.catCard}>
-                      <View style={styles.catRow}>
-                        <DonutRing
-                          size={46}
-                          strokeWidth={6}
-                          progress={pct}
-                          color={isOver ? colors.error : color}
-                          trackColor={dark ? color + '33' : color + '28'}
-                        >
-                          <MaterialCommunityIcons name={getCategoryIcon(cat.name) as never} size={17} color={isOver ? colors.error : color} />
-                        </DonutRing>
-                        <View style={styles.catInfo}>
-                          <Text style={[styles.catName, { color: ink }]}>{cat.name}</Text>
-                          <Text style={[styles.catSub, { color: isOver ? colors.error : ink2 }]}>
-                            {cat.expenses.length} {t('LabelExpenseItems')} · {Math.round(pct * 100)}%
-                          </Text>
-                        </View>
-                        <Text style={[styles.catAmt, { color: ink }]}>
-                          {sym} {fmtCompact(spent)}
-                        </Text>
-                        <MaterialCommunityIcons name="chevron-right" size={18} color={ink2} />
-                      </View>
-                    </GlassCard>
-                  </TouchableOpacity>
-                );
-              })}
+              {activeCategories.map((cat, idx) => (
+                <CategoryCard
+                  key={cat.id}
+                  category={cat}
+                  currency={currency}
+                  index={idx}
+                  dark={dark}
+                  onPress={() => navigation.navigate('ExpenseList', {
+                    categoryId: cat.id, categoryName: cat.name, month, categoryIndex: idx,
+                  })}
+                />
+              ))}
             </View>
           </>
         )}
@@ -361,13 +343,6 @@ const styles = StyleSheet.create({
   projectName: { fontSize: 16, fontWeight: 'bold' },
   notifCard:   { width: 42, height: 42, alignItems: 'center', justifyContent: 'center' },
 
-  errorBanner: {
-    flexDirection: 'row', alignItems: 'center', gap: 8,
-    marginHorizontal: 18, marginBottom: 10, padding: 10, borderRadius: 10,
-    backgroundColor: 'rgba(231,76,60,0.12)', borderWidth: 1, borderColor: 'rgba(231,76,60,0.28)',
-  },
-  errorText: { color: '#e74c3c', fontSize: 13 },
-
   heroCard:    { marginHorizontal: 18, marginBottom: 12 },
   heroPad:     { padding: 22 },
   heroLabel:   { fontSize: 13, fontWeight: '600', opacity: 0.85, marginBottom: 4 },
@@ -382,18 +357,14 @@ const styles = StyleSheet.create({
   summaryRow: { flexDirection: 'row', marginHorizontal: 18, gap: 12, marginBottom: 20 },
 
   budgetCard:       { flex: 1 },
+  budgetCardInner:  { flex: 1 },
   budgetInner:      { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 14 },
-  ringOuter:        { width: 56, height: 56, borderRadius: 28, borderWidth: 7, alignItems: 'center', justifyContent: 'center', flexShrink: 0, position: 'relative' },
-  ringProgress:     { position: 'absolute', width: 56, height: 56, borderRadius: 28, borderWidth: 7 },
-  ringCenter:       { width: 30, height: 30, alignItems: 'center', justifyContent: 'center' },
   ringPct:          { fontSize: 11.5, fontWeight: 'bold' },
   budgetMeta:       { flex: 1, gap: 1 },
   budgetMetaLabel:  { fontSize: 12, fontWeight: '600' },
-  budgetMetaAmt:    { fontSize: 15, fontWeight: 'bold' },
+  budgetMetaAmt:    { fontSize: 14, fontWeight: 'bold' },
+  budgetMetaOver:   { fontSize: 13, fontWeight: '700' },
   budgetMetaSub:    { fontSize: 11 },
-  budgetBar:        { height: 4, borderRadius: 2, marginTop: 5, overflow: 'hidden' },
-  budgetBarFill:    { height: 4, borderRadius: 2, backgroundColor: '#0f76a8' },
-
   savedCard:  { width: 112 },
   savedInner: { gap: 5, padding: 14, flex: 1, borderRadius: 22 },
   savedLabel: { fontSize: 11.5, fontWeight: '600', marginTop: 4 },
@@ -403,16 +374,7 @@ const styles = StyleSheet.create({
   sectionTitle: { fontSize: 16, fontWeight: 'bold' },
   viewAll:      { fontSize: 12.5, fontWeight: '700', color: '#0f76a8' },
 
-  catList: { paddingHorizontal: 18, gap: 10 },
-  catCard: {},
-  catRow:  { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 12 },
-  catIcon: { width: 44, height: 44, borderRadius: 14, alignItems: 'center', justifyContent: 'center', flexShrink: 0 },
-  catInfo: { flex: 1, gap: 3 },
-  catName: { fontSize: 14.5, fontWeight: '700' },
-  catSub:  { fontSize: 12 },
-  catTrack:{ height: 4, borderRadius: 2, marginTop: 3, overflow: 'hidden' },
-  catFill: { height: 4, borderRadius: 2 },
-  catAmt:  { fontSize: 14, fontWeight: 'bold' },
+  catList: {},
 
   emptyCats: { alignItems: 'center', paddingVertical: 48, gap: 12 },
 });

--- a/econoflow-mobile/src/utils/__tests__/budget.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/budget.test.ts
@@ -1,4 +1,4 @@
-import { calculateTotalIncome, calculateTotalExpenses, calculateTotalBudget, calculateTotalOverspend, calculateExpensesOverspend, toggleSetItem } from '../budget';
+import { calculateTotalIncome, calculateTotalExpenses, calculateTotalBudget, calculateTotalOverspend, calculateExpensesOverspend, calculateRemainingBudget, toggleSetItem } from '../budget';
 import type { Category, Expense, Income } from '../../api/types';
 
 const makeIncome = (amount: number): Income =>
@@ -32,12 +32,12 @@ describe('calculateExpensesOverspend', () => {
     expect(calculateExpensesOverspend([])).toBe(0);
   });
 
-  it('counts an unplanned expense (budget=0) as full overspend', () => {
-    expect(calculateExpensesOverspend([makeExpense(100, 100), makeExpense(100, 0)])).toBe(100);
+  it('does not count an unplanned expense (budget=0) as overspend', () => {
+    expect(calculateExpensesOverspend([makeExpense(100, 100), makeExpense(100, 0)])).toBe(0);
   });
 
-  it('does not net underspend against overspend', () => {
-    expect(calculateExpensesOverspend([makeExpense(50, 100), makeExpense(100, 0)])).toBe(100);
+  it('does not count an unplanned expense alongside an under-budget expense', () => {
+    expect(calculateExpensesOverspend([makeExpense(50, 100), makeExpense(100, 0)])).toBe(0);
   });
 
   it('handles a partially over-budget expense', () => {
@@ -112,7 +112,7 @@ describe('calculateTotalOverspend', () => {
     expect(calculateTotalOverspend([])).toBe(0);
   });
 
-  it('counts an unplanned expense (budget=0) as full overspend', () => {
+  it('does not count an unplanned expense (budget=0) as overspend', () => {
     expect(
       calculateTotalOverspend([
         makeCategory([
@@ -120,11 +120,10 @@ describe('calculateTotalOverspend', () => {
           { amount: 100, budget: 0 },
         ]),
       ])
-    ).toBe(100);
+    ).toBe(0);
   });
 
-  it('does not net underspend against overspend across expenses', () => {
-    // E1 underspends by 50, E2 overspends by 100 — net would be 50 but correct is 100
+  it('does not net unplanned expense against under-budget expense', () => {
     expect(
       calculateTotalOverspend([
         makeCategory([
@@ -132,20 +131,67 @@ describe('calculateTotalOverspend', () => {
           { amount: 100, budget: 0 },
         ]),
       ])
-    ).toBe(100);
+    ).toBe(0);
   });
 
-  it('sums overspend across multiple categories', () => {
+  it('sums overspend across categories, ignoring unplanned expenses', () => {
     expect(
       calculateTotalOverspend([
         makeCategory([{ amount: 150, budget: 100 }]),
         makeCategory([{ amount: 100, budget: 0 }]),
       ])
-    ).toBe(150);
+    ).toBe(50);
   });
 
   it('handles partially over-budget expense', () => {
     expect(calculateTotalOverspend([makeCategory([{ amount: 120, budget: 100 }])])).toBe(20);
+  });
+});
+
+describe('calculateRemainingBudget', () => {
+  it('returns full budget when nothing is spent', () => {
+    expect(calculateRemainingBudget([makeCategory([{ amount: 0, budget: 100 }])])).toBe(100);
+  });
+
+  it('returns 0 when budget is exactly spent', () => {
+    expect(calculateRemainingBudget([makeCategory([{ amount: 100, budget: 100 }])])).toBe(0);
+  });
+
+  it('sums remaining across multiple under-budget categories', () => {
+    const cats = [
+      makeCategory([{ amount: 50, budget: 100 }]),
+      makeCategory([{ amount: 20, budget: 80 }]),
+    ];
+    // budget=180, expenses=70, overspend=0 → remaining = 110
+    expect(calculateRemainingBudget(cats)).toBe(110);
+  });
+
+  it('does not let overspend from one category reduce the remaining of another', () => {
+    const cats = [
+      makeCategory([{ amount: 50, budget: 100 }]),  // 50 remaining
+      makeCategory([{ amount: 150, budget: 100 }]), // 50 over
+    ];
+    // budget=200, expenses=200, overspend=50 → remaining = max(200-(200-50),0) = 50
+    expect(calculateRemainingBudget(cats)).toBe(50);
+  });
+
+  it('returns 0 when over budget with no under-budget slack', () => {
+    expect(calculateRemainingBudget([makeCategory([{ amount: 150, budget: 100 }])])).toBe(0);
+  });
+
+  it('returns 0 for empty input', () => {
+    expect(calculateRemainingBudget([])).toBe(0);
+  });
+
+  it('unplanned expenses consume remaining budget but are not counted as overspend', () => {
+    // planned: amount=80, budget=100 → 20 remaining
+    // unplanned: amount=100, budget=0 → consumes budget but not "over"
+    // budget=100, expenses=180, overspend=0 → remaining = max(100-180, 0) = 0
+    const cats = [
+      makeCategory([{ amount: 80, budget: 100 }]),
+      makeCategory([{ amount: 100, budget: 0 }]),
+    ];
+    expect(calculateRemainingBudget(cats)).toBe(0);
   });
 });
 

--- a/econoflow-mobile/src/utils/budget.ts
+++ b/econoflow-mobile/src/utils/budget.ts
@@ -17,6 +17,7 @@ export const calculateTotalBudget = (categories: Category[]): number =>
 
 export const calculateExpensesOverspend = (expenses: Expense[]): number =>
   expenses.reduce((s, e) => {
+    if (e.budget <= 0) return s;
     const overspend = e.amount - e.budget;
     return s + (overspend > 0 ? overspend : 0);
   }, 0);
@@ -26,6 +27,13 @@ export const calculateTotalOverspend = (categories: Category[]): number =>
     (sum, cat) => sum + calculateExpensesOverspend(cat.expenses),
     0
   );
+
+export const calculateRemainingBudget = (categories: Category[]): number => {
+  const budget = calculateTotalBudget(categories);
+  const expenses = calculateTotalExpenses(categories);
+  const overspend = calculateTotalOverspend(categories);
+  return Math.max(budget - (expenses - overspend), 0);
+};
 
 export const toggleSetItem = (prev: Set<string>, id: string): Set<string> => {
   const next = new Set(prev);


### PR DESCRIPTION
## Summary

- **Budget card (MonthlyOverviewScreen)** is now tappable (navigates to Category List) and shows remaining budget and overspend as two separate lines instead of replacing one with the other
- **DonutRing threshold fixed** in both MonthlyOverviewScreen and ExpenseListScreen: ring and bar only turn red when total usage exceeds 100% — partial per-expense overspend no longer prematurely colours the whole ring
- **Per-category overspend indicator** added to CategoryCard and the inline category list: shows `+{sym} {amount} over` in red when any individual expense within the category overshoots its own budget, even while the category total is still under 100%
- **CategoryListScreen** now has a budget summary banner above the list (Budget / Spent% / Remaining / Overspend)
- **ExpenseListScreen** highlights overspent individual expenses with a 3px red left accent bar, red amount text, and `+{sym} {overspend} over` label replacing the `of {budget}` line
- **Unplanned expenses** (`budget=0`) are never flagged as overspent anywhere in the UI — they consume remaining budget but are excluded from overspend calculations
- **CategoryCard deduplicated**: removed the inline rendering loop from MonthlyOverviewScreen in favour of the shared component
- **ErrorBanner** now used consistently in MonthlyOverviewScreen (was a hand-rolled View)
- New utility `calculateRemainingBudget` extracted for reuse; `calculateExpensesOverspend` corrected to exclude `budget ≤ 0` expenses
- Added `LabelSpent`, `LabelBudgetSummary`, `LabelLeft` i18n keys (en + pt)

## Test plan

- [ ] Budget card on Monthly Overview taps through to Category List
- [ ] Budget card shows remaining + overspend as two separate lines when partial overspend exists
- [ ] Budget card ring/percentage stays primary colour below 100% total usage; turns red only when total budget is exceeded
- [ ] Category cards show `+{sym} {amount} over` badge when any individual expense exceeds its own budget (even while category total < 100%)
- [ ] Category List screen shows budget summary banner with correct totals
- [ ] Expense List screen: overspent rows show red accent bar, red amount, `+{sym} {overspend} over` label
- [ ] Expense List summary ring stays category colour below 100%; turns red only when total > 100%
- [ ] Unplanned expenses (no budget set) show no overspend indicator anywhere
- [ ] All 121 Jest tests pass (`cd econoflow-mobile && npm test`)
- [ ] TypeScript and lint clean (`npm run typecheck && npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)