### PR TITLE
fix: configure Sentry source map upload (org/project slug + auth token)

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -148,7 +148,13 @@ jobs:
       working-directory: ./econoflow-mobile/android
       env:
         EXPO_PUBLIC_API_URL: https://econoflow.pt
+        # The Sentry DSN is a public ingest endpoint, not a secret — it is
+        # intentionally baked into the JS bundle by Metro at build time.
         EXPO_PUBLIC_SENTRY_DSN: https://e3e5bdde0b6e300e13e77f760e0c1cdf@o4511512006754304.ingest.de.sentry.io/4511512010096720
+        # Auth token for uploading source maps so Sentry shows real file/line
+        # numbers in crash reports. Add SENTRY_AUTH_TOKEN as a GitHub secret:
+        # repo Settings → Secrets → Actions → New repository secret
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
     - name: Upload release APK
       if: steps.mobile-changes.outputs.mobile == 'true'

--- a/econoflow-mobile/app.json
+++ b/econoflow-mobile/app.json
@@ -45,7 +45,14 @@
           "imageWidth": 150
         }
       ],
-      "@sentry/react-native"
+      [
+        "@sentry/react-native/expo",
+        {
+          "url": "https://sentry.io/",
+          "organization": "econoflow",
+          "project": "econoflow"
+        }
+      ]
     ],
     "extra": {
       "eas": {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization

## Description

Fixes the `android-build` CI failure introduced after merging #734:

```
error: An organization ID or slug is required (provide with --org)
Task :app:createBundleReleaseJsAndAssets_SentryUpload FAILED
```

The `@sentry/react-native` Expo plugin installs a Sentry Gradle plugin that uploads source maps after every release build so crash reports show real file/line numbers. It was missing the org and project slugs, causing the upload step to fail.

### Changes

**`econoflow-mobile/app.json`**
Expanded the plugin entry from the bare `"@sentry/react-native"` string to a full config object with `organization: "econoflow"` and `project: "econoflow"`. This causes `expo prebuild` to write a complete `android/sentry.properties` file that the Gradle plugin can read.

**`.github/workflows/Release.yml`**
Added `SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}` to the Gradle build step env. The auth token authenticates the source map upload to Sentry. It must be added as a GitHub secret before the next build:

> **GitHub → repo Settings → Secrets and variables → Actions → New repository secret**
> Name: `SENTRY_AUTH_TOKEN`
> Value: Sentry auth token with `project:releases` + `org:read` scopes

## Related Tickets & Documents

- Related Issue #
- Closes #

## Added/updated tests?

- [ ] No, and this is why: CI/workflow and JSON config change only — no application logic changed, no testable behaviour added.