### PR TITLE
fix: use dot notation for EXPO_PUBLIC_SENTRY_DSN env var

### DIFF
--- a/econoflow-mobile/src/monitoring/__tests__/sentry.test.ts
+++ b/econoflow-mobile/src/monitoring/__tests__/sentry.test.ts
@@ -37,12 +37,15 @@ describe('sentry monitoring module', () => {
     });
 
     it('passes EXPO_PUBLIC_SENTRY_DSN as dsn', () => {
-      process.env['EXPO_PUBLIC_SENTRY_DSN'] = 'https://test@o123.ingest.sentry.io/456';
+      // In Jest, process.env assignment works regardless of dot/bracket notation.
+      // In the production Metro bundle only dot notation is statically replaced,
+      // which is why sentry.ts uses process.env.EXPO_PUBLIC_SENTRY_DSN.
+      process.env.EXPO_PUBLIC_SENTRY_DSN = 'https://test@o123.ingest.sentry.io/456';
       initSentry();
       expect(Sentry.init).toHaveBeenCalledWith(
         expect.objectContaining({ dsn: 'https://test@o123.ingest.sentry.io/456' }),
       );
-      delete process.env['EXPO_PUBLIC_SENTRY_DSN'];
+      delete process.env.EXPO_PUBLIC_SENTRY_DSN;
     });
 
     it('sets enabled to false because __DEV__ is true in the test environment', () => {

--- a/econoflow-mobile/src/monitoring/sentry.ts
+++ b/econoflow-mobile/src/monitoring/sentry.ts
@@ -17,7 +17,10 @@ export const navigationIntegration = Sentry.reactNavigationIntegration();
  */
 export function initSentry(): void {
   Sentry.init({
-    dsn: process.env['EXPO_PUBLIC_SENTRY_DSN'],
+    // Must use dot notation — Metro's Babel transform only replaces
+    // process.env.VARIABLE statically; bracket notation yields undefined.
+    // eslint-disable-next-line dot-notation
+    dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
     enabled: !__DEV__,
     environment: __DEV__ ? 'development' : 'production',
     // 20% sample rate avoids hitting Sentry's free-tier quota. Raise this


### PR DESCRIPTION
Metro's Babel transform only statically replaces process.env.VAR (dot notation) at bundle time. Bracket notation process.env['VAR'] is not substituted and resolves to undefined in the production APK, causing Sentry to initialise in no-op mode — no events are reported.

Fixes silent no-op Sentry initialisation on physical devices.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
