### PR TITLE
feat(mobile): make expense amount and item name optional on creation

### DIFF
--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -83,4 +83,12 @@ describe('i18n locale completeness', () => {
   it('pt.json contains LabelLeft', () => {
     expect((pt as LocaleMap)['LabelLeft']).toBeTruthy();
   });
+
+  it('en.json contains PlaceholderItemWithoutName', () => {
+    expect((en as LocaleMap)['PlaceholderItemWithoutName']).toBeTruthy();
+  });
+
+  it('pt.json contains PlaceholderItemWithoutName', () => {
+    expect((pt as LocaleMap)['PlaceholderItemWithoutName']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/screens/expenses/ExpenseFormScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseFormScreen.tsx
@@ -133,7 +133,6 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
       <Controller
         control={control}
         name="amount"
-        rules={{ required: t('RequiredField') ?? 'Required', min: { value: 0, message: t('ValueShouldBeGreaterThanOrEqual', { value: 0 }) ?? 'Must be ≥ 0' } }}
         render={({ field: { onChange, value } }) => (
           <TextInput label={t('FieldAmount') ?? 'Amount'} value={value} onChangeText={onChange} keyboardType="decimal-pad" style={styles.input} error={!!errors.amount} />
         )}

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -21,6 +21,7 @@ import { getCurrencySymbol } from '../../utils/currency';
 import { currentMonth, toDateOnly, fromDateOnly, dateToMonth, defaultDateForMonth } from '../../utils/date';
 import { buildPatch, buildExpenseItemPatch } from '../../utils/patch';
 import { shouldShowAmountError } from '../../utils/amountValidation';
+import { isNameRequired } from '../../utils/nameValidation';
 import { extractApiErrors } from '../../utils/apiErrors';
 import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { auroraTokens } from '../../theme/useAuroraSkin';
@@ -645,9 +646,10 @@ export const QuickAddModal: React.FC<Props> = ({
             <View style={[styles.fieldsDivider, { borderTopColor: hair }]} />
 
             <Controller control={control} name="name"
-              rules={{ required: t('RequiredField') ?? 'Required' }}
+              rules={{ required: isNameRequired(editMode, !!modal.selectedExpenseId) ? (t('RequiredField') ?? 'Required') : false }}
               render={({ field: { onChange, value } }) => (
-                <AuroraField dark={dark} icon="text-short" placeholder={t('FieldName') ?? 'Name'}
+                <AuroraField dark={dark} icon="text-short"
+                  placeholder={modal.selectedExpenseId ? (t('PlaceholderItemWithoutName') ?? 'Item') : (t('FieldName') ?? 'Name')}
                   value={value} onChangeText={onChange} hasError={!!errors.name} />
               )}
             />

--- a/econoflow-mobile/src/utils/__tests__/amountValidation.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/amountValidation.test.ts
@@ -2,12 +2,12 @@ import { shouldShowAmountError } from '../amountValidation';
 
 describe('shouldShowAmountError', () => {
   describe('creating a new entry (no editMode)', () => {
-    it('returns true when amount is 0', () => {
-      expect(shouldShowAmountError(undefined, 0)).toBe(true);
+    it('returns false when amount is 0 — amount is optional for new entries', () => {
+      expect(shouldShowAmountError(undefined, 0)).toBe(false);
     });
 
-    it('returns true when amount is negative', () => {
-      expect(shouldShowAmountError(undefined, -5)).toBe(true);
+    it('returns false when amount is negative — no client-side enforcement for new entries', () => {
+      expect(shouldShowAmountError(undefined, -5)).toBe(false);
     });
 
     it('returns false when amount is positive', () => {

--- a/econoflow-mobile/src/utils/__tests__/nameValidation.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/nameValidation.test.ts
@@ -1,0 +1,43 @@
+import { isNameRequired } from '../nameValidation';
+
+describe('isNameRequired', () => {
+  describe('creating a new item added to an existing expense', () => {
+    it('returns false — name is optional for new items', () => {
+      expect(isNameRequired(undefined, true)).toBe(false);
+    });
+  });
+
+  describe('creating a new expense (not adding to an existing one)', () => {
+    it('returns true — name is required for expense creation', () => {
+      expect(isNameRequired(undefined, false)).toBe(true);
+    });
+  });
+
+  describe('creating a new income', () => {
+    it('returns true — name is required for income creation', () => {
+      expect(isNameRequired(undefined, false)).toBe(true);
+    });
+  });
+
+  describe('editing an existing expense', () => {
+    it('returns true — name is still required when editing', () => {
+      expect(isNameRequired({ type: 'expense' }, false)).toBe(true);
+    });
+  });
+
+  describe('editing an existing expense item', () => {
+    it('returns true — name is required when editing an item', () => {
+      expect(isNameRequired({ type: 'expenseItem' }, false)).toBe(true);
+    });
+
+    it('returns true even when isAddingItemToExpense is true (editMode takes precedence)', () => {
+      expect(isNameRequired({ type: 'expenseItem' }, true)).toBe(true);
+    });
+  });
+
+  describe('editing an existing income', () => {
+    it('returns true — name is required when editing income', () => {
+      expect(isNameRequired({ type: 'income' }, false)).toBe(true);
+    });
+  });
+});

--- a/econoflow-mobile/src/utils/__tests__/nameValidation.test.ts
+++ b/econoflow-mobile/src/utils/__tests__/nameValidation.test.ts
@@ -13,9 +13,9 @@ describe('isNameRequired', () => {
     });
   });
 
-  describe('creating a new income', () => {
-    it('returns true — name is required for income creation', () => {
-      expect(isNameRequired(undefined, false)).toBe(true);
+  describe('creating a new item where isAddingItemToExpense is true but editMode is set', () => {
+    it('returns true — editMode takes precedence, name required when editing', () => {
+      expect(isNameRequired({ type: 'income' }, true)).toBe(true);
     });
   });
 

--- a/econoflow-mobile/src/utils/amountValidation.ts
+++ b/econoflow-mobile/src/utils/amountValidation.ts
@@ -4,17 +4,12 @@
  * Rules (checked in priority order):
  * - Editing an expense item: the item carries its own amount — must be > 0,
  *   regardless of whether the parent expense has hasItems set.
- * - Expense with hasItems: amount is derived from child items — never an error.
- * - Editing an existing expense or income: the stored amount (even 0) is valid;
- *   the user should not be blocked from saving without changing the amount.
- * - Creating a new entry: amount must be > 0.
+ * - All other cases (creating new entries, editing expenses/incomes): amount is
+ *   optional — 0 is a valid value.
  */
 export function shouldShowAmountError(
   editMode: { type: string; hasItems?: boolean } | undefined,
   amount: number,
 ): boolean {
-  if (editMode?.type === 'expenseItem') return amount <= 0;
-  if (editMode?.hasItems) return false;
-  if (editMode) return false;
-  return amount <= 0;
+  return editMode?.type === 'expenseItem' && amount <= 0;
 }

--- a/econoflow-mobile/src/utils/nameValidation.ts
+++ b/econoflow-mobile/src/utils/nameValidation.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns true when the name field is required.
+ *
+ * Rules:
+ * - Creating a new item added to an existing expense: name is optional.
+ * - All other cases (creating expenses/incomes, editing any entry): name is required.
+ */
+export function isNameRequired(
+  editMode: { type: string } | undefined,
+  isAddingItemToExpense: boolean,
+): boolean {
+  return !(editMode === undefined && isAddingItemToExpense);
+}


### PR DESCRIPTION
Amount is no longer required when creating a new expense (via both
ExpenseFormScreen and QuickAddModal). Item name is optional when adding
a new item to an existing expense.

- amountValidation: only enforce amount > 0 when editing an expense item
- nameValidation: new utility `isNameRequired` to gate the required rule
- QuickAddModal: use isNameRequired and show PlaceholderItemWithoutName
- ExpenseFormScreen: drop required/min rules from the amount field

https://claude.ai/code/session_01BG7P9xDuA5UbYCynbgMs5Y