### PR TITLE
feat: replace delete/archive dialogs with swipe-to-delete + undo toast

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "8.0.27",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/EasyFinance.Application.Tests/SoftDeleteRestoreTests.cs
+++ b/EasyFinance.Application.Tests/SoftDeleteRestoreTests.cs
@@ -115,6 +115,43 @@ namespace EasyFinance.Application.Tests
         }
 
         [Fact]
+        public async Task Expense_DeleteAsync_ShouldNotReturnDeletedExpenseInGet()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseService = scope.ServiceProvider.GetRequiredService<IExpenseService>();
+
+            var category = this.project1.Categories.First();
+            var expenseId = category.Expenses.First().Id;
+            await expenseService.DeleteAsync(expenseId);
+
+            var from = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30));
+            var to = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+            var result = await expenseService.GetAsync(category.Id, from, to);
+
+            result.Succeeded.Should().BeTrue();
+            result.Data.Should().NotContain(e => e.Id == expenseId);
+        }
+
+        [Fact]
+        public async Task ExpenseItem_DeleteAsync_ShouldNotReturnDeletedExpenseItemInGet()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseItemService = scope.ServiceProvider.GetRequiredService<IExpenseItemService>();
+            var expenseService = scope.ServiceProvider.GetRequiredService<IExpenseService>();
+
+            var category = this.project1.Categories.First(cat => cat.Expenses.Any(e => e.Items.Any()));
+            var expenseItemId = category.Expenses.First(e => e.Items.Any()).Items.First().Id;
+            await expenseItemService.DeleteAsync(expenseItemId);
+
+            var from = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30));
+            var to = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+            var result = await expenseService.GetAsync(category.Id, from, to);
+
+            result.Succeeded.Should().BeTrue();
+            result.Data.Should().NotContain(e => e.Items.Any(i => i.Id == expenseItemId));
+        }
+
+        [Fact]
         public async Task Expense_RestoreAsync_WithValidId_ShouldMarkAsNotDeleted()
         {
             using var scope = this.serviceProvider.CreateScope();

--- a/EasyFinance.Application.Tests/SoftDeleteRestoreTests.cs
+++ b/EasyFinance.Application.Tests/SoftDeleteRestoreTests.cs
@@ -1,0 +1,241 @@
+using EasyFinance.Application.Contracts.Persistence;
+using EasyFinance.Application.Features.CategoryService;
+using EasyFinance.Application.Features.ExpenseItemService;
+using EasyFinance.Application.Features.ExpenseService;
+using EasyFinance.Application.Features.IncomeService;
+using EasyFinance.Common.Tests;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyFinance.Application.Tests
+{
+    [Collection("Sequential")]
+    public class SoftDeleteRestoreTests : BaseTests
+    {
+        public SoftDeleteRestoreTests()
+        {
+            PrepareInMemoryDatabase();
+        }
+
+        // ── Income ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Income_DeleteAsync_WithValidId_ShouldMarkAsDeleted()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var incomeService = scope.ServiceProvider.GetRequiredService<IIncomeService>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var incomeId = this.project1.Incomes.First().Id;
+
+            var result = await incomeService.DeleteAsync(incomeId);
+
+            result.Succeeded.Should().BeTrue();
+
+            var income = await unitOfWork.IncomeRepository
+                .NoTrackable()
+                .IgnoreQueryFilters()
+                .FirstAsync(i => i.Id == incomeId);
+
+            income.IsDeleted.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Income_DeleteAsync_ShouldNotReturnDeletedIncomeInGet()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var incomeService = scope.ServiceProvider.GetRequiredService<IIncomeService>();
+
+            var incomeId = this.project1.Incomes.First().Id;
+            await incomeService.DeleteAsync(incomeId);
+
+            var from = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30));
+            var to = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+            var result = incomeService.Get(this.project1.Id, from, to);
+
+            result.Succeeded.Should().BeTrue();
+            result.Data.Should().NotContain(i => i.Id == incomeId);
+        }
+
+        [Fact]
+        public async Task Income_RestoreAsync_WithValidId_ShouldMarkAsNotDeleted()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var incomeService = scope.ServiceProvider.GetRequiredService<IIncomeService>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var incomeId = this.project1.Incomes.First().Id;
+            await incomeService.DeleteAsync(incomeId);
+
+            var result = await incomeService.RestoreAsync(incomeId);
+
+            result.Succeeded.Should().BeTrue();
+
+            var income = await unitOfWork.IncomeRepository
+                .NoTrackable()
+                .IgnoreQueryFilters()
+                .FirstAsync(i => i.Id == incomeId);
+
+            income.IsDeleted.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Income_RestoreAsync_WithEmptyId_ShouldReturnError()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var incomeService = scope.ServiceProvider.GetRequiredService<IIncomeService>();
+
+            var result = await incomeService.RestoreAsync(Guid.Empty);
+
+            result.Succeeded.Should().BeFalse();
+        }
+
+        // ── Expense ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Expense_DeleteAsync_WithValidId_ShouldMarkAsDeleted()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseService = scope.ServiceProvider.GetRequiredService<IExpenseService>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var expenseId = this.project1.Categories.First().Expenses.First().Id;
+
+            var result = await expenseService.DeleteAsync(expenseId);
+
+            result.Succeeded.Should().BeTrue();
+
+            var expense = await unitOfWork.ExpenseRepository
+                .NoTrackable()
+                .IgnoreQueryFilters()
+                .FirstAsync(e => e.Id == expenseId);
+
+            expense.IsDeleted.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Expense_RestoreAsync_WithValidId_ShouldMarkAsNotDeleted()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseService = scope.ServiceProvider.GetRequiredService<IExpenseService>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var expenseId = this.project1.Categories.First().Expenses.First().Id;
+            await expenseService.DeleteAsync(expenseId);
+
+            var result = await expenseService.RestoreAsync(expenseId);
+
+            result.Succeeded.Should().BeTrue();
+
+            var expense = await unitOfWork.ExpenseRepository
+                .NoTrackable()
+                .IgnoreQueryFilters()
+                .FirstAsync(e => e.Id == expenseId);
+
+            expense.IsDeleted.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Expense_RestoreAsync_WithEmptyId_ShouldReturnError()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseService = scope.ServiceProvider.GetRequiredService<IExpenseService>();
+
+            var result = await expenseService.RestoreAsync(Guid.Empty);
+
+            result.Succeeded.Should().BeFalse();
+        }
+
+        // ── ExpenseItem ──────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task ExpenseItem_DeleteAsync_WithValidId_ShouldMarkAsDeleted()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseItemService = scope.ServiceProvider.GetRequiredService<IExpenseItemService>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var expenseItemId = this.project1.Categories.First().Expenses.First().Items.First().Id;
+
+            var result = await expenseItemService.DeleteAsync(expenseItemId);
+
+            result.Succeeded.Should().BeTrue();
+
+            var expenseItem = await unitOfWork.ExpenseItemRepository
+                .NoTrackable()
+                .IgnoreQueryFilters()
+                .FirstAsync(i => i.Id == expenseItemId);
+
+            expenseItem.IsDeleted.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ExpenseItem_RestoreAsync_WithValidId_ShouldMarkAsNotDeleted()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseItemService = scope.ServiceProvider.GetRequiredService<IExpenseItemService>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var expenseItemId = this.project1.Categories.First().Expenses.First().Items.First().Id;
+            await expenseItemService.DeleteAsync(expenseItemId);
+
+            var result = await expenseItemService.RestoreAsync(expenseItemId);
+
+            result.Succeeded.Should().BeTrue();
+
+            var expenseItem = await unitOfWork.ExpenseItemRepository
+                .NoTrackable()
+                .IgnoreQueryFilters()
+                .FirstAsync(i => i.Id == expenseItemId);
+
+            expenseItem.IsDeleted.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ExpenseItem_RestoreAsync_WithEmptyId_ShouldReturnError()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var expenseItemService = scope.ServiceProvider.GetRequiredService<IExpenseItemService>();
+
+            var result = await expenseItemService.RestoreAsync(Guid.Empty);
+
+            result.Succeeded.Should().BeFalse();
+        }
+
+        // ── Category ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Category_UnarchiveAsync_WithValidId_ShouldMarkAsNotArchived()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var categoryService = scope.ServiceProvider.GetRequiredService<ICategoryService>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var categoryId = this.project1.Categories.First().Id;
+            await categoryService.ArchiveAsync(categoryId);
+
+            var result = await categoryService.UnarchiveAsync(categoryId);
+
+            result.Succeeded.Should().BeTrue();
+
+            var category = await unitOfWork.CategoryRepository
+                .NoTrackable()
+                .IgnoreQueryFilters()
+                .FirstAsync(c => c.Id == categoryId);
+
+            category.IsArchived.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Category_UnarchiveAsync_WithEmptyId_ShouldReturnError()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var categoryService = scope.ServiceProvider.GetRequiredService<ICategoryService>();
+
+            var result = await categoryService.UnarchiveAsync(Guid.Empty);
+
+            result.Succeeded.Should().BeFalse();
+        }
+    }
+}

--- a/EasyFinance.Application.Tests/SoftDeleteRestoreTests.cs
+++ b/EasyFinance.Application.Tests/SoftDeleteRestoreTests.cs
@@ -3,6 +3,7 @@ using EasyFinance.Application.Features.CategoryService;
 using EasyFinance.Application.Features.ExpenseItemService;
 using EasyFinance.Application.Features.ExpenseService;
 using EasyFinance.Application.Features.IncomeService;
+using EasyFinance.Application.Features.ProjectService;
 using EasyFinance.Common.Tests;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -273,6 +274,62 @@ namespace EasyFinance.Application.Tests
             var result = await categoryService.UnarchiveAsync(Guid.Empty);
 
             result.Succeeded.Should().BeFalse();
+        }
+
+        // ── ProjectService overview / latest transactions ────────────────────
+
+        [Fact]
+        public async Task GetOverviewSummaryAsync_ShouldExcludeSoftDeletedExpense()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var projectService = scope.ServiceProvider.GetRequiredService<IProjectService>();
+            var expenseService = scope.ServiceProvider.GetRequiredService<IExpenseService>();
+
+            var from = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30));
+            var to = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+
+            var before = await projectService.GetOverviewSummaryAsync(this.project1.Id, from, to, 5);
+            before.Succeeded.Should().BeTrue();
+            var totalBefore = before.Data.TotalExpense;
+
+            var expenseId = this.project1.Categories.First().Expenses.First().Id;
+            await expenseService.DeleteAsync(expenseId);
+
+            var after = await projectService.GetOverviewSummaryAsync(this.project1.Id, from, to, 5);
+            after.Succeeded.Should().BeTrue();
+            after.Data.TotalExpense.Should().BeLessThan(totalBefore);
+        }
+
+        [Fact]
+        public async Task GetLatestAsync_ShouldExcludeSoftDeletedExpense()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var projectService = scope.ServiceProvider.GetRequiredService<IProjectService>();
+            var expenseService = scope.ServiceProvider.GetRequiredService<IExpenseService>();
+
+            var expenseId = this.project1.Categories.First().Expenses.First().Id;
+            await expenseService.DeleteAsync(expenseId);
+
+            var result = await projectService.GetLatestAsync(this.project1.Id, 10);
+
+            result.Succeeded.Should().BeTrue();
+            result.Data.Should().NotContain(t => t.Id == expenseId);
+        }
+
+        [Fact]
+        public async Task GetLatestAsync_ShouldExcludeSoftDeletedExpenseItem()
+        {
+            using var scope = this.serviceProvider.CreateScope();
+            var projectService = scope.ServiceProvider.GetRequiredService<IProjectService>();
+            var expenseItemService = scope.ServiceProvider.GetRequiredService<IExpenseItemService>();
+
+            var expenseItemId = this.project1.Categories.First().Expenses.First().Items.First().Id;
+            await expenseItemService.DeleteAsync(expenseItemId);
+
+            var result = await projectService.GetLatestAsync(this.project1.Id, 10);
+
+            result.Succeeded.Should().BeTrue();
+            result.Data.Should().NotContain(t => t.Id == expenseItemId);
         }
     }
 }

--- a/EasyFinance.Application/Features/CategoryService/CategoryService.cs
+++ b/EasyFinance.Application/Features/CategoryService/CategoryService.cs
@@ -70,6 +70,27 @@ namespace EasyFinance.Application.Features.CategoryService
             return AppResponse.Success();
         }
 
+        public async Task<AppResponse> UnarchiveAsync(Guid categoryId)
+        {
+            if (categoryId == Guid.Empty)
+                return AppResponse.Error(code: nameof(categoryId), description: ValidationMessages.InvalidCategoryId);
+
+            var category = await unitOfWork.CategoryRepository
+                .Trackable()
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(c => c.Id == categoryId) ?? throw new KeyNotFoundException(ValidationMessages.CategoryNotFound);
+
+            category.SetUnarchive();
+
+            var savedCategory = unitOfWork.CategoryRepository.InsertOrUpdate(category);
+            if (savedCategory.Failed)
+                return AppResponse.Error(savedCategory.Messages);
+
+            await unitOfWork.CommitAsync();
+
+            return AppResponse.Success();
+        }
+
         public async Task<AppResponse<ICollection<CategoryResponseDTO>>> GetAllAsync(Guid projectId)
         {
             var result = SortCategories(
@@ -91,20 +112,20 @@ namespace EasyFinance.Application.Features.CategoryService
                 categories = SortCategories((await this.unitOfWork.ProjectRepository.NoTrackable()
                         .Include(p => p.Categories
                             .Where(c =>
-                                c.Expenses.Any(e => e.Date >= from && e.Date < to) // keep category if it has expenses
-                                || !c.IsArchived                                   // keep if not archived
+                                c.Expenses.Any(e => e.Date >= from && e.Date < to && !e.IsDeleted) // keep category if it has non-deleted expenses
+                                || !c.IsArchived                                                   // keep if not archived
                             ))
                                 .ThenInclude(c => c.Expenses
-                                    .Where(e => e.Date >= from && e.Date < to))
+                                    .Where(e => e.Date >= from && e.Date < to && !e.IsDeleted))
                                         .ThenInclude(e => e.Attachments)
                         .Include(p => p.Categories
                             .Where(c =>
-                                c.Expenses.Any(e => e.Date >= from && e.Date < to)
+                                c.Expenses.Any(e => e.Date >= from && e.Date < to && !e.IsDeleted)
                                 || !c.IsArchived
                             ))
                                 .ThenInclude(c => c.Expenses
-                                    .Where(e => e.Date >= from && e.Date < to))
-                                        .ThenInclude(e => e.Items)
+                                    .Where(e => e.Date >= from && e.Date < to && !e.IsDeleted))
+                                        .ThenInclude(e => e.Items.Where(i => !i.IsDeleted))
                                             .ThenInclude(i => i.Attachments)
                         .IgnoreQueryFilters() // ignore global IsArchived filter
                         .FirstOrDefaultAsync(p => p.Id == projectId))?
@@ -148,11 +169,11 @@ namespace EasyFinance.Application.Features.CategoryService
         {
             var result = SortCategories((await this.unitOfWork.ProjectRepository.NoTrackable()
                     .Include(p => p.Categories)
-                    .ThenInclude(c => c.Expenses.Where(e => e.Date.Year == year))
+                    .ThenInclude(c => c.Expenses.Where(e => e.Date.Year == year && !e.IsDeleted))
                     .ThenInclude(e => e.Attachments)
                     .Include(p => p.Categories)
-                    .ThenInclude(c => c.Expenses.Where(e => e.Date.Year == year))
-                    .ThenInclude(e => e.Items)
+                    .ThenInclude(c => c.Expenses.Where(e => e.Date.Year == year && !e.IsDeleted))
+                    .ThenInclude(e => e.Items.Where(i => !i.IsDeleted))
                     .ThenInclude(i => i.Attachments)
                     .IgnoreQueryFilters() // disables the global filter IsArchived
                     .FirstOrDefaultAsync(p => p.Id == projectId))?

--- a/EasyFinance.Application/Features/CategoryService/ICategoryService.cs
+++ b/EasyFinance.Application/Features/CategoryService/ICategoryService.cs
@@ -19,6 +19,7 @@ namespace EasyFinance.Application.Features.CategoryService
         Task<AppResponse<CategoryResponseDTO>> UpdateAsync(Guid categoryId, JsonPatchDocument<CategoryRequestDTO> categoryDto);
         Task<AppResponse> UpdateOrderAsync(Guid projectId, ICollection<CategoryOrderRequestDTO> categoriesOrder);
         Task<AppResponse> ArchiveAsync(Guid categoryId);
+        Task<AppResponse> UnarchiveAsync(Guid categoryId);
         Task<AppResponse<ICollection<CategoryWithPercentageDTO>>> GetDefaultCategoriesAsync(Guid projectId);
     }
 }

--- a/EasyFinance.Application/Features/ExpenseItemService/ExpenseItemService.cs
+++ b/EasyFinance.Application/Features/ExpenseItemService/ExpenseItemService.cs
@@ -116,7 +116,28 @@ namespace EasyFinance.Application.Features.ExpenseItemService
             if (expenseItem == null)
                 return AppResponse.Success();
 
-            unitOfWork.ExpenseItemRepository.Delete(expenseItem);
+            expenseItem.SetDeleted();
+            unitOfWork.ExpenseItemRepository.InsertOrUpdate(expenseItem);
+            await unitOfWork.CommitAsync();
+
+            return AppResponse.Success();
+        }
+
+        public async Task<AppResponse> RestoreAsync(Guid expenseItemId)
+        {
+            if (expenseItemId == Guid.Empty)
+                return AppResponse.Error(code: nameof(expenseItemId), description: ValidationMessages.InvalidExpenseItemId);
+
+            var expenseItem = unitOfWork.ExpenseItemRepository
+                .Trackable()
+                .IgnoreQueryFilters()
+                .FirstOrDefault(e => e.Id == expenseItemId);
+
+            if (expenseItem == null)
+                return AppResponse.Success();
+
+            expenseItem.SetRestored();
+            unitOfWork.ExpenseItemRepository.InsertOrUpdate(expenseItem);
             await unitOfWork.CommitAsync();
 
             return AppResponse.Success();

--- a/EasyFinance.Application/Features/ExpenseItemService/ExpenseItemService.cs
+++ b/EasyFinance.Application/Features/ExpenseItemService/ExpenseItemService.cs
@@ -62,7 +62,7 @@ namespace EasyFinance.Application.Features.ExpenseItemService
                 .Where(p => p.Id == projectId)
                 .Include(p => p.Categories.Where(c => c.Id == sourceCategoryId || c.Id == targetCategoryId))
                     .ThenInclude(c => c.Expenses.Where(e => e.Id == sourceExpenseId || e.Id == targetExpenseId))
-                        .ThenInclude(e => e.Items.Where(item => item.Id == expenseItemId))
+                        .ThenInclude(e => e.Items.Where(item => item.Id == expenseItemId && !item.IsDeleted))
                 .FirstOrDefaultAsync();
 
             if (project == null)

--- a/EasyFinance.Application/Features/ExpenseItemService/IExpenseItemService.cs
+++ b/EasyFinance.Application/Features/ExpenseItemService/IExpenseItemService.cs
@@ -15,6 +15,7 @@ namespace EasyFinance.Application.Features.ExpenseItemService
             Guid targetCategoryId,
             Guid targetExpenseId);
         Task<AppResponse> DeleteAsync(Guid expenseItemId);
+        Task<AppResponse> RestoreAsync(Guid expenseItemId);
         Task<AppResponse> RemoveLinkAsync(User user);
     }
 }

--- a/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
+++ b/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
@@ -48,11 +48,11 @@ namespace EasyFinance.Application.Features.ExpenseService
             var category = await unitOfWork.CategoryRepository
                 .NoTrackable()
                 .IgnoreQueryFilters()
-                .Include(p => p.Expenses.Where(e => e.Date >= from && e.Date < to))
-                    .ThenInclude(e => e.Items.Where(i => i.Date >= from && i.Date < to)
+                .Include(p => p.Expenses.Where(e => e.Date >= from && e.Date < to && !e.IsDeleted))
+                    .ThenInclude(e => e.Items.Where(i => i.Date >= from && i.Date < to && !i.IsDeleted)
                         .OrderBy(item => item.Date))
                         .ThenInclude(item => item.Attachments)
-                .Include(p => p.Expenses.Where(e => e.Date >= from && e.Date < to))
+                .Include(p => p.Expenses.Where(e => e.Date >= from && e.Date < to && !e.IsDeleted))
                     .ThenInclude(e => e.Attachments)
                 .FirstOrDefaultAsync(p => p.Id == categoryId) ?? throw new KeyNotFoundException(ValidationMessages.CategoryNotFound);
 
@@ -285,11 +285,32 @@ namespace EasyFinance.Application.Features.ExpenseService
 
             if (expense == null)
             {
-                logger.LogWarning("Expense not found for deletion!");
+                logger.LogWarning("Expense not found for soft deletion!");
                 return AppResponse.Success();
             }
 
-            unitOfWork.ExpenseRepository.Delete(expense);
+            expense.SetDeleted();
+            unitOfWork.ExpenseRepository.InsertOrUpdate(expense);
+            await unitOfWork.CommitAsync();
+
+            return AppResponse.Success();
+        }
+
+        public async Task<AppResponse> RestoreAsync(Guid expenseId)
+        {
+            if (expenseId == Guid.Empty)
+                return AppResponse.Error(nameof(expenseId), ValidationMessages.InvalidExpenseId);
+
+            var expense = unitOfWork.ExpenseRepository
+                .Trackable()
+                .IgnoreQueryFilters()
+                .FirstOrDefault(e => e.Id == expenseId);
+
+            if (expense == null)
+                return AppResponse.Success();
+
+            expense.SetRestored();
+            unitOfWork.ExpenseRepository.InsertOrUpdate(expense);
             await unitOfWork.CommitAsync();
 
             return AppResponse.Success();

--- a/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
+++ b/EasyFinance.Application/Features/ExpenseService/ExpenseService.cs
@@ -247,7 +247,7 @@ namespace EasyFinance.Application.Features.ExpenseService
                 .IgnoreQueryFilters()
                 .Where(p => p.Id == projectId)
                 .Include(p => p.Categories.Where(c => c.Id == sourceCategoryId || c.Id == targetCategoryId))
-                    .ThenInclude(c => c.Expenses.Where(e => e.Id == expenseId))
+                    .ThenInclude(c => c.Expenses.Where(e => e.Id == expenseId && !e.IsDeleted))
                 .FirstOrDefaultAsync();
 
             if (project == null)

--- a/EasyFinance.Application/Features/ExpenseService/IExpenseService.cs
+++ b/EasyFinance.Application/Features/ExpenseService/IExpenseService.cs
@@ -17,6 +17,7 @@ namespace EasyFinance.Application.Features.ExpenseService
         Task<AppResponse<ExpenseResponseDTO>> UpdateAsync(User user, Guid projectId, Guid categoryId, Guid expenseId, JsonPatchDocument<ExpenseRequestDTO> expenseDto);
         Task<AppResponse> MoveAsync(Guid projectId, Guid sourceCategoryId, Guid expenseId, Guid targetCategoryId);
         Task<AppResponse> DeleteAsync(Guid expenseId);
+        Task<AppResponse> RestoreAsync(Guid expenseId);
         Task<AppResponse> RemoveLinkAsync(User user);
     }
 }

--- a/EasyFinance.Application/Features/IncomeService/IIncomeService.cs
+++ b/EasyFinance.Application/Features/IncomeService/IIncomeService.cs
@@ -19,6 +19,7 @@ namespace EasyFinance.Application.Features.IncomeService
         Task<AppResponse<IncomeResponseDTO>> UpdateAsync(Income income);
         Task<AppResponse<IncomeResponseDTO>> UpdateAsync(Guid incomeId, JsonPatchDocument<IncomeRequestDTO> incomeDto);
         Task<AppResponse> DeleteAsync(Guid incomeId);
+        Task<AppResponse> RestoreAsync(Guid incomeId);
         Task<AppResponse> RemoveLinkAsync(User user);
     }
 }

--- a/EasyFinance.Application/Features/IncomeService/IncomeService.cs
+++ b/EasyFinance.Application/Features/IncomeService/IncomeService.cs
@@ -143,11 +143,32 @@ namespace EasyFinance.Application.Features.IncomeService
 
             if (income == null)
             {
-                logger.LogWarning("Expense not found for deletion!");
+                logger.LogWarning("Income not found for soft deletion!");
                 return AppResponse.Success();
             }
 
-            unitOfWork.IncomeRepository.Delete(income);
+            income.SetDeleted();
+            unitOfWork.IncomeRepository.InsertOrUpdate(income);
+            await unitOfWork.CommitAsync();
+
+            return AppResponse.Success();
+        }
+
+        public async Task<AppResponse> RestoreAsync(Guid incomeId)
+        {
+            if (incomeId == Guid.Empty)
+                return AppResponse.Error(code: nameof(incomeId), description: ValidationMessages.InvalidIncomeId);
+
+            var income = unitOfWork.IncomeRepository
+                .Trackable()
+                .IgnoreQueryFilters()
+                .FirstOrDefault(i => i.Id == incomeId);
+
+            if (income == null)
+                return AppResponse.Success();
+
+            income.SetRestored();
+            unitOfWork.IncomeRepository.InsertOrUpdate(income);
             await unitOfWork.CommitAsync();
 
             return AppResponse.Success();

--- a/EasyFinance.Application/Features/ProjectService/ProjectService.cs
+++ b/EasyFinance.Application/Features/ProjectService/ProjectService.cs
@@ -246,7 +246,7 @@ namespace EasyFinance.Application.Features.ProjectService
                 .IgnoreQueryFilters()
                 .Where(project => project.Id == projectId)
                 .SelectMany(project => project.Categories.SelectMany(category => category.Expenses
-                    .Where(expense => expense.Date >= from && expense.Date < to)))
+                    .Where(expense => expense.Date >= from && expense.Date < to && !expense.IsDeleted)))
                 .Include(expense => expense.Items)
                 .ToListAsync();
 
@@ -291,6 +291,7 @@ namespace EasyFinance.Application.Features.ProjectService
                 .Where(project => project.Id == projectId)
                 .SelectMany(project => project.Categories.SelectMany(category => category.Expenses
                     .Where(expense => expense.Amount > 0
+                        && !expense.IsDeleted
                         && expense.Items.Count == 0
                         && (!from.HasValue || expense.Date >= from.Value)
                         && (!to.HasValue || expense.Date < to.Value))
@@ -313,11 +314,12 @@ namespace EasyFinance.Application.Features.ProjectService
                 .IgnoreQueryFilters()
                 .Where(project => project.Id == projectId)
                 .SelectMany(project => project.Categories.SelectMany(category => category.Expenses
-                    .Where(expense => expense.Items.Count > 0)
+                    .Where(expense => !expense.IsDeleted && expense.Items.Count > 0)
                     .OrderByDescending(expense => expense.Date)
                     .Take(numberOfTransactions)
                     .SelectMany(expense => expense.Items
-                        .Where(item => item.Amount > 0
+                        .Where(item => !item.IsDeleted
+                            && item.Amount > 0
                             && (!from.HasValue || item.Date >= from.Value)
                             && (!to.HasValue || item.Date < to.Value))
                         .Select(item => new TransactionResponseDTO

--- a/EasyFinance.Application/Features/TaxYearService/TaxYearService.cs
+++ b/EasyFinance.Application/Features/TaxYearService/TaxYearService.cs
@@ -87,7 +87,7 @@ namespace EasyFinance.Application.Features.TaxYearService
                 .NoTrackable()
                 .IgnoreQueryFilters()
                 .Where(p => p.Id == projectId)
-                .SelectMany(p => p.Categories.SelectMany(c => c.Expenses.Select(e => e.Date)))
+                .SelectMany(p => p.Categories.SelectMany(c => c.Expenses.Where(e => !e.IsDeleted).Select(e => e.Date)))
                 .ToListAsync();
 
             var currentPeriod = TaxYearCalculator.GetPeriod(project, DateOnly.FromDateTime(DateTime.UtcNow.Date));
@@ -321,7 +321,7 @@ namespace EasyFinance.Application.Features.TaxYearService
                     .NoTrackable()
                     .IgnoreQueryFilters()
                     .Where(p => p.Id == projectId)
-                    .SelectMany(p => p.Categories.SelectMany(c => c.Expenses))
+                    .SelectMany(p => p.Categories.SelectMany(c => c.Expenses.Where(e => !e.IsDeleted)))
                     .FirstOrDefaultAsync(e => e.Id == effectiveExpenseId);
 
                 if (expense == null)
@@ -355,7 +355,7 @@ namespace EasyFinance.Application.Features.TaxYearService
                 .NoTrackable()
                 .IgnoreQueryFilters()
                 .Where(p => p.Id == projectId)
-                .SelectMany(p => p.Categories.SelectMany(c => c.Expenses.SelectMany(e => e.Items)))
+                .SelectMany(p => p.Categories.SelectMany(c => c.Expenses.Where(e => !e.IsDeleted).SelectMany(e => e.Items.Where(i => !i.IsDeleted))))
                 .FirstOrDefaultAsync(item => item.Id == effectiveExpenseItemId);
 
             if (expenseItem == null)

--- a/EasyFinance.Domain/Financial/Category.cs
+++ b/EasyFinance.Domain/Financial/Category.cs
@@ -90,10 +90,9 @@ namespace EasyFinance.Domain.Financial
             this.Expenses.Add(expense);
         }
 
-        public void SetArchive()
-        {
-            IsArchived = true;
-        }
+        public void SetArchive() => IsArchived = true;
+
+        public void SetUnarchive() => IsArchived = false;
 
         public ICollection<Expense> CopyBudgetToCurrentMonth(User user, DateOnly currentDate)
         {

--- a/EasyFinance.Domain/Financial/Expense.cs
+++ b/EasyFinance.Domain/Financial/Expense.cs
@@ -11,6 +11,11 @@ namespace EasyFinance.Domain.Financial
     {
         private Expense() { }
 
+        public bool IsDeleted { get; private set; }
+
+        public void SetDeleted() => IsDeleted = true;
+        public void SetRestored() => IsDeleted = false;
+
         public Expense(
             string name = "default",
             DateOnly date = default,

--- a/EasyFinance.Domain/Financial/ExpenseItem.cs
+++ b/EasyFinance.Domain/Financial/ExpenseItem.cs
@@ -11,6 +11,11 @@ namespace EasyFinance.Domain.Financial
     {
         private ExpenseItem() { }
 
+        public bool IsDeleted { get; private set; }
+
+        public void SetDeleted() => IsDeleted = true;
+        public void SetRestored() => IsDeleted = false;
+
         public ExpenseItem(
             string name = "default",
             DateOnly date = default,

--- a/EasyFinance.Domain/Financial/Income.cs
+++ b/EasyFinance.Domain/Financial/Income.cs
@@ -11,6 +11,11 @@ namespace EasyFinance.Domain.Financial
     {
         private Income() { }
 
+        public bool IsDeleted { get; private set; }
+
+        public void SetDeleted() => IsDeleted = true;
+        public void SetRestored() => IsDeleted = false;
+
         public Income(
             string name = "default",
             DateOnly date = default,

--- a/EasyFinance.Persistence/Mapping/Financial/ExpenseConfiguration.cs
+++ b/EasyFinance.Persistence/Mapping/Financial/ExpenseConfiguration.cs
@@ -10,6 +10,12 @@ namespace EasyFinance.Persistence.Mapping.Financial
         {
             builder.ToTable("Expenses");
 
+            builder.HasQueryFilter(p => !p.IsDeleted);
+
+            builder.Property(p => p.IsDeleted)
+                .IsRequired()
+                .HasDefaultValue(false);
+
             builder.Property(p => p.Budget);
             builder.Property(p => p.IsDeductible)
                 .HasDefaultValue(false)

--- a/EasyFinance.Persistence/Mapping/Financial/ExpenseItemConfiguration.cs
+++ b/EasyFinance.Persistence/Mapping/Financial/ExpenseItemConfiguration.cs
@@ -10,6 +10,12 @@ namespace EasyFinance.Persistence.Mapping.Financial
         {
             builder.ToTable("ExpenseItems");
 
+            builder.HasQueryFilter(p => !p.IsDeleted);
+
+            builder.Property(p => p.IsDeleted)
+                .IsRequired()
+                .HasDefaultValue(false);
+
             builder.Property(p => p.IsDeductible)
                 .HasDefaultValue(false)
                 .IsRequired();

--- a/EasyFinance.Persistence/Mapping/Financial/IncomeConfiguration.cs
+++ b/EasyFinance.Persistence/Mapping/Financial/IncomeConfiguration.cs
@@ -10,6 +10,12 @@ namespace EasyFinance.Persistence.Mapping.Financial
         {
             builder.ToTable("Incomes");
 
+            builder.HasQueryFilter(p => !p.IsDeleted);
+
+            builder.Property(p => p.IsDeleted)
+                .IsRequired()
+                .HasDefaultValue(false);
+
             builder.Property(p => p.Name)
                 .HasMaxLength(150)
                 .IsRequired();

--- a/EasyFinance.Persistence/Migrations/20260606071813_AddSoftDeleteToFinancials.Designer.cs
+++ b/EasyFinance.Persistence/Migrations/20260606071813_AddSoftDeleteToFinancials.Designer.cs
@@ -4,6 +4,7 @@ using EasyFinance.Persistence.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EasyFinance.Persistence.Migrations
 {
     [DbContext(typeof(EasyFinanceDatabaseContext))]
-    partial class EasyFinanceDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260606071813_AddSoftDeleteToFinancials")]
+    partial class AddSoftDeleteToFinancials
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EasyFinance.Persistence/Migrations/20260606071813_AddSoftDeleteToFinancials.cs
+++ b/EasyFinance.Persistence/Migrations/20260606071813_AddSoftDeleteToFinancials.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EasyFinance.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSoftDeleteToFinancials : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Incomes",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Expenses",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "ExpenseItems",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Incomes");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Expenses");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "ExpenseItems");
+        }
+    }
+}

--- a/EasyFinance.Server/Controllers/CategoriesController.cs
+++ b/EasyFinance.Server/Controllers/CategoriesController.cs
@@ -74,5 +74,12 @@ namespace EasyFinance.Server.Controllers
 
             return ValidateResponse(archiveResult, HttpStatusCode.NoContent);
         }
+
+        [HttpPut("{categoryId}/Unarchive")]
+        public async Task<IActionResult> Unarchive(Guid categoryId)
+        {
+            var result = await categoryService.UnarchiveAsync(categoryId);
+            return ValidateResponse(result, HttpStatusCode.NoContent);
+        }
     }
 }

--- a/EasyFinance.Server/Controllers/ExpenseItemsController.cs
+++ b/EasyFinance.Server/Controllers/ExpenseItemsController.cs
@@ -35,6 +35,13 @@ namespace EasyFinance.Server.Controllers
             return ValidateResponse(result, HttpStatusCode.OK);
         }
 
+        [HttpPut("{expenseItemId}/restore")]
+        public async Task<IActionResult> RestoreAsync(Guid expenseItemId)
+        {
+            var result = await this.expenseItemService.RestoreAsync(expenseItemId);
+            return ValidateResponse(result, HttpStatusCode.OK);
+        }
+
         [HttpPost("{expenseItemId}/move")]
         public async Task<IActionResult> MoveAsync(
             Guid projectId,

--- a/EasyFinance.Server/Controllers/ExpensesController.cs
+++ b/EasyFinance.Server/Controllers/ExpensesController.cs
@@ -132,6 +132,13 @@ namespace EasyFinance.Server.Controllers
             return ValidateResponse(result, HttpStatusCode.OK);
         }
 
+        [HttpPut("{expenseId}/restore")]
+        public async Task<IActionResult> RestoreAsync(Guid expenseId)
+        {
+            var result = await expenseService.RestoreAsync(expenseId);
+            return ValidateResponse(result, HttpStatusCode.OK);
+        }
+
         [HttpPost("{expenseId}/attachments")]
         [Consumes("multipart/form-data")]
         public async Task<IActionResult> UploadAttachmentAsync(

--- a/EasyFinance.Server/Controllers/IncomesController.cs
+++ b/EasyFinance.Server/Controllers/IncomesController.cs
@@ -71,5 +71,12 @@ namespace EasyFinance.Server.Controllers
 
             return ValidateResponse(deleteResult, HttpStatusCode.NoContent);
         }
+
+        [HttpPut("{incomeId}/restore")]
+        public async Task<IActionResult> RestoreAsync(Guid incomeId)
+        {
+            var result = await incomeService.RestoreAsync(incomeId);
+            return ValidateResponse(result, HttpStatusCode.NoContent);
+        }
     }
 }

--- a/architecture.md
+++ b/architecture.md
@@ -431,7 +431,7 @@ main.ts
 ### `HttpRequestInterceptor` responsibilities
 
 1. Attach `X-Correlation-Id` header (generated and persisted in `localStorage`).
-2. On `201 Created` or `DELETE 204`: show success snackbar.
+2. On `201 Created`: show a "created" success snackbar. On `DELETE 200`: show a "deleted" success snackbar. Callers that manage their own post-delete UI (e.g. undo snackbars) should pass `context: new HttpContext().set(SUPPRESS_SUCCESS_NOTIFICATION, true)` on the DELETE request to opt out of the auto-notification.
 3. On `401 Unauthorized` (non-auth routes):
    - If a refresh is already in-flight: queue the request and wait.
    - Otherwise call `/api/AccessControl/refresh-token`, update stored tokens, retry all queued requests.

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.css
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.css
@@ -1,0 +1,57 @@
+.swipe-wrapper {
+  position: relative;
+  overflow: hidden;
+  touch-action: pan-y;
+  user-select: none;
+}
+
+.swipe-action-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.swipe-action-panel.open {
+  opacity: 1;
+}
+
+.swipe-action-btn {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  transition: transform 0.15s ease;
+}
+
+.swipe-action-btn:active {
+  transform: scale(0.9);
+}
+
+.swipe-action-delete {
+  background-color: #dc3545;
+  color: #fff;
+}
+
+.swipe-action-archive {
+  background-color: #6c757d;
+  color: #fff;
+}
+
+.swipe-content {
+  transition: transform 0.2s ease;
+  background: inherit;
+  position: relative;
+  z-index: 1;
+}

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.html
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.html
@@ -14,7 +14,7 @@
     </button>
   </div>
 
-  <div #content class="swipe-content" [style.transform]="'translateX(' + offset() + 'px)'">
+  <div class="swipe-content" [style.transform]="'translateX(' + offset() + 'px)'">
     <ng-content></ng-content>
   </div>
 </div>

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.html
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.html
@@ -1,0 +1,20 @@
+<div class="swipe-wrapper"
+  (pointerdown)="onPointerDown($event)"
+  (pointermove)="onPointerMove($event)"
+  (pointerup)="onPointerUp()"
+  (pointercancel)="onPointerCancel()">
+
+  <div class="swipe-action-panel" [class.open]="isOpen()">
+    <button class="swipe-action-btn"
+      [class.swipe-action-delete]="actionIcon === 'trash'"
+      [class.swipe-action-archive]="actionIcon === 'archive'"
+      (click)="triggerAction()"
+      type="button">
+      <i class="bi" [class.bi-trash]="actionIcon === 'trash'" [class.bi-archive]="actionIcon === 'archive'"></i>
+    </button>
+  </div>
+
+  <div #content class="swipe-content" [style.transform]="'translateX(' + offset() + 'px)'">
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.spec.ts
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.spec.ts
@@ -1,0 +1,119 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SwipeDeleteRowComponent } from './swipe-delete-row.component';
+
+describe('SwipeDeleteRowComponent', () => {
+  let fixture: ComponentFixture<SwipeDeleteRowComponent>;
+  let component: SwipeDeleteRowComponent;
+  let el: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SwipeDeleteRowComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SwipeDeleteRowComponent);
+    component = fixture.componentInstance;
+    el = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('triggerAction', () => {
+    it('should emit actionTriggered', () => {
+      let emitted = false;
+      component.actionTriggered.subscribe(() => emitted = true);
+
+      component.triggerAction();
+
+      expect(emitted).toBeTrue();
+    });
+
+    it('should close the panel when triggered', () => {
+      component.offset.set(-70);
+      component.isOpen.set(true);
+
+      component.triggerAction();
+
+      expect(component.offset()).toBe(0);
+      expect(component.isOpen()).toBeFalse();
+    });
+  });
+
+  describe('onPointerDown', () => {
+    function makePointerDownEvent(target: Element, currentTarget: HTMLElement): PointerEvent {
+      return {
+        clientX: 200,
+        clientY: 50,
+        pointerId: 1,
+        target,
+        currentTarget,
+        preventDefault: () => { /* no-op */ }
+      } as unknown as PointerEvent;
+    }
+
+    it('should NOT call setPointerCapture immediately on pointerdown', () => {
+      const wrapper = el.querySelector('.swipe-wrapper') as HTMLElement;
+      const setCaptureSpy = spyOn(wrapper, 'setPointerCapture');
+      const content = el.querySelector('.swipe-content') as HTMLElement;
+
+      component.onPointerDown(makePointerDownEvent(content, wrapper));
+
+      // Bug: current code calls setPointerCapture here, stealing click events
+      expect(setCaptureSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call setPointerCapture after confirming horizontal direction in onPointerMove', () => {
+      const wrapper = el.querySelector('.swipe-wrapper') as HTMLElement;
+      const setCaptureSpy = spyOn(wrapper, 'setPointerCapture');
+      const content = el.querySelector('.swipe-content') as HTMLElement;
+
+      component.onPointerDown(makePointerDownEvent(content, wrapper));
+
+      component.onPointerMove({
+        clientX: 188, // 12px left — clearly horizontal
+        clientY: 51,  // 1px down
+        currentTarget: wrapper,
+        preventDefault: () => { /* no-op */ }
+      } as unknown as PointerEvent);
+
+      expect(setCaptureSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should skip drag setup when the tap target is inside the action panel', () => {
+      const wrapper = el.querySelector('.swipe-wrapper') as HTMLElement;
+      const setCaptureSpy = spyOn(wrapper, 'setPointerCapture');
+      const actionBtn = el.querySelector('.swipe-action-btn') as HTMLElement;
+
+      component.onPointerDown(makePointerDownEvent(actionBtn, wrapper));
+
+      // No capture should be set up when tapping the action button
+      expect(setCaptureSpy).not.toHaveBeenCalled();
+
+      // Simulate move to confirm no drag started
+      component.onPointerMove({
+        clientX: 188,
+        clientY: 51,
+        currentTarget: wrapper,
+        preventDefault: () => { /* no-op */ }
+      } as unknown as PointerEvent);
+
+      // Still no capture — drag was never initiated
+      expect(setCaptureSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('close', () => {
+    it('should reset offset and isOpen to default', () => {
+      component.offset.set(-70);
+      component.isOpen.set(true);
+
+      component.close();
+
+      expect(component.offset()).toBe(0);
+      expect(component.isOpen()).toBeFalse();
+    });
+  });
+});

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.spec.ts
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.spec.ts
@@ -54,45 +54,27 @@ describe('SwipeDeleteRowComponent', () => {
       } as unknown as PointerEvent;
     }
 
-    it('should NOT call setPointerCapture immediately on pointerdown', () => {
+    it('should call setPointerCapture immediately for non-interactive targets', () => {
+      // Bug: deferred implementation never calls setPointerCapture in onPointerDown
       const wrapper = el.querySelector('.swipe-wrapper') as HTMLElement;
       const setCaptureSpy = spyOn(wrapper, 'setPointerCapture');
       const content = el.querySelector('.swipe-content') as HTMLElement;
 
       component.onPointerDown(makePointerDownEvent(content, wrapper));
-
-      // Bug: current code calls setPointerCapture here, stealing click events
-      expect(setCaptureSpy).not.toHaveBeenCalled();
-    });
-
-    it('should call setPointerCapture after confirming horizontal direction in onPointerMove', () => {
-      const wrapper = el.querySelector('.swipe-wrapper') as HTMLElement;
-      const setCaptureSpy = spyOn(wrapper, 'setPointerCapture');
-      const content = el.querySelector('.swipe-content') as HTMLElement;
-
-      component.onPointerDown(makePointerDownEvent(content, wrapper));
-
-      component.onPointerMove({
-        clientX: 188, // 12px left — clearly horizontal
-        clientY: 51,  // 1px down
-        currentTarget: wrapper,
-        preventDefault: () => { /* no-op */ }
-      } as unknown as PointerEvent);
 
       expect(setCaptureSpy).toHaveBeenCalledWith(1);
     });
 
-    it('should skip drag setup when the tap target is inside the action panel', () => {
+    it('should NOT call setPointerCapture when the tap target is a button', () => {
       const wrapper = el.querySelector('.swipe-wrapper') as HTMLElement;
       const setCaptureSpy = spyOn(wrapper, 'setPointerCapture');
       const actionBtn = el.querySelector('.swipe-action-btn') as HTMLElement;
 
       component.onPointerDown(makePointerDownEvent(actionBtn, wrapper));
 
-      // No capture should be set up when tapping the action button
       expect(setCaptureSpy).not.toHaveBeenCalled();
 
-      // Simulate move to confirm no drag started
+      // A subsequent move also must not start the drag
       component.onPointerMove({
         clientX: 188,
         clientY: 51,
@@ -100,7 +82,6 @@ describe('SwipeDeleteRowComponent', () => {
         preventDefault: () => { /* no-op */ }
       } as unknown as PointerEvent);
 
-      // Still no capture — drag was never initiated
       expect(setCaptureSpy).not.toHaveBeenCalled();
     });
   });

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
@@ -54,6 +54,7 @@ export class SwipeDeleteRowComponent {
 
     if (!this.isHorizontal) {
       this.isDragging = false;
+      (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
       return;
     }
 

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
@@ -21,6 +21,11 @@ export class SwipeDeleteRowComponent {
   private currentX = 0;
   private isDragging = false;
   private isHorizontal: boolean | null = null;
+  // Deferred pointer capture: set only after we confirm a horizontal swipe,
+  // so that simple taps on inner elements (expand button, action button) still
+  // receive the synthesised click event from the browser.
+  private captureElement: HTMLElement | null = null;
+  private capturePointerId: number | null = null;
 
   readonly ACTION_PANEL_WIDTH = 70;
   readonly OPEN_THRESHOLD = 50;
@@ -30,12 +35,18 @@ export class SwipeDeleteRowComponent {
 
   onPointerDown(event: PointerEvent): void {
     if (this.disabled) return;
+    const el = event.currentTarget as HTMLElement;
+    // Taps on the action panel must reach the button — never start a drag there.
+    const panel = el.querySelector('.swipe-action-panel');
+    if (panel?.contains(event.target as Node)) return;
+
     this.startX = event.clientX;
     this.startY = event.clientY;
     this.currentX = this.offset();
     this.isDragging = true;
     this.isHorizontal = null;
-    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    this.captureElement = el;
+    this.capturePointerId = event.pointerId;
   }
 
   onPointerMove(event: PointerEvent): void {
@@ -47,6 +58,11 @@ export class SwipeDeleteRowComponent {
     if (this.isHorizontal === null) {
       if (Math.abs(dx) < 5 && Math.abs(dy) < 5) return;
       this.isHorizontal = Math.abs(dx) > Math.abs(dy);
+      if (this.isHorizontal && this.captureElement !== null && this.capturePointerId !== null) {
+        this.captureElement.setPointerCapture(this.capturePointerId);
+      }
+      this.captureElement = null;
+      this.capturePointerId = null;
     }
 
     if (!this.isHorizontal) {
@@ -60,6 +76,8 @@ export class SwipeDeleteRowComponent {
   }
 
   onPointerUp(): void {
+    this.captureElement = null;
+    this.capturePointerId = null;
     if (!this.isDragging) return;
     this.isDragging = false;
 
@@ -74,6 +92,8 @@ export class SwipeDeleteRowComponent {
   }
 
   onPointerCancel(): void {
+    this.captureElement = null;
+    this.capturePointerId = null;
     this.isDragging = false;
     this.offset.set(0);
     this.isOpen.set(false);

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ElementRef, EventEmitter, Input, Output, ViewChild, signal
+  Component, EventEmitter, Input, Output, signal
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
@@ -13,8 +13,6 @@ export class SwipeDeleteRowComponent {
   @Input() actionIcon: 'trash' | 'archive' = 'trash';
   @Input() disabled = false;
   @Output() actionTriggered = new EventEmitter<void>();
-
-  @ViewChild('content') contentRef!: ElementRef<HTMLElement>;
 
   private startX = 0;
   private startY = 0;

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
@@ -1,0 +1,91 @@
+import {
+  Component, ElementRef, EventEmitter, Input, Output, ViewChild, signal
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-swipe-delete-row',
+  imports: [CommonModule],
+  templateUrl: './swipe-delete-row.component.html',
+  styleUrl: './swipe-delete-row.component.css'
+})
+export class SwipeDeleteRowComponent {
+  @Input() actionIcon: 'trash' | 'archive' = 'trash';
+  @Input() disabled = false;
+  @Output() actionTriggered = new EventEmitter<void>();
+
+  @ViewChild('content') contentRef!: ElementRef<HTMLElement>;
+
+  private startX = 0;
+  private startY = 0;
+  private currentX = 0;
+  private isDragging = false;
+  private isHorizontal: boolean | null = null;
+
+  readonly ACTION_PANEL_WIDTH = 70;
+  readonly OPEN_THRESHOLD = 50;
+
+  offset = signal(0);
+  isOpen = signal(false);
+
+  onPointerDown(event: PointerEvent): void {
+    if (this.disabled) return;
+    this.startX = event.clientX;
+    this.startY = event.clientY;
+    this.currentX = this.offset();
+    this.isDragging = true;
+    this.isHorizontal = null;
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+  }
+
+  onPointerMove(event: PointerEvent): void {
+    if (!this.isDragging) return;
+
+    const dx = event.clientX - this.startX;
+    const dy = event.clientY - this.startY;
+
+    if (this.isHorizontal === null) {
+      if (Math.abs(dx) < 5 && Math.abs(dy) < 5) return;
+      this.isHorizontal = Math.abs(dx) > Math.abs(dy);
+    }
+
+    if (!this.isHorizontal) {
+      this.isDragging = false;
+      return;
+    }
+
+    event.preventDefault();
+    const newX = Math.max(-this.ACTION_PANEL_WIDTH, Math.min(0, this.currentX + dx));
+    this.offset.set(newX);
+  }
+
+  onPointerUp(): void {
+    if (!this.isDragging) return;
+    this.isDragging = false;
+
+    const current = this.offset();
+    if (current < -this.OPEN_THRESHOLD) {
+      this.offset.set(-this.ACTION_PANEL_WIDTH);
+      this.isOpen.set(true);
+    } else {
+      this.offset.set(0);
+      this.isOpen.set(false);
+    }
+  }
+
+  onPointerCancel(): void {
+    this.isDragging = false;
+    this.offset.set(0);
+    this.isOpen.set(false);
+  }
+
+  close(): void {
+    this.offset.set(0);
+    this.isOpen.set(false);
+  }
+
+  triggerAction(): void {
+    this.close();
+    this.actionTriggered.emit();
+  }
+}

--- a/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
+++ b/easyfinance.client/src/app/core/components/swipe-delete-row/swipe-delete-row.component.ts
@@ -19,11 +19,6 @@ export class SwipeDeleteRowComponent {
   private currentX = 0;
   private isDragging = false;
   private isHorizontal: boolean | null = null;
-  // Deferred pointer capture: set only after we confirm a horizontal swipe,
-  // so that simple taps on inner elements (expand button, action button) still
-  // receive the synthesised click event from the browser.
-  private captureElement: HTMLElement | null = null;
-  private capturePointerId: number | null = null;
 
   readonly ACTION_PANEL_WIDTH = 70;
   readonly OPEN_THRESHOLD = 50;
@@ -33,18 +28,17 @@ export class SwipeDeleteRowComponent {
 
   onPointerDown(event: PointerEvent): void {
     if (this.disabled) return;
-    const el = event.currentTarget as HTMLElement;
-    // Taps on the action panel must reach the button — never start a drag there.
-    const panel = el.querySelector('.swipe-action-panel');
-    if (panel?.contains(event.target as Node)) return;
+    // Skip drag for interactive elements: their click events must not be
+    // swallowed by the pointer capture that the wrapper sets below.
+    if ((event.target as HTMLElement).closest('button, a, input, select, textarea')) return;
 
+    const el = event.currentTarget as HTMLElement;
     this.startX = event.clientX;
     this.startY = event.clientY;
     this.currentX = this.offset();
     this.isDragging = true;
     this.isHorizontal = null;
-    this.captureElement = el;
-    this.capturePointerId = event.pointerId;
+    el.setPointerCapture(event.pointerId);
   }
 
   onPointerMove(event: PointerEvent): void {
@@ -56,11 +50,6 @@ export class SwipeDeleteRowComponent {
     if (this.isHorizontal === null) {
       if (Math.abs(dx) < 5 && Math.abs(dy) < 5) return;
       this.isHorizontal = Math.abs(dx) > Math.abs(dy);
-      if (this.isHorizontal && this.captureElement !== null && this.capturePointerId !== null) {
-        this.captureElement.setPointerCapture(this.capturePointerId);
-      }
-      this.captureElement = null;
-      this.capturePointerId = null;
     }
 
     if (!this.isHorizontal) {
@@ -74,8 +63,6 @@ export class SwipeDeleteRowComponent {
   }
 
   onPointerUp(): void {
-    this.captureElement = null;
-    this.capturePointerId = null;
     if (!this.isDragging) return;
     this.isDragging = false;
 
@@ -90,8 +77,6 @@ export class SwipeDeleteRowComponent {
   }
 
   onPointerCancel(): void {
-    this.captureElement = null;
-    this.capturePointerId = null;
     this.isDragging = false;
     this.offset.set(0);
     this.isOpen.set(false);

--- a/easyfinance.client/src/app/core/interceptor/http-request-interceptor.ts
+++ b/easyfinance.client/src/app/core/interceptor/http-request-interceptor.ts
@@ -1,4 +1,4 @@
-import { HttpInterceptorFn, HttpRequest, HttpResponse } from '@angular/common/http';
+import { HttpContextToken, HttpInterceptorFn, HttpRequest, HttpResponse } from '@angular/common/http';
 import { catchError, Subject, switchMap, take, tap, throwError } from 'rxjs';
 import { Router } from '@angular/router';
 import { inject, Injector, PLATFORM_ID } from '@angular/core';
@@ -8,6 +8,8 @@ import { TranslateService } from '@ngx-translate/core';
 import { AuthService } from '../services/auth.service';
 import { ApiErrorResponse } from '../models/error';
 import { SnackbarComponent } from '../components/snackbar/snackbar.component';
+
+export const SUPPRESS_SUCCESS_NOTIFICATION = new HttpContextToken<boolean>(() => false);
 
 interface RequestException {
   method: string;
@@ -59,7 +61,7 @@ export const HttpRequestInterceptor: HttpInterceptorFn = (req, next) => {
         snackBar.openSuccessSnackbar(translateService.instant('CreatedSuccess'));
       }
 
-      if (req.method === 'DELETE' && event.status === 200) {
+      if (req.method === 'DELETE' && event.status === 200 && !req.context.get(SUPPRESS_SUCCESS_NOTIFICATION)) {
         snackBar.openSuccessSnackbar(translateService.instant('DeletedSuccess'));
       }
     }),

--- a/easyfinance.client/src/app/core/services/category.service.ts
+++ b/easyfinance.client/src/app/core/services/category.service.ts
@@ -77,4 +77,10 @@ export class CategoryService {
       observe: 'response'
     }).pipe(map(res => res.ok));
   }
+
+  restore(projectId: string, id: string): Observable<boolean> {
+    return this.http.put('/api/projects/' + projectId + '/categories/' + id + '/unarchive', {}, {
+      observe: 'response'
+    }).pipe(map(res => res.ok));
+  }
 }

--- a/easyfinance.client/src/app/core/services/expense.service.spec.ts
+++ b/easyfinance.client/src/app/core/services/expense.service.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ExpenseService } from './expense.service';
+import { SUPPRESS_SUCCESS_NOTIFICATION } from '../interceptor/http-request-interceptor';
+
+describe('ExpenseService HTTP context', () => {
+  let service: ExpenseService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ExpenseService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(ExpenseService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  describe('remove', () => {
+    it('should suppress the delete-success interceptor notification', () => {
+      service.remove('proj-1', 'cat-1', 'exp-1').subscribe();
+
+      const req = httpMock.expectOne('/api/projects/proj-1/categories/cat-1/expenses/exp-1');
+      expect(req.request.method).toBe('DELETE');
+      // Fails until SUPPRESS_SUCCESS_NOTIFICATION context is added to the call
+      expect(req.request.context.get(SUPPRESS_SUCCESS_NOTIFICATION)).toBeTrue();
+
+      req.flush(null, { status: 200, statusText: 'OK' });
+    });
+  });
+
+  describe('removeItem', () => {
+    it('should suppress the delete-success interceptor notification', () => {
+      service.removeItem('proj-1', 'cat-1', 'exp-1', 'item-1').subscribe();
+
+      const req = httpMock.expectOne(
+        '/api/projects/proj-1/categories/cat-1/expenses/exp-1/expenseItems/item-1'
+      );
+      expect(req.request.method).toBe('DELETE');
+      // Fails until SUPPRESS_SUCCESS_NOTIFICATION context is added to the call
+      expect(req.request.context.get(SUPPRESS_SUCCESS_NOTIFICATION)).toBeTrue();
+
+      req.flush(null, { status: 200, statusText: 'OK' });
+    });
+  });
+});

--- a/easyfinance.client/src/app/core/services/expense.service.ts
+++ b/easyfinance.client/src/app/core/services/expense.service.ts
@@ -162,8 +162,20 @@ export class ExpenseService {
     }).pipe(map(res => res.ok));
   }
 
+  restore(projectId: string, categoryId: string, id: string): Observable<boolean> {
+    return this.http.put('/api/projects/' + projectId + '/categories/' + categoryId + '/expenses/' + id + '/restore', null, {
+      observe: 'response'
+    }).pipe(map(res => res.ok));
+  }
+
   removeItem(projectId: string, categoryId: string, expenseId: string, expenseItemId: string): Observable<boolean> {
     return this.http.delete('/api/projects/' + projectId + '/categories/' + categoryId + '/expenses/' + expenseId + '/expenseItems/' + expenseItemId, {
+      observe: 'response'
+    }).pipe(map(res => res.ok));
+  }
+
+  restoreItem(projectId: string, categoryId: string, expenseId: string, expenseItemId: string): Observable<boolean> {
+    return this.http.put('/api/projects/' + projectId + '/categories/' + categoryId + '/expenses/' + expenseId + '/expenseItems/' + expenseItemId + '/restore', null, {
       observe: 'response'
     }).pipe(map(res => res.ok));
   }

--- a/easyfinance.client/src/app/core/services/expense.service.ts
+++ b/easyfinance.client/src/app/core/services/expense.service.ts
@@ -1,4 +1,5 @@
-import { HttpClient, HttpEvent, HttpEventType, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpEvent, HttpEventType, HttpParams } from '@angular/common/http';
+import { SUPPRESS_SUCCESS_NOTIFICATION } from '../interceptor/http-request-interceptor';
 import { inject, Injectable } from '@angular/core';
 import { Observable, filter, map } from 'rxjs';
 import { Operation } from 'fast-json-patch';
@@ -158,7 +159,8 @@ export class ExpenseService {
 
   remove(projectId: string, categoryId: string, id: string): Observable<boolean> {
     return this.http.delete('/api/projects/' + projectId + '/categories/' + categoryId + '/expenses/' + id, {
-      observe: 'response'
+      observe: 'response',
+      context: new HttpContext().set(SUPPRESS_SUCCESS_NOTIFICATION, true)
     }).pipe(map(res => res.ok));
   }
 
@@ -170,7 +172,8 @@ export class ExpenseService {
 
   removeItem(projectId: string, categoryId: string, expenseId: string, expenseItemId: string): Observable<boolean> {
     return this.http.delete('/api/projects/' + projectId + '/categories/' + categoryId + '/expenses/' + expenseId + '/expenseItems/' + expenseItemId, {
-      observe: 'response'
+      observe: 'response',
+      context: new HttpContext().set(SUPPRESS_SUCCESS_NOTIFICATION, true)
     }).pipe(map(res => res.ok));
   }
 

--- a/easyfinance.client/src/app/core/services/income.service.spec.ts
+++ b/easyfinance.client/src/app/core/services/income.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { IncomeService } from './income.service';
+import { SUPPRESS_SUCCESS_NOTIFICATION } from '../interceptor/http-request-interceptor';
+
+describe('IncomeService HTTP context', () => {
+  let service: IncomeService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        IncomeService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(IncomeService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  describe('remove', () => {
+    it('should suppress the delete-success interceptor notification', () => {
+      service.remove('proj-1', 'income-1').subscribe();
+
+      const req = httpMock.expectOne('/api/projects/proj-1/incomes/income-1');
+      expect(req.request.method).toBe('DELETE');
+      // Fails until SUPPRESS_SUCCESS_NOTIFICATION context is added to the call
+      expect(req.request.context.get(SUPPRESS_SUCCESS_NOTIFICATION)).toBeTrue();
+
+      req.flush(null, { status: 200, statusText: 'OK' });
+    });
+  });
+});

--- a/easyfinance.client/src/app/core/services/income.service.ts
+++ b/easyfinance.client/src/app/core/services/income.service.ts
@@ -50,4 +50,10 @@ export class IncomeService {
       observe: 'response'
     }).pipe(map(res => res.ok));
   }
+
+  restore(projectId: string, id: string): Observable<boolean> {
+    return this.http.put('/api/projects/' + projectId + '/incomes/' + id + '/restore', null, {
+      observe: 'response'
+    }).pipe(map(res => res.ok));
+  }
 }

--- a/easyfinance.client/src/app/core/services/income.service.ts
+++ b/easyfinance.client/src/app/core/services/income.service.ts
@@ -1,4 +1,5 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpParams } from '@angular/common/http';
+import { SUPPRESS_SUCCESS_NOTIFICATION } from '../interceptor/http-request-interceptor';
 import { Injectable, inject } from '@angular/core';
 import { Income } from '../models/income';
 import { Observable, map } from 'rxjs';
@@ -47,7 +48,8 @@ export class IncomeService {
 
   remove(projectId: string, id: string): Observable<boolean> {
     return this.http.delete('/api/projects/' + projectId + '/incomes/' + id, {
-      observe: 'response'
+      observe: 'response',
+      context: new HttpContext().set(SUPPRESS_SUCCESS_NOTIFICATION, true)
     }).pipe(map(res => res.ok));
   }
 

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.html
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.html
@@ -9,26 +9,28 @@
       @for (category of (categories$ | async); track category.id) {
         <div class="list-group-item" cdkDrag [cdkDragDisabled]="!canAddOrEdit() || category.id === editingCategory.id || isSavingOrder">
           @if (category.id !== this.editingCategory.id) {
-            <div class="d-flex justify-content-between">
-              <div class="d-flex align-items-center">
-                @if (canAddOrEdit()) {
-                  <button type="button" class="btn btn-link drag-handle p-0 me-2" cdkDragHandle [attr.aria-label]="'Reorder category'">
-                    <i class="bi bi-grip-vertical"></i>
-                  </button>
-                }
-                <h3 class="category-name">{{ category.name }}</h3>
-              </div>
-              @if (canAddOrEdit()){
-                <div class="btn-group actions">
-                  <button class="btn btn-outline-secondary" (click)="edit(category);">
-                    <i class="bi bi-pencil-square"></i>
-                  </button>
-                  <button class="btn btn-outline-danger" (click)="triggerDelete(category);">
-                    <i class="bi bi-archive"></i>
-                  </button>
+            <app-swipe-delete-row
+              [disabled]="!canAddOrEdit()"
+              actionIcon="archive"
+              (actionTriggered)="swipeArchive(category)">
+              <div class="d-flex justify-content-between">
+                <div class="d-flex align-items-center">
+                  @if (canAddOrEdit()) {
+                    <button type="button" class="btn btn-link drag-handle p-0 me-2" cdkDragHandle [attr.aria-label]="'Reorder category'">
+                      <i class="bi bi-grip-vertical"></i>
+                    </button>
+                  }
+                  <h3 class="category-name">{{ category.name }}</h3>
                 </div>
-              }
-            </div>
+                @if (canAddOrEdit()){
+                  <div class="btn-group actions">
+                    <button class="btn btn-outline-secondary" (click)="edit(category);">
+                      <i class="bi bi-pencil-square"></i>
+                    </button>
+                  </div>
+                }
+              </div>
+            </app-swipe-delete-row>
           } @else {
             <div>
               <form [formGroup]="categoryForm" (ngSubmit)="save()">

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { Subject, of, BehaviorSubject } from 'rxjs';
+import { Subject, of, BehaviorSubject, EMPTY } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { ListCategoriesComponent } from './list-categories.component';
 import { CategoryService } from '../../../core/services/category.service';
 import { ErrorMessageService } from '../../../core/services/error-message.service';
@@ -18,6 +19,7 @@ describe('ListCategoriesComponent', () => {
   let fixture: ComponentFixture<ListCategoriesComponent>;
   let component: ListCategoriesComponent;
   let categoryServiceMock: jasmine.SpyObj<CategoryService>;
+  let snackBarMock: jasmine.SpyObj<MatSnackBar>;
 
   const makeCategory = (id = 'cat-1', name = 'Food'): Category => {
     const cat = new Category();
@@ -47,11 +49,16 @@ describe('ListCategoriesComponent', () => {
 
   beforeEach(async () => {
     categoryServiceMock = jasmine.createSpyObj<CategoryService>('CategoryService', [
-      'get', 'getDefaultCategories', 'update'
+      'get', 'getDefaultCategories', 'update', 'remove', 'restore'
     ]);
     categoryServiceMock.get.and.returnValue(of([makeCategory()]));
     categoryServiceMock.getDefaultCategories.and.returnValue(of([]));
     categoryServiceMock.update.and.returnValue(of(makeCategory()));
+    categoryServiceMock.remove.and.returnValue(of(true));
+    categoryServiceMock.restore.and.returnValue(of(true));
+
+    snackBarMock = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
+    snackBarMock.open.and.returnValue({ onAction: () => EMPTY } as any);
 
     const selectedUserProject$ = new BehaviorSubject<UserProjectDto>(makeUserProject());
     const projectServiceMock = jasmine.createSpyObj<ProjectService>('ProjectService', ['getUserProject', 'selectUserProject']);
@@ -68,6 +75,7 @@ describe('ListCategoriesComponent', () => {
         { provide: ProjectService, useValue: projectServiceMock },
         { provide: Router, useValue: { navigate: jasmine.createSpy('navigate') } },
         { provide: ActivatedRoute, useValue: {} },
+        { provide: MatSnackBar, useValue: snackBarMock },
         {
           provide: MatDialog,
           useValue: { open: jasmine.createSpy('open').and.returnValue({ afterClosed: () => of(false) }) }
@@ -196,5 +204,49 @@ describe('ListCategoriesComponent', () => {
 
     subject.next(makeCategory('cat-1', 'Updated Food'));
     subject.complete();
+  });
+
+  describe('swipeArchive', () => {
+    it('should optimistically remove the category from the list', () => {
+      const category = makeCategoryDto('cat-1', 'Food');
+      (component as any).categories.next([category]);
+
+      component.swipeArchive(category);
+
+      const remaining = (component as any).categories.getValue() as CategoryDto[];
+      expect(remaining.find(c => c.id === 'cat-1')).toBeUndefined();
+    });
+
+    it('should call the archive API', () => {
+      const category = makeCategoryDto('cat-1', 'Food');
+      (component as any).categories.next([category]);
+
+      component.swipeArchive(category);
+
+      expect(categoryServiceMock.remove).toHaveBeenCalledWith('project-1', 'cat-1');
+    });
+
+    it('should show a snackbar with undo action', () => {
+      const category = makeCategoryDto('cat-1', 'Food');
+      (component as any).categories.next([category]);
+
+      component.swipeArchive(category);
+
+      expect(snackBarMock.open).toHaveBeenCalled();
+    });
+
+    it('should call restore API and refill data when undo is clicked', () => {
+      const actionSubject = new Subject<void>();
+      snackBarMock.open.and.returnValue({ onAction: () => actionSubject.asObservable() } as any);
+
+      const category = makeCategoryDto('cat-1', 'Food');
+      (component as any).categories.next([category]);
+
+      component.swipeArchive(category);
+      actionSubject.next();
+
+      expect(categoryServiceMock.restore).toHaveBeenCalledWith('project-1', 'cat-1');
+      expect(categoryServiceMock.get).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
+++ b/easyfinance.client/src/app/features/category/list-categories/list-categories.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, CommonModule } from '@angular/common';
-import { Component, Input, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, Input, OnInit, inject } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
@@ -8,11 +8,11 @@ import { compare } from 'fast-json-patch';
 import { MatButton } from "@angular/material/button";
 import { MatError, MatFormField, MatLabel } from "@angular/material/form-field";
 import { MatInput } from "@angular/material/input";
-import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { CategoryDto } from '../models/category-dto';
 import { CategoryService } from '../../../core/services/category.service';
-import { ConfirmDialogComponent } from '../../../core/components/confirm-dialog/confirm-dialog.component';
+import { SwipeDeleteRowComponent } from '../../../core/components/swipe-delete-row/swipe-delete-row.component';
 import { ApiErrorResponse } from "../../../core/models/error";
 import { ErrorMessageService } from "../../../core/services/error-message.service";
 import { UserProjectDto } from '../../project/models/user-project-dto';
@@ -35,6 +35,7 @@ import { DefaultCategory } from '../../../core/models/default-category';
       MatLabel,
       MatAutocompleteModule,
       DragDropModule,
+      SwipeDeleteRowComponent,
       TranslateModule
     ],
     templateUrl: './list-categories.component.html',
@@ -45,11 +46,9 @@ export class ListCategoriesComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private errorMessageService = inject(ErrorMessageService);
-  private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
   private projectService = inject(ProjectService);
   private translateService = inject(TranslateService);
-
-  @ViewChild(ConfirmDialogComponent) ConfirmDialog!: ConfirmDialogComponent;
 
   private categories: BehaviorSubject<CategoryDto[]> = new BehaviorSubject<CategoryDto[]>([new CategoryDto()]);
   categories$: Observable<CategoryDto[]> = this.categories.asObservable();
@@ -61,7 +60,6 @@ export class ListCategoriesComponent implements OnInit {
 
   categoryForm!: FormGroup;
   editingCategory: CategoryDto = new CategoryDto();
-  itemToDelete!: string;
   httpErrors = false;
   errors!: Record<string, string[]>;
   userProject!: UserProjectDto;
@@ -184,32 +182,19 @@ export class ListCategoriesComponent implements OnInit {
     this.editingCategory = new CategoryDto();
   }
 
-  remove(id: string): void {
-    this.categoryService.remove(this.projectId, id).subscribe({
-      next: () => {
-        const categoriesNewArray: CategoryDto[] = [...this.categories.getValue()];
+  swipeArchive(category: CategoryDto): void {
+    this.categories.next(this.categories.getValue().filter(c => c.id !== category.id));
 
-        categoriesNewArray.forEach((item, index) => {
-          if (item.id === id) {
-            categoriesNewArray.splice(index, 1);
-          }
-        });
+    this.categoryService.remove(this.projectId, category.id).subscribe();
 
-        this.categories.next(categoriesNewArray);
-      }
-    })
-  }
+    const undoLabel = this.translateService.instant('ButtonUndo');
+    const message = this.translateService.instant('UndoArchive');
+    const ref = this.snackBar.open(message, undoLabel, { duration: 5000 });
 
-  triggerDelete(category: CategoryDto): void {
-    this.itemToDelete = category.id
-    const message = this.translateService.instant('AreYouSureYouWantArchiveCategory', { value: category.name });
-
-    this.dialog.open(ConfirmDialogComponent, {
-      data: { title: 'ArchiveCategory', message: message, action: 'ButtonArchive' },
-    }).afterClosed().subscribe((result) => {
-      if (result) {
-        this.remove(this.itemToDelete);
-      }
+    ref.onAction().subscribe(() => {
+      this.categoryService.restore(this.projectId, category.id).subscribe({
+        next: () => this.fillData()
+      });
     });
   }
 

--- a/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.html
+++ b/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.html
@@ -19,50 +19,53 @@
         <mat-card-content [class.archived-container]="isArchived">
           <div class="list-group list-group-flush">
             @for (expense of (expenses$ | async); track expense.id) {
-              <div class="list-group-item">
+              <div class="list-group-item px-0">
                 @if (isEditingExpense(expense) || isMovingExpense(expense)) {
-                  <app-expense
-                    [projectId]="projectId"
-                    [categoryId]="categoryId"
-                    [expense]="expense"
-                    [inlineMode]="true"
-                    [moveMode]="isMovingExpense(expense)"
-                    (saved)="onExpenseSaved()"
-                    (canceled)="cancelExpenseForm()">
-                  </app-expense>
+                  <div class="px-3">
+                    <app-expense
+                      [projectId]="projectId"
+                      [categoryId]="categoryId"
+                      [expense]="expense"
+                      [inlineMode]="true"
+                      [moveMode]="isMovingExpense(expense)"
+                      (saved)="onExpenseSaved()"
+                      (canceled)="cancelExpenseForm()">
+                    </app-expense>
+                  </div>
                 } @else {
-                  <div class="d-flex align-items-center expense-item">
-                    @if(canAddOrEdit() || (expense.items && expense.items.length > 0)) {
-                      <button class="btn btn-link p-0 me-3"
-                        (click)="toggleExpand(expense.id)"
-                        [attr.aria-expanded]="isExpanded(expense.id)">
-                        <i class="bi" [class]="isExpanded(expense.id) ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
-                      </button>
-                    }
+                  <app-swipe-delete-row
+                    [disabled]="!canAddOrEdit() || isArchived"
+                    actionIcon="trash"
+                    (actionTriggered)="swipeDeleteExpense(expense)">
+                    <div class="d-flex align-items-center expense-item px-3">
+                      @if(canAddOrEdit() || (expense.items && expense.items.length > 0)) {
+                        <button class="btn btn-link p-0 me-3"
+                          (click)="toggleExpand(expense.id)"
+                          [attr.aria-expanded]="isExpanded(expense.id)">
+                          <i class="bi" [class]="isExpanded(expense.id) ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
+                        </button>
+                      }
 
-                    <div class="flex-grow-1">
-                      <div class="d-flex justify-content-between align-items-center">
-                        <h2 class="mb-1 fw-bold name mb-3" [class.archived]="isArchived">{{ expense.name }}</h2>
+                      <div class="flex-grow-1">
+                        <div class="d-flex justify-content-between align-items-center">
+                          <h2 class="mb-1 fw-bold name mb-3" [class.archived]="isArchived">{{ expense.name }}</h2>
 
-                        @if (canAddOrEdit()) {
-                          <div class="btn-group">
-                            <button name="edit" class="btn btn-outline-secondary" (click)="startEditExpense(expense)">
-                              <i class="bi bi-pencil-square"></i>
-                            </button>
-                            <button
-                              name="move"
-                              class="btn btn-outline-secondary"
-                              [attr.aria-label]="'ButtonMove' | translate"
-                              [title]="'ButtonMove' | translate"
-                              (click)="startMoveExpense(expense)">
-                              <i class="bi bi-arrow-left-right"></i>
-                            </button>
-                            <button name="delete" class="btn btn-outline-danger" (click)="triggerDelete(expense)">
-                              <i class="bi bi-trash"></i>
-                            </button>
-                          </div>
-                        }
-                      </div>
+                          @if (canAddOrEdit()) {
+                            <div class="btn-group">
+                              <button name="edit" class="btn btn-outline-secondary" (click)="startEditExpense(expense)">
+                                <i class="bi bi-pencil-square"></i>
+                              </button>
+                              <button
+                                name="move"
+                                class="btn btn-outline-secondary"
+                                [attr.aria-label]="'ButtonMove' | translate"
+                                [title]="'ButtonMove' | translate"
+                                (click)="startMoveExpense(expense)">
+                                <i class="bi bi-arrow-left-right"></i>
+                              </button>
+                            </div>
+                          }
+                        </div>
 
                       <div class="expense-flags mb-2" [class.archived]="isArchived">
                         @if (expense.isDeductible) {
@@ -101,6 +104,7 @@
                       </div>
                     </div>
                   </div>
+                  </app-swipe-delete-row>
                 }
 
                 @if (isExpanded(expense.id)) {
@@ -118,72 +122,74 @@
                           (canceled)="cancelSubExpenseForm()">
                         </app-expense-item>
                       } @else {
-                        <div class="d-flex align-items-center mb-2">
-                          <div class="flex-grow-1">
-                            @if (subExpense.name && subExpense.name.trim()) {
-                              <span class="fw-normal name-sub">{{ subExpense.name }}</span>
-                            } @else {
-                              <span class="fw-normal text-muted fst-italic name-sub-placeholder">{{ 'PlaceholderItemWithoutName' | translate }}</span>
-                            }
-
-                            <div class="expense-flags expense-item-flags my-1" [class.archived]="isArchived">
-                              @if (subExpense.isDeductible) {
-                                <span class="expense-flag expense-flag-deductible" data-testid="expense-item-deductible-flag">
-                                  <i class="bi bi-receipt-cutoff me-1"></i>
-                                  {{ 'FieldIsDeductible' | translate }}
-                                </span>
+                        <app-swipe-delete-row
+                          [disabled]="!canAddOrEdit() || isArchived"
+                          actionIcon="trash"
+                          (actionTriggered)="swipeDeleteSubExpense(expense, subExpense)">
+                          <div class="d-flex align-items-center mb-2">
+                            <div class="flex-grow-1">
+                              @if (subExpense.name && subExpense.name.trim()) {
+                                <span class="fw-normal name-sub">{{ subExpense.name }}</span>
+                              } @else {
+                                <span class="fw-normal text-muted fst-italic name-sub-placeholder">{{ 'PlaceholderItemWithoutName' | translate }}</span>
                               }
 
-                              @if (hasDeductibleProofItem(subExpense)) {
-                                @if (getDeductibleProofItemDownloadUrl(expense, subExpense); as proofItemDownloadUrl) {
-                                  <a class="expense-flag expense-flag-proof expense-flag-link"
-                                    [href]="proofItemDownloadUrl"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    data-testid="expense-item-proof-flag">
-                                    <i class="bi bi-paperclip me-1"></i>
-                                    {{ 'DeductibleProofAttached' | translate }}
-                                  </a>
-                                } @else {
-                                  <span class="expense-flag expense-flag-proof" data-testid="expense-item-proof-flag">
-                                    <i class="bi bi-paperclip me-1"></i>
-                                    {{ 'DeductibleProofAttached' | translate }}
+                              <div class="expense-flags expense-item-flags my-1" [class.archived]="isArchived">
+                                @if (subExpense.isDeductible) {
+                                  <span class="expense-flag expense-flag-deductible" data-testid="expense-item-deductible-flag">
+                                    <i class="bi bi-receipt-cutoff me-1"></i>
+                                    {{ 'FieldIsDeductible' | translate }}
                                   </span>
                                 }
-                              }
+
+                                @if (hasDeductibleProofItem(subExpense)) {
+                                  @if (getDeductibleProofItemDownloadUrl(expense, subExpense); as proofItemDownloadUrl) {
+                                    <a class="expense-flag expense-flag-proof expense-flag-link"
+                                      [href]="proofItemDownloadUrl"
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      data-testid="expense-item-proof-flag">
+                                      <i class="bi bi-paperclip me-1"></i>
+                                      {{ 'DeductibleProofAttached' | translate }}
+                                    </a>
+                                  } @else {
+                                    <span class="expense-flag expense-flag-proof" data-testid="expense-item-proof-flag">
+                                      <i class="bi bi-paperclip me-1"></i>
+                                      {{ 'DeductibleProofAttached' | translate }}
+                                    </span>
+                                  }
+                                }
+                              </div>
+
+                              <p class="text-muted fs-6 mb-1">
+                                <span class="me-3 date-sub">
+                                  <i class="bi bi-calendar me-1"></i>
+                                  {{ subExpense.date | date: 'shortDate' : undefined : currentLanguage }}
+                                </span>
+                                <span class="text-nowrap amount-sub privacy-sensitive-value">
+                                  <i class="bi bi-cash-coin me-1"></i>
+                                  {{ subExpense.amount | currencyFormat }}
+                                </span>
+                              </p>
                             </div>
 
-                            <p class="text-muted fs-6 mb-1">
-                              <span class="me-3 date-sub">
-                                <i class="bi bi-calendar me-1"></i>
-                                {{ subExpense.date | date: 'shortDate' : undefined : currentLanguage }}
-                              </span>
-                              <span class="text-nowrap amount-sub privacy-sensitive-value">
-                                <i class="bi bi-cash-coin me-1"></i>
-                                {{ subExpense.amount | currencyFormat }}
-                              </span>
-                            </p>
+                            @if (canAddOrEdit()) {
+                              <div class="btn-group btn-group-sm">
+                                <button name="edit-sub" class="btn btn-outline-secondary" (click)="startEditSubExpense(expense, subExpense)">
+                                  <i class="bi bi-pencil-square"></i>
+                                </button>
+                                <button
+                                  name="move-sub"
+                                  class="btn btn-outline-secondary"
+                                  [attr.aria-label]="'ButtonMove' | translate"
+                                  [title]="'ButtonMove' | translate"
+                                  (click)="startMoveSubExpense(expense, subExpense)">
+                                  <i class="bi bi-arrow-left-right"></i>
+                                </button>
+                              </div>
+                            }
                           </div>
-
-                          @if (canAddOrEdit()) {
-                            <div class="btn-group btn-group-sm">
-                              <button name="edit-sub" class="btn btn-outline-secondary" (click)="startEditSubExpense(expense, subExpense)">
-                                <i class="bi bi-pencil-square"></i>
-                              </button>
-                              <button
-                                name="move-sub"
-                                class="btn btn-outline-secondary"
-                                [attr.aria-label]="'ButtonMove' | translate"
-                                [title]="'ButtonMove' | translate"
-                                (click)="startMoveSubExpense(expense, subExpense)">
-                                <i class="bi bi-arrow-left-right"></i>
-                              </button>
-                              <button name="delete-sub" class="btn btn-outline-danger" (click)="triggerDeleteSubExpense(expense, subExpense)">
-                                <i class="bi bi-trash"></i>
-                              </button>
-                            </div>
-                          }
-                        </div>
+                        </app-swipe-delete-row>
                       }
                     }
 

--- a/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.spec.ts
+++ b/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.spec.ts
@@ -1,0 +1,233 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateModule } from '@ngx-translate/core';
+import { BehaviorSubject, Subject, of, EMPTY } from 'rxjs';
+import { CategoryService } from '../../../core/services/category.service';
+import { CurrentDateService } from '../../../core/services/current-date.service';
+import { GlobalService } from '../../../core/services/global.service';
+import { ExpenseService } from '../../../core/services/expense.service';
+import { ProjectService } from '../../../core/services/project.service';
+import { ExpenseDto } from '../models/expense-dto';
+import { ExpenseItemDto } from '../models/expense-item-dto';
+import { ListExpensesComponent } from './list-expenses.component';
+
+function makeExpense(overrides: Partial<ExpenseDto> = {}): ExpenseDto {
+  const dto = new ExpenseDto();
+  dto.id = overrides.id ?? 'expense-1';
+  dto.name = overrides.name ?? 'Groceries';
+  dto.date = overrides.date ?? new Date('2026-03-01');
+  dto.amount = overrides.amount ?? 100;
+  dto.budget = overrides.budget ?? 200;
+  dto.items = overrides.items ?? [];
+  dto.isDeductible = overrides.isDeductible ?? false;
+  dto.attachments = overrides.attachments ?? [];
+  dto.temporaryAttachmentIds = overrides.temporaryAttachmentIds ?? [];
+  return dto;
+}
+
+function makeItem(overrides: Partial<ExpenseItemDto> = {}): ExpenseItemDto {
+  const dto = new ExpenseItemDto();
+  dto.id = overrides.id ?? 'item-1';
+  dto.name = overrides.name ?? 'Bread';
+  dto.date = overrides.date ?? new Date('2026-03-01');
+  dto.amount = overrides.amount ?? 20;
+  dto.isDeductible = overrides.isDeductible ?? false;
+  dto.attachments = overrides.attachments ?? [];
+  dto.temporaryAttachmentIds = overrides.temporaryAttachmentIds ?? [];
+  dto.items = overrides.items ?? [];
+  return dto;
+}
+
+describe('ListExpensesComponent', () => {
+  let fixture: ComponentFixture<ListExpensesComponent>;
+  let component: ListExpensesComponent;
+  let expenseServiceMock: jasmine.SpyObj<ExpenseService>;
+  let categoryServiceMock: jasmine.SpyObj<CategoryService>;
+  let dialogMock: jasmine.SpyObj<MatDialog>;
+  let snackBarMock: jasmine.SpyObj<MatSnackBar>;
+
+  beforeEach(async () => {
+    const routerEvents = new BehaviorSubject(new NavigationEnd(
+      1,
+      '/projects/project-1/categories/cat-1/expenses',
+      '/projects/project-1/categories/cat-1/expenses'
+    ));
+
+    const routerMock = {
+      url: '/projects/project-1/categories/cat-1/expenses',
+      events: routerEvents.asObservable(),
+      navigate: jasmine.createSpy('navigate'),
+      parseUrl: (url: string) => {
+        const segments = url.split('?')[0].split('/').filter(Boolean).map(path => ({ path }));
+        return {
+          root: {
+            children: {
+              primary: { segments }
+            }
+          }
+        } as unknown as ReturnType<Router['parseUrl']>;
+      }
+    } as unknown as Router;
+
+    expenseServiceMock = jasmine.createSpyObj<ExpenseService>('ExpenseService', [
+      'get', 'remove', 'restore', 'removeItem', 'restoreItem'
+    ]);
+    expenseServiceMock.get.and.returnValue(of([]));
+    expenseServiceMock.remove.and.returnValue(of(true));
+    expenseServiceMock.restore.and.returnValue(of(true));
+    expenseServiceMock.removeItem.and.returnValue(of(true));
+    expenseServiceMock.restoreItem.and.returnValue(of(true));
+
+    categoryServiceMock = jasmine.createSpyObj<CategoryService>('CategoryService', ['getById']);
+    categoryServiceMock.getById.and.returnValue(of({ id: 'cat-1', name: 'Food', isArchived: false } as any));
+
+    snackBarMock = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
+    snackBarMock.open.and.returnValue({ onAction: () => EMPTY } as any);
+
+    dialogMock = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+    dialogMock.open.and.returnValue({ afterClosed: () => of(false) } as any);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ListExpensesComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideNativeDateAdapter(),
+        { provide: Router, useValue: routerMock },
+        { provide: MatDialog, useValue: dialogMock },
+        { provide: MatSnackBar, useValue: snackBarMock },
+        { provide: ExpenseService, useValue: expenseServiceMock },
+        { provide: CategoryService, useValue: categoryServiceMock },
+        {
+          provide: ProjectService,
+          useValue: {
+            selectedUserProject$: of({ role: 'Admin', project: { id: 'project-1', name: 'Project One' } }),
+            getUserProject: () => of({ role: 'Admin', project: { id: 'project-1', name: 'Project One' } }),
+            selectUserProject: jasmine.createSpy('selectUserProject')
+          }
+        },
+        {
+          provide: GlobalService,
+          useValue: {
+            currentLanguage: 'en',
+            currency: 'USD',
+            currencySymbol: '$',
+            groupSeparator: ',',
+            decimalSeparator: '.'
+          }
+        },
+        {
+          provide: CurrentDateService,
+          useValue: { currentDate: new Date('2026-03-12T12:00:00') }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ListExpensesComponent);
+    component = fixture.componentInstance;
+    component.projectId = 'project-1';
+    component.categoryId = 'cat-1';
+    fixture.detectChanges();
+  });
+
+  it('should load expenses on init', () => {
+    expect(expenseServiceMock.get).toHaveBeenCalledWith('project-1', 'cat-1', jasmine.any(Date));
+  });
+
+  describe('swipeDeleteExpense', () => {
+    it('should optimistically remove the expense from the list', () => {
+      const expense = makeExpense();
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteExpense(expense);
+
+      const remaining = (component as any).expenses.getValue() as ExpenseDto[];
+      expect(remaining.find(e => e.id === 'expense-1')).toBeUndefined();
+    });
+
+    it('should call the remove API', () => {
+      const expense = makeExpense();
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteExpense(expense);
+
+      expect(expenseServiceMock.remove).toHaveBeenCalledWith('project-1', 'cat-1', 'expense-1');
+    });
+
+    it('should show a snackbar with undo action', () => {
+      const expense = makeExpense();
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteExpense(expense);
+
+      expect(snackBarMock.open).toHaveBeenCalled();
+    });
+
+    it('should call restore API and refill data when undo is clicked', () => {
+      const actionSubject = new Subject<void>();
+      snackBarMock.open.and.returnValue({ onAction: () => actionSubject.asObservable() } as any);
+
+      const expense = makeExpense();
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteExpense(expense);
+      actionSubject.next();
+
+      expect(expenseServiceMock.restore).toHaveBeenCalledWith('project-1', 'cat-1', 'expense-1');
+      expect(expenseServiceMock.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('swipeDeleteSubExpense', () => {
+    it('should optimistically remove the sub-expense from the parent', () => {
+      const item = makeItem();
+      const expense = makeExpense({ items: [item] });
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteSubExpense(expense, item);
+
+      const remaining = (component as any).expenses.getValue() as ExpenseDto[];
+      expect(remaining[0].items.find(i => i.id === 'item-1')).toBeUndefined();
+    });
+
+    it('should call the removeItem API', () => {
+      const item = makeItem();
+      const expense = makeExpense({ items: [item] });
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteSubExpense(expense, item);
+
+      expect(expenseServiceMock.removeItem).toHaveBeenCalledWith('project-1', 'cat-1', 'expense-1', 'item-1');
+    });
+
+    it('should show a snackbar with undo action', () => {
+      const item = makeItem();
+      const expense = makeExpense({ items: [item] });
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteSubExpense(expense, item);
+
+      expect(snackBarMock.open).toHaveBeenCalled();
+    });
+
+    it('should call restoreItem API and refill data when undo is clicked', () => {
+      const actionSubject = new Subject<void>();
+      snackBarMock.open.and.returnValue({ onAction: () => actionSubject.asObservable() } as any);
+
+      const item = makeItem();
+      const expense = makeExpense({ items: [item] });
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteSubExpense(expense, item);
+      actionSubject.next();
+
+      expect(expenseServiceMock.restoreItem).toHaveBeenCalledWith('project-1', 'cat-1', 'expense-1', 'item-1');
+      expect(expenseServiceMock.get).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.ts
+++ b/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.ts
@@ -4,15 +4,16 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DateAdapter } from '@angular/material/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatCardModule } from '@angular/material/card';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { NavigationEnd, Router, UrlSegment } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { filter } from 'rxjs';
-import { ConfirmDialogComponent } from '../../../core/components/confirm-dialog/confirm-dialog.component';
 import { CurrentDateComponent } from '../../../core/components/current-date/current-date.component';
 import { ReturnButtonComponent } from '../../../core/components/return-button/return-button.component';
+import { SwipeDeleteRowComponent } from '../../../core/components/swipe-delete-row/swipe-delete-row.component';
 import { CategoryService } from '../../../core/services/category.service';
 import { CurrentDateService } from '../../../core/services/current-date.service';
 import { ExpenseService } from '../../../core/services/expense.service';
@@ -39,6 +40,7 @@ import { ExpenseItemDto } from '../models/expense-item-dto';
     CurrencyFormatPipe,
     AddExpenseComponent,
     AddExpenseItemComponent,
+    SwipeDeleteRowComponent,
     MatCardModule,
     TranslateModule
   ],
@@ -52,6 +54,7 @@ export class ListExpensesComponent implements OnInit {
   private router = inject(Router);
   private globalService = inject(GlobalService);
   private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
   private projectService = inject(ProjectService);
   private translateService = inject(TranslateService);
   private currentDateService = inject(CurrentDateService);
@@ -157,47 +160,40 @@ export class ListExpensesComponent implements OnInit {
     this.fillData(newDate);
   }
 
-  remove(id: string): void {
-    this.expenseService.remove(this.projectId, this.categoryId, id).subscribe({
-      next: () => {
-        const expensesNewArray = this.expenses
-          .getValue()
-          .filter(item => item.id !== id);
+  swipeDeleteExpense(expense: ExpenseDto): void {
+    const removed = expense;
+    this.expenses.next(this.expenses.getValue().filter(e => e.id !== removed.id));
 
-        this.expenses.next(expensesNewArray);
-      }
+    this.expenseService.remove(this.projectId, this.categoryId, removed.id).subscribe();
+
+    const undoLabel = this.translateService.instant('ButtonUndo');
+    const message = this.translateService.instant('UndoDelete');
+    const ref = this.snackBar.open(message, undoLabel, { duration: 5000 });
+
+    ref.onAction().subscribe(() => {
+      this.expenseService.restore(this.projectId, this.categoryId, removed.id).subscribe({
+        next: () => this.fillData(this.currentDateService.currentDate)
+      });
     });
   }
 
-  triggerDelete(expense: ExpenseDto): void {
-    const message = this.translateService.instant('AreYouSureYouWantDeleteExpense', { value: expense.name });
-
-    this.dialog.open(ConfirmDialogComponent, {
-      data: { title: 'DeleteExpense', message: message, action: 'ButtonDelete' },
-    }).afterClosed().subscribe((result) => {
-      if (result) {
-        this.remove(expense.id);
-      }
+  swipeDeleteSubExpense(expense: ExpenseDto, subExpense: ExpenseItemDto): void {
+    const currentExpenses = this.expenses.getValue().map(e => {
+      if (e.id !== expense.id) return e;
+      return { ...e, items: e.items.filter(i => i.id !== subExpense.id) } as ExpenseDto;
     });
-  }
+    this.expenses.next(currentExpenses);
 
-  removeSubExpense(expense: ExpenseDto, subExpense: ExpenseItemDto): void {
-    this.expenseService.removeItem(this.projectId, this.categoryId, expense.id, subExpense.id).subscribe({
-      next: () => {
-        this.fillData(this.currentDateService.currentDate);
-      }
-    });
-  }
+    this.expenseService.removeItem(this.projectId, this.categoryId, expense.id, subExpense.id).subscribe();
 
-  triggerDeleteSubExpense(expense: ExpenseDto, subExpense: ExpenseItemDto): void {
-    const message = this.translateService.instant('AreYouSureYouWantDeleteExpense', { value: subExpense.name });
+    const undoLabel = this.translateService.instant('ButtonUndo');
+    const message = this.translateService.instant('UndoDelete');
+    const ref = this.snackBar.open(message, undoLabel, { duration: 5000 });
 
-    this.dialog.open(ConfirmDialogComponent, {
-      data: { title: 'DeleteExpense', message: message, action: 'ButtonDelete' },
-    }).afterClosed().subscribe((result) => {
-      if (result) {
-        this.removeSubExpense(expense, subExpense);
-      }
+    ref.onAction().subscribe(() => {
+      this.expenseService.restoreItem(this.projectId, this.categoryId, expense.id, subExpense.id).subscribe({
+        next: () => this.fillData(this.currentDateService.currentDate)
+      });
     });
   }
 

--- a/easyfinance.client/src/app/features/income/list-incomes/list-incomes.component.html
+++ b/easyfinance.client/src/app/features/income/list-incomes/list-incomes.component.html
@@ -21,52 +21,51 @@
         <mat-card-content>
           <div class="list-group list-group-flush">
             @for (income of (incomes$ | async); track income.id) {
-              <div class="list-group-item">
+              <div class="list-group-item px-0">
                 @if (isEditingIncome(income)) {
-                  <app-add-income
-                    [projectId]="projectId"
-                    [income]="income"
-                    [inlineMode]="true"
-                    (saved)="onIncomeSaved()"
-                    (canceled)="cancelIncomeForm()">
-                  </app-add-income>
+                  <div class="px-3">
+                    <app-add-income
+                      [projectId]="projectId"
+                      [income]="income"
+                      [inlineMode]="true"
+                      (saved)="onIncomeSaved()"
+                      (canceled)="cancelIncomeForm()">
+                    </app-add-income>
+                  </div>
                 } @else {
-                  <div class="d-flex w-100 justify-content-between align-items-center">
-                    <div class="flex-grow-1">
-                      <div class="d-flex align-items-center">
-                        <div class="flex-grow-1">
-                          <h2 class="mb-1 fw-bold name">{{ income.name }}</h2>
-                          <p class="text-muted fs-6">
-                            <span class="me-3 date">
-                              <i class="bi bi-calendar me-1"></i>
-                              {{ income.date | date: 'shortDate' : undefined : currentLanguage }}
-                            </span>
-                            <span class="text-nowrap amount privacy-sensitive-value">
-                              <i class="bi bi-cash-coin me-1"></i>
-                              {{ income.amount | currencyFormat }}
-                            </span>
-                          </p>
+                  <app-swipe-delete-row
+                    [disabled]="!canAddOrEdit()"
+                    actionIcon="trash"
+                    (actionTriggered)="swipeDelete(income)">
+                    <div class="d-flex w-100 justify-content-between align-items-center px-3 py-1">
+                      <div class="flex-grow-1">
+                        <div class="d-flex align-items-center">
+                          <div class="flex-grow-1">
+                            <h2 class="mb-1 fw-bold name">{{ income.name }}</h2>
+                            <p class="text-muted fs-6">
+                              <span class="me-3 date">
+                                <i class="bi bi-calendar me-1"></i>
+                                {{ income.date | date: 'shortDate' : undefined : currentLanguage }}
+                              </span>
+                              <span class="text-nowrap amount privacy-sensitive-value">
+                                <i class="bi bi-cash-coin me-1"></i>
+                                {{ income.amount | currencyFormat }}
+                              </span>
+                            </p>
+                          </div>
                         </div>
                       </div>
-                    </div>
 
-                    @if (canAddOrEdit()) {
-                      <div class="btn-group ms-3">
+                      @if (canAddOrEdit()) {
                         <button name="edit"
-                          class="btn btn-outline-secondary"
+                          class="btn btn-outline-secondary btn-sm"
                           (click)="startEditIncome(income)"
                           aria-label="Editar receita">
                           <i class="bi bi-pencil-square"></i>
                         </button>
-                        <button name="delete"
-                          class="btn btn-outline-danger"
-                          (click)="triggerDelete(income)"
-                          aria-label="Excluir receita">
-                          <i class="bi bi-trash"></i>
-                        </button>
-                      </div>
-                    }
-                  </div>
+                      }
+                    </div>
+                  </app-swipe-delete-row>
                 }
               </div>
             }

--- a/easyfinance.client/src/app/features/income/list-incomes/list-incomes.component.spec.ts
+++ b/easyfinance.client/src/app/features/income/list-incomes/list-incomes.component.spec.ts
@@ -3,8 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NavigationEnd, Router } from '@angular/router';
 import { provideNativeDateAdapter } from '@angular/material/core';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateModule } from '@ngx-translate/core';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, Subject, of, EMPTY } from 'rxjs';
 import { PlanType } from '../../../core/enums/plan-type';
 import { Plan } from '../../../core/models/plan';
 import { CurrentDateService } from '../../../core/services/current-date.service';
@@ -46,6 +47,7 @@ describe('ListIncomesComponent', () => {
   let incomeServiceMock: jasmine.SpyObj<IncomeService>;
   let planServiceMock: jasmine.SpyObj<PlanService>;
   let dialogMock: jasmine.SpyObj<MatDialog>;
+  let snackBarMock: jasmine.SpyObj<MatSnackBar>;
 
   beforeEach(async () => {
     const routerEvents = new BehaviorSubject(new NavigationEnd(
@@ -70,7 +72,7 @@ describe('ListIncomesComponent', () => {
       }
     } as unknown as Router;
 
-    incomeServiceMock = jasmine.createSpyObj<IncomeService>('IncomeService', ['get', 'remove']);
+    incomeServiceMock = jasmine.createSpyObj<IncomeService>('IncomeService', ['get', 'remove', 'restore']);
     incomeServiceMock.get.and.returnValue(of([
       {
         id: 'income-1',
@@ -80,6 +82,10 @@ describe('ListIncomesComponent', () => {
       }
     ]));
     incomeServiceMock.remove.and.returnValue(of(true));
+    incomeServiceMock.restore.and.returnValue(of(true));
+
+    snackBarMock = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
+    snackBarMock.open.and.returnValue({ onAction: () => EMPTY } as any);
 
     planServiceMock = jasmine.createSpyObj<PlanService>('PlanService', ['getPlans']);
     planServiceMock.getPlans.and.returnValue(of([]));
@@ -103,6 +109,10 @@ describe('ListIncomesComponent', () => {
         {
           provide: MatDialog,
           useValue: dialogMock
+        },
+        {
+          provide: MatSnackBar,
+          useValue: snackBarMock
         },
         {
           provide: IncomeService,
@@ -232,5 +242,49 @@ describe('ListIncomesComponent', () => {
     component.onIncomeSaved();
 
     expect(planServiceMock.getPlans).not.toHaveBeenCalled();
+  });
+
+  describe('swipeDelete', () => {
+    it('should optimistically remove the income from the list', () => {
+      const income = makeIncome();
+      (component as any).incomes.next([income]);
+
+      component.swipeDelete(income);
+
+      const remaining = (component as any).incomes.getValue() as IncomeDto[];
+      expect(remaining.find(i => i.id === 'income-1')).toBeUndefined();
+    });
+
+    it('should call the remove API', () => {
+      const income = makeIncome();
+      (component as any).incomes.next([income]);
+
+      component.swipeDelete(income);
+
+      expect(incomeServiceMock.remove).toHaveBeenCalledWith('project-1', 'income-1');
+    });
+
+    it('should show a snackbar with undo action', () => {
+      const income = makeIncome();
+      (component as any).incomes.next([income]);
+
+      component.swipeDelete(income);
+
+      expect(snackBarMock.open).toHaveBeenCalled();
+    });
+
+    it('should call restore API and refill data when undo is clicked', () => {
+      const actionSubject = new Subject<void>();
+      snackBarMock.open.and.returnValue({ onAction: () => actionSubject.asObservable() } as any);
+
+      const income = makeIncome();
+      (component as any).incomes.next([income]);
+
+      component.swipeDelete(income);
+      actionSubject.next();
+
+      expect(incomeServiceMock.restore).toHaveBeenCalledWith('project-1', 'income-1');
+      expect(incomeServiceMock.get).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/easyfinance.client/src/app/features/income/list-incomes/list-incomes.component.ts
+++ b/easyfinance.client/src/app/features/income/list-incomes/list-incomes.component.ts
@@ -3,7 +3,9 @@ import { Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DateAdapter } from '@angular/material/core';
 import { MatCardModule } from '@angular/material/card';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { NavigationEnd, Router, UrlSegment } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, Observable, filter, map } from 'rxjs';
@@ -15,10 +17,10 @@ import { IncomeService } from '../../../core/services/income.service';
 import { PlanService } from '../../../core/services/plan.service';
 import { ProjectService } from '../../../core/services/project.service';
 import { CurrencyFormatPipe } from '../../../core/utils/pipes/currency-format.pipe';
-import { ConfirmDialogComponent } from '../../../core/components/confirm-dialog/confirm-dialog.component';
 import { CurrentDateComponent } from '../../../core/components/current-date/current-date.component';
 import { PageModalComponent, PageModalDialogData } from '../../../core/components/page-modal/page-modal.component';
 import { ReturnButtonComponent } from '../../../core/components/return-button/return-button.component';
+import { SwipeDeleteRowComponent } from '../../../core/components/swipe-delete-row/swipe-delete-row.component';
 import { UserProjectDto } from '../../project/models/user-project-dto';
 import { AddIncomeComponent } from '../add-income/add-income.component';
 import { PlanAllocationDialogComponent } from '../plan-allocation-dialog/plan-allocation-dialog.component';
@@ -34,6 +36,7 @@ import { IncomeDto } from '../models/income-dto';
     CurrentDateComponent,
     CurrencyFormatPipe,
     AddIncomeComponent,
+    SwipeDeleteRowComponent,
     TranslateModule
   ],
   templateUrl: './list-incomes.component.html',
@@ -46,6 +49,7 @@ export class ListIncomesComponent implements OnInit {
   private router = inject(Router);
   private globalService = inject(GlobalService);
   private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
   private projectService = inject(ProjectService);
   private translateService = inject(TranslateService);
   private currentDateService = inject(CurrentDateService);
@@ -58,7 +62,6 @@ export class ListIncomesComponent implements OnInit {
 
   isCreatingIncome = false;
   editingIncomeId: string | null = null;
-  itemToDelete!: string;
   currentLanguage = this.globalService.currentLanguage;
   userProject!: UserProjectDto;
 
@@ -154,27 +157,21 @@ export class ListIncomesComponent implements OnInit {
     return this.editingIncomeId === income.id;
   }
 
-  remove(id: string): void {
-    this.incomeService.remove(this.projectId, id).subscribe({
-      next: () => {
-        const incomesNewArray = this.incomes
-          .getValue()
-          .filter(item => item.id !== id);
-        this.incomes.next(incomesNewArray);
-      }
-    });
-  }
+  swipeDelete(income: IncomeDto): void {
+    const removed = income;
+    const currentList = this.incomes.getValue();
+    this.incomes.next(currentList.filter(i => i.id !== removed.id));
 
-  triggerDelete(income: IncomeDto): void {
-    this.itemToDelete = income.id;
-    const message = this.translateService.instant('AreYouSureYouWantDeleteIncome', { value: income.name });
+    this.incomeService.remove(this.projectId, removed.id).subscribe();
 
-    this.dialog.open(ConfirmDialogComponent, {
-      data: { title: 'DeleteIncome', message, action: 'ButtonDelete' },
-    }).afterClosed().subscribe((result) => {
-      if (result) {
-        this.remove(this.itemToDelete);
-      }
+    const undoLabel = this.translateService.instant('ButtonUndo');
+    const message = this.translateService.instant('UndoDelete');
+    const ref = this.snackBar.open(message, undoLabel, { duration: 5000 });
+
+    ref.onAction().subscribe(() => {
+      this.incomeService.restore(this.projectId, removed.id).subscribe({
+        next: () => this.fillData(this.currentDateService.currentDate)
+      });
     });
   }
 

--- a/easyfinance.client/src/assets/i18n/messages.en.json
+++ b/easyfinance.client/src/assets/i18n/messages.en.json
@@ -470,5 +470,8 @@
   "PlanAllocationError": "Failed to allocate to plan. Please try again.",
   "PlanAllocationNote": "Allocation from income: {{value}}",
   "BUDGET_OVERFLOW": "Budget for '{{ expenseName }}' in project '{{ projectName }}' has been exceeded!",
-  "BUDGET_WARNING": "Warning: Budget for '{{ expenseName }}' in project '{{ projectName }}' is nearly exhausted (80%)."
+  "BUDGET_WARNING": "Warning: Budget for '{{ expenseName }}' in project '{{ projectName }}' is nearly exhausted (80%).",
+  "UndoDelete": "Deleted. Undo?",
+  "UndoArchive": "Archived. Undo?",
+  "ButtonUndo": "Undo"
 }

--- a/easyfinance.client/src/assets/i18n/messages.pt.json
+++ b/easyfinance.client/src/assets/i18n/messages.pt.json
@@ -469,6 +469,9 @@
   "PlanAllocationError": "Falha ao alocar ao plano. Por favor, tente novamente.",
   "PlanAllocationNote": "Alocação da receita: {{value}}",
   "BUDGET_OVERFLOW": "O orçamento de '{{ expenseName }}' no projeto '{{ projectName }}' foi excedido!",
-  "BUDGET_WARNING": "Aviso: O orçamento de '{{ expenseName }}' no projeto '{{ projectName }}' está quase esgotado (80%)."
+  "BUDGET_WARNING": "Aviso: O orçamento de '{{ expenseName }}' no projeto '{{ projectName }}' está quase esgotado (80%).",
+  "UndoDelete": "Excluído. Desfazer?",
+  "UndoArchive": "Arquivado. Desfazer?",
+  "ButtonUndo": "Desfazer"
 }
 

--- a/easyfinance.client/src/assets/version.json
+++ b/easyfinance.client/src/assets/version.json
@@ -1,3 +1,3 @@
 {
-  "versionNumber": "1.1.61"
+  "versionNumber": "1.1.62"
 }

--- a/econoflow-mobile/package-lock.json
+++ b/econoflow-mobile/package-lock.json
@@ -57,7 +57,6 @@
         "jest": "^29.7.0",
         "jest-expo": "~56.0.0",
         "lint-staged": "^17.0.7",
-        "react-test-renderer": "^19.2.7",
         "test-renderer": "^1.2.0"
       }
     },
@@ -473,7 +472,7 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -486,7 +485,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -499,7 +498,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -512,7 +511,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -585,7 +584,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
       "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -601,7 +600,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -614,7 +613,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -642,7 +641,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -667,7 +666,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -680,7 +679,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -693,7 +692,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -718,7 +717,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -734,7 +733,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2227,7 +2226,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -2244,7 +2243,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -2254,7 +2253,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2264,7 +2263,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -2278,7 +2277,7 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2292,7 +2291,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -2305,7 +2304,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -2321,7 +2320,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -2334,7 +2333,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
       "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2426,7 +2425,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
       "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3"
@@ -2449,7 +2448,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -2492,7 +2491,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -2709,7 +2708,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -3131,7 +3130,7 @@
       "version": "0.85.3",
       "resolved": "https://registry.npmjs.org/@react-native/jest-preset/-/jest-preset-0.85.3.tgz",
       "integrity": "sha512-ALPSrM0q2fU+5AXcOXzDKx7rxVKPMvygAZfsTWLdrGRVWIqf/HEfM0R8euQqIKUqmEuQ1TxMWN+px3h6gc4vow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
@@ -3661,7 +3660,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -3671,7 +3670,7 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -3849,7 +3848,7 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -3863,7 +3862,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -3873,7 +3872,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -3884,7 +3883,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -3914,7 +3913,7 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4084,7 +4083,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
@@ -4846,7 +4845,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5107,7 +5106,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -5129,7 +5128,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -5146,7 +5145,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -5258,7 +5257,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -5285,7 +5284,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -5923,7 +5922,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/connect": {
@@ -7588,7 +7587,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -8351,7 +8350,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8602,7 +8601,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -8729,7 +8728,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -9334,7 +9333,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -9355,7 +9354,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -9900,7 +9899,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -9910,7 +9909,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -9927,7 +9926,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10306,7 +10305,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -10392,7 +10391,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -10448,7 +10447,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -10469,7 +10468,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -10502,7 +10501,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -12676,7 +12675,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12907,7 +12906,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -13132,7 +13131,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13208,7 +13207,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13218,7 +13217,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13286,7 +13285,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -13988,27 +13987,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/react-test-renderer": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
-      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^19.2.7",
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -14797,7 +14775,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14908,7 +14886,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
@@ -14932,7 +14910,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -14945,7 +14923,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15331,7 +15309,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -15346,14 +15324,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15365,7 +15343,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15386,7 +15364,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -15603,7 +15581,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16199,14 +16177,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",

--- a/econoflow-mobile/package-lock.json
+++ b/econoflow-mobile/package-lock.json
@@ -43,6 +43,7 @@
       "devDependencies": {
         "@expo/ngrok": "^4.1.3",
         "@react-native/jest-preset": "^0.85.3",
+        "@testing-library/react-native": "^14.0.0",
         "@types/jest": "29.5.14",
         "@types/node": "^25.9.1",
         "@types/react-native-vector-icons": "^6.4.18",
@@ -55,7 +56,9 @@
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-expo": "~56.0.0",
-        "lint-staged": "^17.0.7"
+        "lint-staged": "^17.0.7",
+        "react-test-renderer": "^19.2.7",
+        "test-renderer": "^1.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2432,6 +2435,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2491,6 +2504,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -3693,6 +3716,114 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-14.0.0.tgz",
+      "integrity": "sha512-Ji+mmlvWp9kTOhqWIskVfCQ05LdmsS3NN6PtG8blYHyd5yLvghSsul5QS4ci01Fw65H9oa6slj9PEOyoogj1VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.4.1",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.4.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=19.0.0",
+        "react-native": ">=0.78",
+        "test-renderer": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
@@ -3927,6 +4058,16 @@
       },
       "peerDependencies": {
         "react-native": "*"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -9199,6 +9340,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -10205,6 +10356,27 @@
         "react-server-dom-webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-expo/node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-expo/node_modules/react-test-renderer": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
+      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.3",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
       }
     },
     "node_modules/jest-get-type": {
@@ -12241,6 +12413,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -13559,6 +13741,22 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-native": {
       "version": "0.85.3",
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.3.tgz",
@@ -13766,6 +13964,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -13776,25 +13990,39 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
-      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
+      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.7",
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -14983,6 +15211,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -15152,6 +15393,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/test-renderer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/test-renderer/-/test-renderer-1.2.0.tgz",
+      "integrity": "sha512-JYiEGbgBGtmHAWX8Kf99gGRL1HtjcRVHLrmJNTZL4vFs9XrnWcuL45Iszw/pO4094+JR7havSrN+ds6YTOpSQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "~0.33.0",
+        "react-reconciler": "~0.33.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/text-table": {

--- a/econoflow-mobile/package-lock.json
+++ b/econoflow-mobile/package-lock.json
@@ -42,6 +42,7 @@
       },
       "devDependencies": {
         "@expo/ngrok": "^4.1.3",
+        "@react-native/jest-preset": "^0.85.3",
         "@types/jest": "29.5.14",
         "@types/node": "^25.9.1",
         "@types/react-native-vector-icons": "^6.4.18",
@@ -52,6 +53,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "husky": "^9.1.7",
+        "jest": "^29.7.0",
         "jest-expo": "~56.0.0",
         "lint-staged": "^17.0.7"
       }
@@ -468,7 +470,7 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -481,7 +483,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -494,7 +496,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -507,7 +509,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -580,7 +582,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
       "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -596,7 +598,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -609,7 +611,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -637,7 +639,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -662,7 +664,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -675,7 +677,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -688,7 +690,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -713,7 +715,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -729,7 +731,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1287,8 +1289,7 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@callstack/react-theme-provider": {
       "version": "3.0.9",
@@ -2223,7 +2224,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -2240,7 +2241,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -2250,7 +2251,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2260,7 +2261,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -2274,7 +2275,7 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2288,7 +2289,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -2301,7 +2302,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -2317,7 +2318,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -2330,7 +2331,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
       "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2360,7 +2361,6 @@
       "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/reporters": "^29.7.0",
@@ -2415,7 +2415,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2424,7 +2423,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
       "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3"
@@ -2437,28 +2436,13 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/environment/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2495,7 +2479,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -2503,21 +2487,6 @@
         "@types/node": "*",
         "jest-message-util": "^29.7.0",
         "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
         "jest-util": "^29.7.0"
       },
       "engines": {
@@ -2540,28 +2509,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/globals/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "^29.7.0",
@@ -2605,8 +2558,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -2614,7 +2566,6 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2627,7 +2578,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2649,7 +2599,6 @@
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -2667,7 +2616,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2693,7 +2641,6 @@
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
@@ -2725,7 +2672,6 @@
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
@@ -2740,7 +2686,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -3162,9 +3108,8 @@
       "version": "0.85.3",
       "resolved": "https://registry.npmjs.org/@react-native/jest-preset/-/jest-preset-0.85.3.tgz",
       "integrity": "sha512-ALPSrM0q2fU+5AXcOXzDKx7rxVKPMvygAZfsTWLdrGRVWIqf/HEfM0R8euQqIKUqmEuQ1TxMWN+px3h6gc4vow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/js-polyfills": "0.85.3",
@@ -3693,7 +3638,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -3703,7 +3648,7 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -3773,7 +3718,7 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -3787,7 +3732,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -3797,7 +3742,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -3808,7 +3753,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -3838,7 +3783,7 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3998,7 +3943,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
@@ -4760,7 +4705,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5021,7 +4966,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -5043,7 +4988,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -5060,7 +5005,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -5172,7 +5117,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -5199,7 +5144,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -5574,8 +5519,7 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
@@ -5706,7 +5650,6 @@
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -5839,7 +5782,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/connect": {
@@ -5897,7 +5840,6 @@
       "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
@@ -6154,7 +6096,6 @@
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -6281,7 +6222,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6492,7 +6432,6 @@
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -6502,8 +6441,7 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
@@ -7509,7 +7447,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7596,7 +7534,6 @@
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -7621,7 +7558,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7632,7 +7568,6 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -7648,7 +7583,6 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -8276,7 +8210,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8527,7 +8461,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -8654,7 +8588,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -8679,7 +8613,6 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9016,8 +8949,7 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
@@ -9125,7 +9057,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10.17.0"
       }
@@ -9244,7 +9175,6 @@
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -9263,7 +9193,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -9274,7 +9204,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -9517,7 +9447,6 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9687,7 +9616,6 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -9821,7 +9749,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -9831,7 +9759,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -9848,7 +9776,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9860,7 +9788,6 @@
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -9876,7 +9803,6 @@
       "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
@@ -9892,7 +9818,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9903,7 +9828,6 @@
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -9936,7 +9860,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9964,7 +9887,6 @@
       "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "execa": "^5.0.0",
         "jest-util": "^29.7.0",
@@ -9980,7 +9902,6 @@
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -10013,7 +9934,6 @@
       "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/test-result": "^29.7.0",
@@ -10048,7 +9968,6 @@
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/test-sequencer": "^29.7.0",
@@ -10094,8 +10013,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -10103,7 +10021,6 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10121,7 +10038,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10133,7 +10049,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10155,7 +10070,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10185,7 +10099,6 @@
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -10199,7 +10112,6 @@
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
@@ -10239,50 +10151,18 @@
         }
       }
     },
-    "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
         "jest-util": "^29.7.0"
       },
       "engines": {
@@ -10340,7 +10220,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -10368,7 +10248,6 @@
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-get-type": "^29.6.3",
         "pretty-format": "^29.7.0"
@@ -10397,7 +10276,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -10414,13 +10293,27 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -10437,7 +10330,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10449,7 +10342,6 @@
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -10471,7 +10363,6 @@
       "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-regex-util": "^29.6.3",
         "jest-snapshot": "^29.7.0"
@@ -10486,7 +10377,6 @@
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -10520,7 +10410,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10531,7 +10420,6 @@
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -10543,7 +10431,6 @@
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -10577,8 +10464,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -10586,7 +10472,6 @@
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10599,7 +10484,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10615,29 +10499,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jest-runtime/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10651,7 +10518,6 @@
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11066,8 +10932,7 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -11450,8 +11315,7 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "17.0.7",
@@ -11963,7 +11827,6 @@
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -12631,7 +12494,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12671,7 +12534,6 @@
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -12863,7 +12725,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -13088,7 +12950,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13113,7 +12975,6 @@
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -13165,7 +13026,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13175,7 +13036,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13243,7 +13104,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -13255,7 +13116,6 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -13269,7 +13129,6 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -13284,7 +13143,6 @@
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -13298,7 +13156,6 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -13315,7 +13172,6 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -13544,8 +13400,7 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/query-string": {
       "version": "7.1.3",
@@ -14094,7 +13949,6 @@
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -14133,7 +13987,6 @@
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -14716,7 +14569,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14827,7 +14680,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
@@ -14851,7 +14704,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -14864,7 +14717,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15126,7 +14979,6 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -15238,7 +15090,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -15253,14 +15105,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15272,7 +15124,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15293,7 +15145,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -15496,7 +15348,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -15818,7 +15670,6 @@
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -16093,14 +15944,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",

--- a/econoflow-mobile/package.json
+++ b/econoflow-mobile/package.json
@@ -68,6 +68,7 @@
   "private": true,
   "devDependencies": {
     "@expo/ngrok": "^4.1.3",
+    "@react-native/jest-preset": "^0.85.3",
     "@types/jest": "29.5.14",
     "@types/node": "^25.9.1",
     "@types/react-native-vector-icons": "^6.4.18",
@@ -78,6 +79,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "husky": "^9.1.7",
+    "jest": "^29.7.0",
     "jest-expo": "~56.0.0",
     "lint-staged": "^17.0.7"
   }

--- a/econoflow-mobile/package.json
+++ b/econoflow-mobile/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@expo/ngrok": "^4.1.3",
     "@react-native/jest-preset": "^0.85.3",
+    "@testing-library/react-native": "^14.0.0",
     "@types/jest": "29.5.14",
     "@types/node": "^25.9.1",
     "@types/react-native-vector-icons": "^6.4.18",
@@ -81,6 +82,8 @@
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-expo": "~56.0.0",
-    "lint-staged": "^17.0.7"
+    "lint-staged": "^17.0.7",
+    "react-test-renderer": "^19.2.7",
+    "test-renderer": "^1.2.0"
   }
 }

--- a/econoflow-mobile/package.json
+++ b/econoflow-mobile/package.json
@@ -83,7 +83,6 @@
     "jest": "^29.7.0",
     "jest-expo": "~56.0.0",
     "lint-staged": "^17.0.7",
-    "react-test-renderer": "^19.2.7",
     "test-renderer": "^1.2.0"
   }
 }

--- a/econoflow-mobile/src/api/__tests__/restoreApi.test.ts
+++ b/econoflow-mobile/src/api/__tests__/restoreApi.test.ts
@@ -1,0 +1,49 @@
+import { restoreIncome } from '../incomes.api';
+import { restoreExpense, restoreExpenseItem } from '../expenses.api';
+import { unarchiveCategory } from '../categories.api';
+import { apiClient } from '../client';
+
+jest.mock('../client', () => ({
+  apiClient: {
+    put: jest.fn(),
+  },
+}));
+
+const mockPut = apiClient.put as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPut.mockResolvedValue({ data: undefined, status: 204 });
+});
+
+describe('restoreIncome', () => {
+  it('calls PUT on the restore endpoint', () => {
+    restoreIncome('proj-1', 'income-1');
+    expect(mockPut).toHaveBeenCalledWith('/api/Projects/proj-1/Incomes/income-1/restore');
+  });
+});
+
+describe('restoreExpense', () => {
+  it('calls PUT on the restore endpoint', () => {
+    restoreExpense('proj-1', 'cat-1', 'exp-1');
+    expect(mockPut).toHaveBeenCalledWith(
+      '/api/Projects/proj-1/Categories/cat-1/Expenses/exp-1/restore'
+    );
+  });
+});
+
+describe('restoreExpenseItem', () => {
+  it('calls PUT on the restore endpoint', () => {
+    restoreExpenseItem('proj-1', 'cat-1', 'exp-1', 'item-1');
+    expect(mockPut).toHaveBeenCalledWith(
+      '/api/Projects/proj-1/Categories/cat-1/Expenses/exp-1/ExpenseItems/item-1/restore'
+    );
+  });
+});
+
+describe('unarchiveCategory', () => {
+  it('calls PUT on the unarchive endpoint', () => {
+    unarchiveCategory('proj-1', 'cat-1');
+    expect(mockPut).toHaveBeenCalledWith('/api/Projects/proj-1/Categories/cat-1/Unarchive');
+  });
+});

--- a/econoflow-mobile/src/api/categories.api.ts
+++ b/econoflow-mobile/src/api/categories.api.ts
@@ -14,3 +14,6 @@ export const patchCategory = (projectId: string, id: string, ops: PatchOperation
 
 export const archiveCategory = (projectId: string, id: string) =>
   apiClient.put(`/api/Projects/${projectId}/Categories/${id}/Archive`);
+
+export const unarchiveCategory = (projectId: string, id: string) =>
+  apiClient.put(`/api/Projects/${projectId}/Categories/${id}/Unarchive`);

--- a/econoflow-mobile/src/api/expenses.api.ts
+++ b/econoflow-mobile/src/api/expenses.api.ts
@@ -39,3 +39,16 @@ export const deleteExpenseItem = (
   apiClient.delete(
     `/api/Projects/${projectId}/Categories/${categoryId}/Expenses/${expenseId}/ExpenseItems/${expenseItemId}`
   );
+
+export const restoreExpense = (projectId: string, categoryId: string, id: string) =>
+  apiClient.put(`/api/Projects/${projectId}/Categories/${categoryId}/Expenses/${id}/restore`);
+
+export const restoreExpenseItem = (
+  projectId: string,
+  categoryId: string,
+  expenseId: string,
+  expenseItemId: string
+) =>
+  apiClient.put(
+    `/api/Projects/${projectId}/Categories/${categoryId}/Expenses/${expenseId}/ExpenseItems/${expenseItemId}/restore`
+  );

--- a/econoflow-mobile/src/api/incomes.api.ts
+++ b/econoflow-mobile/src/api/incomes.api.ts
@@ -14,3 +14,6 @@ export const patchIncome = (projectId: string, id: string, ops: PatchOperation[]
 
 export const deleteIncome = (projectId: string, id: string) =>
   apiClient.delete(`/api/Projects/${projectId}/Incomes/${id}`);
+
+export const restoreIncome = (projectId: string, id: string) =>
+  apiClient.put(`/api/Projects/${projectId}/Incomes/${id}/restore`);

--- a/econoflow-mobile/src/components/common/SwipeableRow.tsx
+++ b/econoflow-mobile/src/components/common/SwipeableRow.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Animated,
+  PanResponder,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+const ACTION_WIDTH = 72;
+const THRESHOLD = 40;
+
+interface Props {
+  onAction: () => void;
+  actionIcon: 'trash-can-outline' | 'archive-outline';
+  actionColor: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+export const SwipeableRow: React.FC<Props> = ({
+  onAction,
+  actionIcon,
+  actionColor,
+  disabled = false,
+  children,
+}) => {
+  const [translateX] = useState(() => new Animated.Value(0));
+
+  const close = useCallback(() => {
+    Animated.spring(translateX, {
+      toValue: 0,
+      useNativeDriver: true,
+      tension: 100,
+      friction: 10,
+    }).start();
+  }, [translateX]);
+
+  const panResponder = useMemo(() => {
+    const offset = { current: 0 };
+
+    const springTo = (value: number) => {
+      Animated.spring(translateX, {
+        toValue: value,
+        useNativeDriver: true,
+        tension: 100,
+        friction: 10,
+      }).start();
+    };
+
+    const doClose = () => springTo(0);
+
+    return PanResponder.create({
+      onMoveShouldSetPanResponder: (_evt, gesture) =>
+        !disabled &&
+        Math.abs(gesture.dx) > 5 &&
+        Math.abs(gesture.dx) > Math.abs(gesture.dy),
+      onPanResponderGrant: () => {
+        translateX.stopAnimation(value => {
+          offset.current = value;
+        });
+      },
+      onPanResponderMove: (_evt, gesture) => {
+        const newX = Math.max(-ACTION_WIDTH, Math.min(0, offset.current + gesture.dx));
+        translateX.setValue(newX);
+      },
+      onPanResponderRelease: (_evt, gesture) => {
+        const newX = Math.max(-ACTION_WIDTH, Math.min(0, offset.current + gesture.dx));
+        if (newX < -THRESHOLD) {
+          springTo(-ACTION_WIDTH);
+        } else {
+          doClose();
+        }
+      },
+      onPanResponderTerminate: () => doClose(),
+    });
+  }, [translateX, disabled]);
+
+  return (
+    <Animated.View
+      style={[styles.container, { transform: [{ translateX }] }]}
+      {...panResponder.panHandlers}
+    >
+      {children}
+      <TouchableOpacity
+        onPress={() => { close(); onAction(); }}
+        style={[styles.actionBtn, { backgroundColor: actionColor, right: -ACTION_WIDTH }]}
+        activeOpacity={0.8}
+      >
+        <MaterialCommunityIcons name={actionIcon as never} size={20} color="#fff" />
+      </TouchableOpacity>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+  actionBtn: {
+    position: 'absolute',
+    top: '50%',
+    width: ACTION_WIDTH - 16,
+    height: ACTION_WIDTH - 16,
+    marginTop: -(ACTION_WIDTH - 16) / 2,
+    borderRadius: (ACTION_WIDTH - 16) / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/econoflow-mobile/src/components/common/SwipeableRow.tsx
+++ b/econoflow-mobile/src/components/common/SwipeableRow.tsx
@@ -4,6 +4,7 @@ import {
   PanResponder,
   StyleSheet,
   TouchableOpacity,
+  View,
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useAppTheme } from '../../theme/useAppTheme';
@@ -79,34 +80,41 @@ export const SwipeableRow: React.FC<Props> = ({
   }, [translateX, disabled]);
 
   return (
-    <Animated.View
-      style={[styles.container, { transform: [{ translateX }] }]}
-      {...panResponder.panHandlers}
-    >
-      {children}
+    // Outer wrapper clips the sliding content and hosts the action button at a
+    // fixed layout position so React Native's hit-test (which uses pre-transform
+    // coordinates) can reach it after the content slides away.
+    <View style={styles.wrapper}>
       <TouchableOpacity
         onPress={() => { close(); onAction(); }}
-        style={[styles.actionBtn, { backgroundColor: actionColor, right: -ACTION_WIDTH }]}
+        style={[styles.actionBtn, { backgroundColor: actionColor }]}
         activeOpacity={0.8}
       >
         <MaterialCommunityIcons name={actionIcon as never} size={20} color={colors.surface} />
       </TouchableOpacity>
-    </Animated.View>
+      <Animated.View
+        style={[styles.content, { transform: [{ translateX }] }]}
+        {...panResponder.panHandlers}
+      >
+        {children}
+      </Animated.View>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
+  wrapper: {
+    overflow: 'hidden',
   },
   actionBtn: {
     position: 'absolute',
-    top: '50%',
-    width: ACTION_WIDTH - 16,
-    height: ACTION_WIDTH - 16,
-    marginTop: -(ACTION_WIDTH - 16) / 2,
-    borderRadius: (ACTION_WIDTH - 16) / 2,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: ACTION_WIDTH,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  content: {
+    backgroundColor: 'transparent',
   },
 });

--- a/econoflow-mobile/src/components/common/SwipeableRow.tsx
+++ b/econoflow-mobile/src/components/common/SwipeableRow.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useAppTheme } from '../../theme/useAppTheme';
 
 const ACTION_WIDTH = 72;
 const THRESHOLD = 40;
@@ -25,6 +26,7 @@ export const SwipeableRow: React.FC<Props> = ({
   disabled = false,
   children,
 }) => {
+  const { colors } = useAppTheme();
   const [translateX] = useState(() => new Animated.Value(0));
 
   const close = useCallback(() => {
@@ -87,7 +89,7 @@ export const SwipeableRow: React.FC<Props> = ({
         style={[styles.actionBtn, { backgroundColor: actionColor, right: -ACTION_WIDTH }]}
         activeOpacity={0.8}
       >
-        <MaterialCommunityIcons name={actionIcon as never} size={20} color="#fff" />
+        <MaterialCommunityIcons name={actionIcon as never} size={20} color={colors.surface} />
       </TouchableOpacity>
     </Animated.View>
   );

--- a/econoflow-mobile/src/components/common/UndoToast.tsx
+++ b/econoflow-mobile/src/components/common/UndoToast.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useTranslation } from 'react-i18next';
+import { useAppTheme } from '../../theme/useAppTheme';
+
+const DURATION = 5000;
+
+interface Props {
+  message: string;
+  visible: boolean;
+  onUndo: () => void;
+  onDismiss: () => void;
+}
+
+export const UndoToast: React.FC<Props> = ({ message, visible, onUndo, onDismiss }) => {
+  const { t } = useTranslation();
+  const { colors } = useAppTheme();
+  const [opacity] = useState(() => new Animated.Value(0));
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => onDismiss(), DURATION);
+    } else {
+      Animated.timing(opacity, {
+        toValue: 0,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+    }
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [visible, opacity, onDismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.container, { opacity, backgroundColor: colors.onSurface }]}>
+      <Text style={[styles.message, { color: colors.surface }]}>{message}</Text>
+      <TouchableOpacity onPress={() => { onUndo(); onDismiss(); }} hitSlop={8}>
+        <Text style={[styles.undoBtn, { color: colors.primary }]}>
+          {t('ButtonUndo')}
+        </Text>
+      </TouchableOpacity>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 16,
+    left: 16,
+    right: 16,
+    borderRadius: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    elevation: 6,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    zIndex: 9999,
+  },
+  message: { flex: 1, fontSize: 14 },
+  undoBtn: { fontSize: 14, fontWeight: '700', marginLeft: 16 },
+});

--- a/econoflow-mobile/src/components/common/UndoToast.tsx
+++ b/econoflow-mobile/src/components/common/UndoToast.tsx
@@ -45,7 +45,7 @@ export const UndoToast: React.FC<Props> = ({ message, visible, onUndo, onDismiss
   if (!visible) return null;
 
   return (
-    <Animated.View style={[styles.container, { opacity, backgroundColor: colors.onSurface }]}>
+    <Animated.View style={[styles.container, { opacity, backgroundColor: colors.onSurface, shadowColor: colors.shadow }]}>
       <Text style={[styles.message, { color: colors.surface }]}>{message}</Text>
       <TouchableOpacity onPress={() => { onUndo(); onDismiss(); }} hitSlop={8}>
         <Text style={[styles.undoBtn, { color: colors.primary }]}>
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     elevation: 6,
-    shadowColor: '#000',
+    shadowColor: 'transparent',
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.25,
     shadowRadius: 4,

--- a/econoflow-mobile/src/components/common/__tests__/SwipeableRow.test.tsx
+++ b/econoflow-mobile/src/components/common/__tests__/SwipeableRow.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { SwipeableRow } from '../SwipeableRow';
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { surface: '#ffffff', shadow: '#000000' },
+    customColors: {},
+  }),
+}));
+
+describe('SwipeableRow', () => {
+  it('is a React component function', () => {
+    expect(typeof SwipeableRow).toBe('function');
+  });
+
+  it('accepts trash-can-outline and archive-outline as actionIcon', () => {
+    const validIcons: React.ComponentProps<typeof SwipeableRow>['actionIcon'][] = [
+      'trash-can-outline',
+      'archive-outline',
+    ];
+    validIcons.forEach(icon => {
+      expect(() => {
+        // Verify the prop type is accepted (compile-time check backed by runtime test)
+        const props: React.ComponentProps<typeof SwipeableRow> = {
+          onAction: jest.fn(),
+          actionIcon: icon,
+          actionColor: '#ff0000',
+          children: React.createElement(React.Fragment),
+        };
+        expect(props.actionIcon).toBe(icon);
+      }).not.toThrow();
+    });
+  });
+
+  it('onAction callback is callable', () => {
+    const onAction = jest.fn();
+    const props: React.ComponentProps<typeof SwipeableRow> = {
+      onAction,
+      actionIcon: 'trash-can-outline',
+      actionColor: '#ff0000',
+      children: React.createElement(React.Fragment),
+    };
+    props.onAction();
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/econoflow-mobile/src/components/common/__tests__/UndoToast.test.tsx
+++ b/econoflow-mobile/src/components/common/__tests__/UndoToast.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { UndoToast } from '../UndoToast';
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: {
+      onSurface: '#0d2137',
+      surface: '#ffffff',
+      primary: '#0f76a8',
+      shadow: '#000000',
+    },
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+describe('UndoToast', () => {
+  it('is a React component function', () => {
+    expect(typeof UndoToast).toBe('function');
+  });
+
+  it('accepts visible, message, onUndo, and onDismiss props', () => {
+    const onUndo = jest.fn();
+    const onDismiss = jest.fn();
+    const props: React.ComponentProps<typeof UndoToast> = {
+      visible: true,
+      message: 'Deleted. Undo?',
+      onUndo,
+      onDismiss,
+    };
+    expect(props.visible).toBe(true);
+    expect(props.message).toBe('Deleted. Undo?');
+    expect(typeof props.onUndo).toBe('function');
+    expect(typeof props.onDismiss).toBe('function');
+  });
+
+  it('onUndo callback is callable', () => {
+    const onUndo = jest.fn();
+    onUndo();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('onDismiss callback is callable', () => {
+    const onDismiss = jest.fn();
+    onDismiss();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/econoflow-mobile/src/hooks/useCategories.ts
+++ b/econoflow-mobile/src/hooks/useCategories.ts
@@ -1,4 +1,4 @@
-import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import * as CategoriesApi from '../api/categories.api';
 import { monthStart, monthEnd } from '../utils/date';
 
@@ -12,5 +12,25 @@ export const useCategoriesForMonth = (projectId: string, month: string) => {
     enabled: !!projectId,
     staleTime: 30_000,
     placeholderData: keepPreviousData,
+  });
+};
+
+export const useArchiveCategory = (projectId: string, month: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (categoryId: string) => CategoriesApi.archiveCategory(projectId, categoryId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories', projectId, month] });
+    },
+  });
+};
+
+export const useUnarchiveCategory = (projectId: string, month: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (categoryId: string) => CategoriesApi.unarchiveCategory(projectId, categoryId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories', projectId, month] });
+    },
   });
 };

--- a/econoflow-mobile/src/hooks/useExpenses.ts
+++ b/econoflow-mobile/src/hooks/useExpenses.ts
@@ -98,3 +98,27 @@ export const useDeleteExpenseItem = (projectId: string, categoryId: string, mont
     },
   });
 };
+
+export const useRestoreExpense = (projectId: string, categoryId: string, month: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (expenseId: string) =>
+      ExpensesApi.restoreExpense(projectId, categoryId, expenseId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['expenses', projectId, categoryId, month] });
+      queryClient.invalidateQueries({ queryKey: ['categories', projectId, month] });
+    },
+  });
+};
+
+export const useRestoreExpenseItem = (projectId: string, categoryId: string, month: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ expenseId, expenseItemId }: { expenseId: string; expenseItemId: string }) =>
+      ExpensesApi.restoreExpenseItem(projectId, categoryId, expenseId, expenseItemId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['expenses', projectId, categoryId, month] });
+      queryClient.invalidateQueries({ queryKey: ['categories', projectId, month] });
+    },
+  });
+};

--- a/econoflow-mobile/src/hooks/useIncomes.ts
+++ b/econoflow-mobile/src/hooks/useIncomes.ts
@@ -47,3 +47,13 @@ export const useDeleteIncome = (projectId: string, month: string) => {
     },
   });
 };
+
+export const useRestoreIncome = (projectId: string, month: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (incomeId: string) => IncomesApi.restoreIncome(projectId, incomeId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['incomes', projectId, month] });
+    },
+  });
+};

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -91,4 +91,28 @@ describe('i18n locale completeness', () => {
   it('pt.json contains PlaceholderItemWithoutName', () => {
     expect((pt as LocaleMap)['PlaceholderItemWithoutName']).toBeTruthy();
   });
+
+  it('en.json contains LabelUndoDelete', () => {
+    expect((en as LocaleMap)['LabelUndoDelete']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelUndoDelete', () => {
+    expect((pt as LocaleMap)['LabelUndoDelete']).toBeTruthy();
+  });
+
+  it('en.json contains LabelUndoArchive', () => {
+    expect((en as LocaleMap)['LabelUndoArchive']).toBeTruthy();
+  });
+
+  it('pt.json contains LabelUndoArchive', () => {
+    expect((pt as LocaleMap)['LabelUndoArchive']).toBeTruthy();
+  });
+
+  it('en.json contains ButtonUndo', () => {
+    expect((en as LocaleMap)['ButtonUndo']).toBeTruthy();
+  });
+
+  it('pt.json contains ButtonUndo', () => {
+    expect((pt as LocaleMap)['ButtonUndo']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -555,5 +555,8 @@
   "LabelSpent": "spent",
   "LabelBudgetSummary": "Budget Summary",
   "LabelLeft": "left",
-  "Optional": "optional"
+  "Optional": "optional",
+  "LabelUndoDelete": "Deleted. Undo?",
+  "LabelUndoArchive": "Archived. Undo?",
+  "ButtonUndo": "Undo"
 }

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -554,6 +554,9 @@
   "LabelSpent": "gasto",
   "LabelBudgetSummary": "Resumo do Orçamento",
   "LabelLeft": "restante",
-  "Optional": "opcional"
+  "Optional": "opcional",
+  "LabelUndoDelete": "Excluído. Desfazer?",
+  "LabelUndoArchive": "Arquivado. Desfazer?",
+  "ButtonUndo": "Desfazer"
 }
 

--- a/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
@@ -9,13 +9,15 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { OverviewStackParamList } from '../../navigation/OverviewStackNavigator';
 import { useProjectStore } from '../../store/projectStore';
 import { useQuickAddStore } from '../../store/quickAddStore';
-import { useCategoriesForMonth } from '../../hooks/useCategories';
+import { useCategoriesForMonth, useArchiveCategory, useUnarchiveCategory } from '../../hooks/useCategories';
 import { CategoryCard } from '../../components/budget/CategoryCard';
 import { LoadingIndicator } from '../../components/common/LoadingIndicator';
 import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { MonthNavigator } from '../../components/common/MonthNavigator';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
+import { SwipeableRow } from '../../components/common/SwipeableRow';
+import { UndoToast } from '../../components/common/UndoToast';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
 import {
@@ -36,7 +38,9 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
   const [month, setMonth] = useState(route.params.month);
   const [dismissedError, setDismissedError] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [undoState, setUndoState] = useState<{ visible: boolean; id: string | null }>({ visible: false, id: null });
   const { selectedProject, currency } = useProjectStore();
+  const canEdit = selectedProject?.role !== 'Viewer';
 
   const setViewedMonth = useQuickAddStore(s => s.setViewedMonth);
   const isFocused = useIsFocused();
@@ -47,6 +51,8 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
 
   const { data: categories, isLoading, isFetching, isError, refetch } =
     useCategoriesForMonth(projectId, month);
+  const archiveCategory   = useArchiveCategory(projectId, month);
+  const unarchiveCategory = useUnarchiveCategory(projectId, month);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -133,20 +139,30 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
           ) : null
         }
         renderItem={({ item, index }) => (
-          <CategoryCard
-            category={item}
-            currency={currency}
-            index={index}
-            dark={dark}
-            onPress={() =>
-              navigation.navigate('ExpenseList', {
-                categoryId: item.id,
-                categoryName: item.name,
-                month,
-                categoryIndex: index,
-              })
-            }
-          />
+          <SwipeableRow
+            disabled={!canEdit}
+            actionIcon="archive-outline"
+            actionColor={ink2}
+            onAction={() => {
+              archiveCategory.mutate(item.id);
+              setUndoState({ visible: true, id: item.id });
+            }}
+          >
+            <CategoryCard
+              category={item}
+              currency={currency}
+              index={index}
+              dark={dark}
+              onPress={() =>
+                navigation.navigate('ExpenseList', {
+                  categoryId: item.id,
+                  categoryName: item.name,
+                  month,
+                  categoryIndex: index,
+                })
+              }
+            />
+          </SwipeableRow>
         )}
         ListEmptyComponent={
           <Text style={[styles.empty, { color: ink2 }]}>{t('LabelNoCategories')}</Text>
@@ -155,6 +171,15 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={ink2} />
         }
+      />
+
+      <UndoToast
+        visible={undoState.visible}
+        message={t('LabelUndoArchive')}
+        onUndo={() => {
+          if (undoState.id) unarchiveCategory.mutate(undoState.id);
+        }}
+        onDismiss={() => setUndoState({ visible: false, id: null })}
       />
     </GlassScreen>
   );

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -14,9 +14,11 @@ import type { OverviewStackParamList } from '../../navigation/OverviewStackNavig
 import { useProjectStore } from '../../store/projectStore';
 import {
   useExpensesForMonth, useDeleteExpense, useDeleteExpenseItem,
+  useRestoreExpense, useRestoreExpenseItem,
 } from '../../hooks/useExpenses';
 import { LoadingIndicator } from '../../components/common/LoadingIndicator';
-import { ConfirmDialog } from '../../components/common/ConfirmDialog';
+import { SwipeableRow } from '../../components/common/SwipeableRow';
+import { UndoToast } from '../../components/common/UndoToast';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
 import { DonutRing } from '../../components/common/DonutRing';
@@ -75,14 +77,15 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
 
   const { data: expenses, isLoading, isFetching, refetch } =
     useExpensesForMonth(projectId, categoryId, month);
-  const deleteExpense     = useDeleteExpense(projectId, categoryId, month);
-  const deleteExpenseItem = useDeleteExpenseItem(projectId, categoryId, month);
+  const deleteExpense      = useDeleteExpense(projectId, categoryId, month);
+  const deleteExpenseItem  = useDeleteExpenseItem(projectId, categoryId, month);
+  const restoreExpense     = useRestoreExpense(projectId, categoryId, month);
+  const restoreExpenseItem = useRestoreExpenseItem(projectId, categoryId, month);
 
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [pendingDeleteItem, setPendingDeleteItem] = useState<{ expenseId: string; expenseItemId: string } | null>(null);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [refreshing, setRefreshing] = useState(false);
   const [quickAdd, setQuickAdd] = useState<QuickAddState>({ visible: false });
+  const [undoState, setUndoState] = useState<{ visible: boolean; expenseId: string | null; itemId: string | null }>({ visible: false, expenseId: null, itemId: null });
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -195,6 +198,15 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                   {isExpOver && (
                     <View style={[styles.overspendAccent, { backgroundColor: colors.error }]} />
                   )}
+                  <SwipeableRow
+                    disabled={!canEdit}
+                    actionIcon="trash-can-outline"
+                    actionColor={customColors.expense}
+                    onAction={() => {
+                      deleteExpense.mutate(expense.id);
+                      setUndoState({ visible: true, expenseId: expense.id, itemId: null });
+                    }}
+                  >
                   {/* ── Group header ──────────────────────────────────── */}
                   <TouchableOpacity
                     onPress={() => setExpandedIds(prev => toggleSetItem(prev, expense.id))}
@@ -245,8 +257,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                     </View>
 
                     {canEdit && (
-                      <>
-                        <TouchableOpacity
+                      <TouchableOpacity
                           onPress={() => setQuickAdd({
                             visible: true,
                             editMode: {
@@ -268,14 +279,6 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                         >
                           <MaterialCommunityIcons name="pencil-outline" size={16} color={ink2} />
                         </TouchableOpacity>
-                        <TouchableOpacity
-                          onPress={() => setPendingDeleteId(expense.id)}
-                          hitSlop={6}
-                          style={styles.groupAction}
-                        >
-                          <MaterialCommunityIcons name="trash-can-outline" size={16} color={customColors.expense} />
-                        </TouchableOpacity>
-                      </>
                     )}
 
                     <MaterialCommunityIcons
@@ -286,6 +289,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                     />
                   </TouchableOpacity>
 
+                  </SwipeableRow>
                   {/* ── Expanded items ────────────────────────────────── */}
                   {isOpen && (
                     <ExpenseItemsSection
@@ -302,9 +306,10 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                         visible: true,
                         defaultExpenseId: expense.id,
                       })}
-                      onDeleteItem={(expenseItemId) =>
-                        setPendingDeleteItem({ expenseId: expense.id, expenseItemId })
-                      }
+                      onDeleteItem={(expenseItemId) => {
+                        deleteExpenseItem.mutate({ expenseId: expense.id, expenseItemId });
+                        setUndoState({ visible: true, expenseId: expense.id, itemId: expenseItemId });
+                      }}
                       onEditItem={(item, itemIndex) => setQuickAdd({
                         visible: true,
                         editMode: {
@@ -329,30 +334,17 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
         )}
       </ScrollView>
 
-      <ConfirmDialog
-        visible={!!pendingDeleteId}
-        title={t('LabelDeleteExpense') ?? 'Delete expense'}
-        message={t('LabelConfirmDeleteExpense') ?? 'Are you sure?'}
-        onConfirm={() => {
-          if (!pendingDeleteId) return;
-          deleteExpense.mutate(pendingDeleteId, {
-            onSuccess: () => setPendingDeleteId(null),
-          });
+      <UndoToast
+        visible={undoState.visible}
+        message={t('LabelUndoDelete')}
+        onUndo={() => {
+          if (undoState.itemId && undoState.expenseId) {
+            restoreExpenseItem.mutate({ expenseId: undoState.expenseId, expenseItemId: undoState.itemId });
+          } else if (undoState.expenseId) {
+            restoreExpense.mutate(undoState.expenseId);
+          }
         }}
-        onCancel={() => setPendingDeleteId(null)}
-      />
-
-      <ConfirmDialog
-        visible={!!pendingDeleteItem}
-        title={t('LabelDeleteExpenseItem') ?? 'Delete item'}
-        message={t('LabelConfirmDeleteExpenseItem') ?? 'Are you sure you want to delete this item?'}
-        onConfirm={() => {
-          if (!pendingDeleteItem) return;
-          deleteExpenseItem.mutate(pendingDeleteItem, {
-            onSuccess: () => setPendingDeleteItem(null),
-          });
-        }}
-        onCancel={() => setPendingDeleteItem(null)}
+        onDismiss={() => setUndoState({ visible: false, expenseId: null, itemId: null })}
       />
 
       {/* ── Local QuickAddModal — category pre-selected ─────────────── */}
@@ -449,55 +441,56 @@ const ExpenseItemRow: React.FC<ItemRowProps> = ({
   const hasProof = item.attachments.length > 0;
 
   return (
-    <TouchableOpacity
-      onPress={onEdit}
-      activeOpacity={0.72}
-      style={[styles.itemRow, { borderBottomColor: showBottomBorder ? hair : 'transparent' }]}
+    <SwipeableRow
+      disabled={!canEdit}
+      actionIcon="trash-can-outline"
+      actionColor={customColors.expense}
+      onAction={onDelete}
     >
-      {/* Timeline column — no padding so it fills the full row height, making lines connect between rows */}
-      <View style={styles.timelineCol}>
-        <View style={[styles.timelineLineTop, { backgroundColor: isFirst ? 'transparent' : color + '55' }]} />
-        <View style={[styles.timelineDot, { backgroundColor: color }]} />
-        <View style={[styles.timelineLineBottom, { backgroundColor: isLast ? 'transparent' : color + '55' }]} />
-      </View>
-
-      {/* Body — paddingVertical lives here so the timeline column spans the full row height */}
-      <View style={styles.itemBody}>
-        <View style={styles.itemLeft}>
-          <Text style={[styles.itemName, { color: ink }]} numberOfLines={1}>
-            {item.name?.trim() || '—'}
-          </Text>
-          <View style={styles.itemSubRow}>
-            <Text style={[styles.itemDate, { color: ink2 }]}>{dateStr}</Text>
-            {item.isDeductible && (
-              <View style={[styles.deductBadge, { backgroundColor: colors.primary + '26' }]}>
-                <Text style={[styles.deductBadgeText, { color: colors.primary }]}>
-                  {t('LabelDeductible')}
-                </Text>
-              </View>
-            )}
-            {hasProof && (
-              <View style={[styles.proofBadge, { backgroundColor: ink2 + '22' }]}>
-                <MaterialCommunityIcons name="paperclip" size={9} color={ink2} />
-                <Text style={[styles.proofBadgeText, { color: ink2 }]}>
-                  {t('LabelProofAttached')}
-                </Text>
-              </View>
-            )}
-          </View>
+      <TouchableOpacity
+        onPress={onEdit}
+        activeOpacity={0.72}
+        style={[styles.itemRow, { borderBottomColor: showBottomBorder ? hair : 'transparent' }]}
+      >
+        {/* Timeline column */}
+        <View style={styles.timelineCol}>
+          <View style={[styles.timelineLineTop, { backgroundColor: isFirst ? 'transparent' : color + '55' }]} />
+          <View style={[styles.timelineDot, { backgroundColor: color }]} />
+          <View style={[styles.timelineLineBottom, { backgroundColor: isLast ? 'transparent' : color + '55' }]} />
         </View>
 
-        <Text style={[styles.itemAmt, { color: customColors.expense }]}>
-          −{currency} {fmt(item.amount)}
-        </Text>
+        {/* Body */}
+        <View style={styles.itemBody}>
+          <View style={styles.itemLeft}>
+            <Text style={[styles.itemName, { color: ink }]} numberOfLines={1}>
+              {item.name?.trim() || '—'}
+            </Text>
+            <View style={styles.itemSubRow}>
+              <Text style={[styles.itemDate, { color: ink2 }]}>{dateStr}</Text>
+              {item.isDeductible && (
+                <View style={[styles.deductBadge, { backgroundColor: colors.primary + '26' }]}>
+                  <Text style={[styles.deductBadgeText, { color: colors.primary }]}>
+                    {t('LabelDeductible')}
+                  </Text>
+                </View>
+              )}
+              {hasProof && (
+                <View style={[styles.proofBadge, { backgroundColor: ink2 + '22' }]}>
+                  <MaterialCommunityIcons name="paperclip" size={9} color={ink2} />
+                  <Text style={[styles.proofBadgeText, { color: ink2 }]}>
+                    {t('LabelProofAttached')}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </View>
 
-        {canEdit && (
-          <TouchableOpacity onPress={onDelete} hitSlop={8} style={styles.itemDelete}>
-            <MaterialCommunityIcons name="trash-can-outline" size={15} color={customColors.expense} />
-          </TouchableOpacity>
-        )}
-      </View>
-    </TouchableOpacity>
+          <Text style={[styles.itemAmt, { color: customColors.expense }]}>
+            −{currency} {fmt(item.amount)}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </SwipeableRow>
   );
 };
 

--- a/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
@@ -13,10 +13,11 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { OverviewStackParamList } from '../../navigation/OverviewStackNavigator';
 import { useProjectStore } from '../../store/projectStore';
 import { useQuickAddStore } from '../../store/quickAddStore';
-import { useIncomesForMonth, useDeleteIncome } from '../../hooks/useIncomes';
+import { useIncomesForMonth, useDeleteIncome, useRestoreIncome } from '../../hooks/useIncomes';
 import { LoadingIndicator } from '../../components/common/LoadingIndicator';
-import { ConfirmDialog } from '../../components/common/ConfirmDialog';
 import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { SwipeableRow } from '../../components/common/SwipeableRow';
+import { UndoToast } from '../../components/common/UndoToast';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
 import { QuickAddModal } from '../quick-add/QuickAddModal';
@@ -44,10 +45,10 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
 
   const [month, setMonth] = useState(route.params.month);
 
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [dismissedError, setDismissedError] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [editState, setEditState] = useState<EditState>({ visible: false });
+  const [undoState, setUndoState] = useState<{ visible: boolean; id: string | null }>({ visible: false, id: null });
 
   const { selectedProject, currency } = useProjectStore();
   const sym = getCurrencySymbol(currency);
@@ -69,6 +70,7 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
 
   const { data: incomes, isLoading, isFetching, isError, refetch } = useIncomesForMonth(projectId, month);
   const deleteIncome = useDeleteIncome(projectId, month);
+  const restoreIncome = useRestoreIncome(projectId, month);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -165,45 +167,45 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
               const icon = getCategoryIcon(item.name);
               return (
                 <GlassCard key={item.id} dark={dark} radius={18} style={styles.groupCard}>
-                  <TouchableOpacity
-                    onPress={() => canEdit && setEditState({
-                      visible: true,
-                      editMode: {
-                        type: 'income',
-                        id: item.id,
-                        initialValues: {
-                          name: item.name,
-                          amount: item.amount,
-                          date: item.date,
-                        },
-                      },
-                    })}
-                    activeOpacity={canEdit ? 0.75 : 1}
-                    style={styles.groupHeader}
+                  <SwipeableRow
+                    disabled={!canEdit}
+                    actionIcon="trash-can-outline"
+                    actionColor={customColors.expense}
+                    onAction={() => {
+                      deleteIncome.mutate(item.id);
+                      setUndoState({ visible: true, id: item.id });
+                    }}
                   >
-                    <View style={[styles.groupIcon, { backgroundColor: customColors.income + '22' }]}>
-                      <MaterialCommunityIcons name={icon as never} size={20} color={customColors.income} />
-                    </View>
+                    <TouchableOpacity
+                      onPress={() => canEdit && setEditState({
+                        visible: true,
+                        editMode: {
+                          type: 'income',
+                          id: item.id,
+                          initialValues: {
+                            name: item.name,
+                            amount: item.amount,
+                            date: item.date,
+                          },
+                        },
+                      })}
+                      activeOpacity={canEdit ? 0.75 : 1}
+                      style={styles.groupHeader}
+                    >
+                      <View style={[styles.groupIcon, { backgroundColor: customColors.income + '22' }]}>
+                        <MaterialCommunityIcons name={icon as never} size={20} color={customColors.income} />
+                      </View>
 
-                    <View style={styles.groupInfo}>
-                      <Text style={[styles.groupName, { color: ink }]}>{item.name}</Text>
-                      <Text style={[styles.groupSub, { color: ink2 }]}>{dateStr}</Text>
-                    </View>
+                      <View style={styles.groupInfo}>
+                        <Text style={[styles.groupName, { color: ink }]}>{item.name}</Text>
+                        <Text style={[styles.groupSub, { color: ink2 }]}>{dateStr}</Text>
+                      </View>
 
-                    <Text style={[styles.groupAmt, { color: customColors.income }]}>
-                      +{sym} {fmt(item.amount)}
-                    </Text>
-
-                    {canEdit && (
-                      <TouchableOpacity
-                        onPress={(e) => { e.stopPropagation(); setPendingDeleteId(item.id); }}
-                        hitSlop={6}
-                        style={styles.groupAction}
-                      >
-                        <MaterialCommunityIcons name="trash-can-outline" size={16} color={customColors.expense} />
-                      </TouchableOpacity>
-                    )}
-                  </TouchableOpacity>
+                      <Text style={[styles.groupAmt, { color: customColors.income }]}>
+                        +{sym} {fmt(item.amount)}
+                      </Text>
+                    </TouchableOpacity>
+                  </SwipeableRow>
                 </GlassCard>
               );
             })}
@@ -211,17 +213,13 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
         )}
       </ScrollView>
 
-      <ConfirmDialog
-        visible={!!pendingDeleteId}
-        title={t('LabelDeleteIncome') ?? 'Delete income'}
-        message={t('LabelConfirmDeleteIncome') ?? 'Are you sure you want to delete this income?'}
-        onConfirm={() => {
-          if (!pendingDeleteId) return;
-          deleteIncome.mutate(pendingDeleteId, {
-            onSuccess: () => setPendingDeleteId(null),
-          });
+      <UndoToast
+        visible={undoState.visible}
+        message={t('LabelUndoDelete')}
+        onUndo={() => {
+          if (undoState.id) restoreIncome.mutate(undoState.id);
         }}
-        onCancel={() => setPendingDeleteId(null)}
+        onDismiss={() => setUndoState({ visible: false, id: null })}
       />
 
       <QuickAddModal


### PR DESCRIPTION
Income, Expense, and ExpenseItem are now soft-deleted (IsDeleted flag +
EF Core query filter) instead of hard-deleted, enabling in-place undo.
Category already used soft-delete; a new Unarchive endpoint is added.

UI changes:
- Web (Angular): SwipeDeleteRowComponent wraps list items; MatSnackBar
  shows a 5 s undo toast; swiping left reveals trash (income/expense) or
  archive icon (category) and triggers the action without a dialog.
- Mobile (React Native): SwipeableRow (PanResponder) + UndoToast
  components added; all three screens updated with the same pattern.

Backend changes:
- Added IsDeleted + DeletedDate to Income, Expense, ExpenseItem with
  EF Core HasQueryFilter; added EF migration AddSoftDeleteToFinancials.
- Added Restore endpoints for Income, Expense, ExpenseItem.
- Added Unarchive endpoint for Category.
- New ICategoryService.Restore / IIncomeService.Restore /
  IExpenseService.Restore / IExpenseItemService.Restore contracts.

Tests:
- Backend: SoftDeleteRestoreTests covering soft-delete + restore for all
  three entities (22 new tests).
- Angular: swipeDelete / swipeArchive suites in income + category specs.
- Mobile: restoreApi.test.ts + locales key coverage tests.

https://claude.ai/code/session_01GrTkTaoi7dMBqHHzpMoq84