### PR TITLE
feat: improve swipe-to-delete UX — CategoryCard encapsulation, web prototype fix, toast positioning

### DIFF
--- a/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.spec.ts
+++ b/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.spec.ts
@@ -229,5 +229,42 @@ describe('ListExpensesComponent', () => {
       expect(expenseServiceMock.restoreItem).toHaveBeenCalledWith('project-1', 'cat-1', 'expense-1', 'item-1');
       expect(expenseServiceMock.get).toHaveBeenCalledTimes(2);
     });
+
+    it('should preserve ExpenseDto prototype methods on the parent after item removal', () => {
+      const item = makeItem();
+      const expense = makeExpense({ items: [item] });
+      (component as any).expenses.next([expense]);
+
+      component.swipeDeleteSubExpense(expense, item);
+
+      const remaining = (component as any).expenses.getValue() as ExpenseDto[];
+      expect(remaining[0]).toBeInstanceOf(ExpenseDto);
+      expect(() => remaining[0].getSpend()).not.toThrow();
+    });
+  });
+
+  describe('snackbar positioning', () => {
+    it('swipeDeleteExpense should open snackbar with center-bottom position', () => {
+      const expense = makeExpense();
+      (component as any).expenses.next([expense]);
+      component.swipeDeleteExpense(expense);
+      expect(snackBarMock.open).toHaveBeenCalledWith(
+        jasmine.any(String),
+        jasmine.any(String),
+        jasmine.objectContaining({ horizontalPosition: 'center', verticalPosition: 'bottom' }),
+      );
+    });
+
+    it('swipeDeleteSubExpense should open snackbar with center-bottom position', () => {
+      const item = makeItem();
+      const expense = makeExpense({ items: [item] });
+      (component as any).expenses.next([expense]);
+      component.swipeDeleteSubExpense(expense, item);
+      expect(snackBarMock.open).toHaveBeenCalledWith(
+        jasmine.any(String),
+        jasmine.any(String),
+        jasmine.objectContaining({ horizontalPosition: 'center', verticalPosition: 'bottom' }),
+      );
+    });
   });
 });

--- a/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.ts
+++ b/easyfinance.client/src/app/features/expense/list-expenses/list-expenses.component.ts
@@ -168,7 +168,11 @@ export class ListExpensesComponent implements OnInit {
 
     const undoLabel = this.translateService.instant('ButtonUndo');
     const message = this.translateService.instant('UndoDelete');
-    const ref = this.snackBar.open(message, undoLabel, { duration: 5000 });
+    const ref = this.snackBar.open(message, undoLabel, {
+      duration: 5000,
+      horizontalPosition: 'center',
+      verticalPosition: 'bottom',
+    });
 
     ref.onAction().subscribe(() => {
       this.expenseService.restore(this.projectId, this.categoryId, removed.id).subscribe({
@@ -180,7 +184,9 @@ export class ListExpensesComponent implements OnInit {
   swipeDeleteSubExpense(expense: ExpenseDto, subExpense: ExpenseItemDto): void {
     const currentExpenses = this.expenses.getValue().map(e => {
       if (e.id !== expense.id) return e;
-      return { ...e, items: e.items.filter(i => i.id !== subExpense.id) } as ExpenseDto;
+      const updated = Object.assign(new ExpenseDto(), e);
+      updated.items = e.items.filter(i => i.id !== subExpense.id);
+      return updated;
     });
     this.expenses.next(currentExpenses);
 
@@ -188,7 +194,11 @@ export class ListExpensesComponent implements OnInit {
 
     const undoLabel = this.translateService.instant('ButtonUndo');
     const message = this.translateService.instant('UndoDelete');
-    const ref = this.snackBar.open(message, undoLabel, { duration: 5000 });
+    const ref = this.snackBar.open(message, undoLabel, {
+      duration: 5000,
+      horizontalPosition: 'center',
+      verticalPosition: 'bottom',
+    });
 
     ref.onAction().subscribe(() => {
       this.expenseService.restoreItem(this.projectId, this.categoryId, expense.id, subExpense.id).subscribe({

--- a/easyfinance.client/src/assets/version.json
+++ b/easyfinance.client/src/assets/version.json
@@ -1,3 +1,3 @@
 {
-  "versionNumber": "1.1.62"
+  "versionNumber": "1.1.63"
 }

--- a/econoflow-mobile/src/components/budget/CategoryCard.tsx
+++ b/econoflow-mobile/src/components/budget/CategoryCard.tsx
@@ -10,6 +10,7 @@ import { getCurrencySymbol } from '../../utils/currency';
 import { calculateExpensesOverspend } from '../../utils/budget';
 import { GlassCard } from '../common/GlassCard';
 import { DonutRing } from '../common/DonutRing';
+import { SwipeableRow } from '../common/SwipeableRow';
 import { auroraTokens } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
 
@@ -19,6 +20,9 @@ interface Props {
   onPress: () => void;
   index?: number;
   dark?: boolean;
+  onSwipeAction?: () => void;
+  swipeActionColor?: string;
+  swipeDisabled?: boolean;
 }
 
 const getTotalSpend  = (cat: Category): number =>
@@ -28,6 +32,7 @@ const getTotalBudget = (cat: Category): number =>
 
 export const CategoryCard: React.FC<Props> = ({
   category, currency, onPress, index = 0, dark,
+  onSwipeAction, swipeActionColor, swipeDisabled,
 }) => {
   const { t }  = useTranslation();
   const { ink, ink2 } = auroraTokens(!!dark);
@@ -41,39 +46,54 @@ export const CategoryCard: React.FC<Props> = ({
   const sym         = getCurrencySymbol(currency);
   const icon        = getCategoryIcon(category.name);
 
-  return (
-    <TouchableOpacity onPress={onPress} activeOpacity={0.78} style={styles.wrapper}>
-      <GlassCard dark={!!dark} radius={18} intensity={30}>
-        <View style={styles.row}>
-          <DonutRing
-            size={46}
-            strokeWidth={6}
-            progress={pct}
-            color={isOver ? colors.error : color}
-            trackColor={dark ? color + '33' : color + '28'}
-          >
-            <MaterialCommunityIcons name={icon as never} size={17} color={isOver ? colors.error : color} />
-          </DonutRing>
+  const rowContent = (
+    <TouchableOpacity onPress={onPress} activeOpacity={0.78}>
+      <View style={styles.row}>
+        <DonutRing
+          size={46}
+          strokeWidth={6}
+          progress={pct}
+          color={isOver ? colors.error : color}
+          trackColor={dark ? color + '33' : color + '28'}
+        >
+          <MaterialCommunityIcons name={icon as never} size={17} color={isOver ? colors.error : color} />
+        </DonutRing>
 
-          <View style={styles.info}>
-            <Text style={[styles.name, { color: ink }]}>{category.name}</Text>
-            <Text style={[styles.sub, { color: isOver ? colors.error : ink2 }]}>
-              {category.expenses.length} {t('LabelExpenseItems')} · {Math.round(pct * 100)}%
-            </Text>
-            {catOverspend > 0 && (
-              <Text style={[styles.overspend, { color: colors.error }]}>
-                +{sym} {Math.round(catOverspend).toLocaleString()} {t('LabelOver') ?? 'over'}
-              </Text>
-            )}
-          </View>
-
-          <Text style={[styles.amount, { color: ink }]}>
-            {sym} {Math.round(spent).toLocaleString()}
+        <View style={styles.info}>
+          <Text style={[styles.name, { color: ink }]}>{category.name}</Text>
+          <Text style={[styles.sub, { color: isOver ? colors.error : ink2 }]}>
+            {category.expenses.length} {t('LabelExpenseItems')} · {Math.round(pct * 100)}%
           </Text>
-          <MaterialCommunityIcons name="chevron-right" size={18} color={ink2} />
+          {catOverspend > 0 && (
+            <Text style={[styles.overspend, { color: colors.error }]}>
+              +{sym} {Math.round(catOverspend).toLocaleString()} {t('LabelOver') ?? 'over'}
+            </Text>
+          )}
         </View>
-      </GlassCard>
+
+        <Text style={[styles.amount, { color: ink }]}>
+          {sym} {Math.round(spent).toLocaleString()}
+        </Text>
+        <MaterialCommunityIcons name="chevron-right" size={18} color={ink2} />
+      </View>
     </TouchableOpacity>
+  );
+
+  return (
+    <GlassCard dark={!!dark} radius={18} intensity={30} style={styles.wrapper}>
+      {onSwipeAction ? (
+        <SwipeableRow
+          disabled={!!swipeDisabled}
+          actionIcon="archive-outline"
+          actionColor={swipeActionColor ?? ink2}
+          onAction={onSwipeAction}
+        >
+          {rowContent}
+        </SwipeableRow>
+      ) : (
+        rowContent
+      )}
+    </GlassCard>
   );
 };
 

--- a/econoflow-mobile/src/components/budget/__tests__/CategoryCard.test.tsx
+++ b/econoflow-mobile/src/components/budget/__tests__/CategoryCard.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { CategoryCard } from '../CategoryCard';
+import type { Category } from '../../../api/types';
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c', surface: '#fff' },
+    customColors: {},
+  }),
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666' }),
+  auroraTokens: () => ({ ink: '#000', ink2: '#666' }),
+}));
+
+jest.mock('../../../components/common/GlassCard', () => ({
+  // Render children so that nested SwipeableRow / content is actually mounted.
+  GlassCard: jest.fn(({ children }: { children: unknown }) => children),
+}));
+
+jest.mock('../../../components/common/DonutRing', () => ({
+  DonutRing: 'DonutRing',
+}));
+
+jest.mock('../../../components/common/SwipeableRow', () => ({
+  SwipeableRow: jest.fn(() => null),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const makeCategory = (): Category => ({
+  id: 'cat-1',
+  name: 'Food',
+  isArchived: false,
+  displayOrder: 0,
+  totalBudget: 100,
+  totalWaste: 0,
+  expenses: [
+    {
+      id: 'exp-1',
+      name: 'Groceries',
+      amount: 50,
+      budget: 100,
+      date: '2026-01-01',
+      isDeductible: false,
+      items: [],
+      attachments: [],
+      temporaryAttachmentIds: [],
+    } as unknown as Category['expenses'][0],
+  ],
+});
+
+// Access the spy through jest.requireMock so it is the same reference used inside the module
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getSwipeableRowSpy = (): jest.Mock => (jest.requireMock('../../../components/common/SwipeableRow') as any).SwipeableRow;
+
+beforeEach(() => {
+  getSwipeableRowSpy().mockClear();
+});
+
+describe('CategoryCard', () => {
+  it('does NOT render a SwipeableRow when onSwipeAction is not provided', async () => {
+    await act(async () => {
+      render(<CategoryCard category={makeCategory()} currency="USD" onPress={jest.fn()} />);
+    });
+    expect(getSwipeableRowSpy()).not.toHaveBeenCalled();
+  });
+
+  it('renders a SwipeableRow when onSwipeAction is provided', async () => {
+    await act(async () => {
+      render(
+        <CategoryCard
+          category={makeCategory()}
+          currency="USD"
+          onPress={jest.fn()}
+          onSwipeAction={jest.fn()}
+          swipeActionColor="#aabbcc"
+          swipeDisabled={false}
+        />,
+      );
+    });
+    expect(getSwipeableRowSpy()).toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
@@ -16,7 +16,6 @@ import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { MonthNavigator } from '../../components/common/MonthNavigator';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
-import { SwipeableRow } from '../../components/common/SwipeableRow';
 import { UndoToast } from '../../components/common/UndoToast';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
@@ -139,30 +138,26 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
           ) : null
         }
         renderItem={({ item, index }) => (
-          <SwipeableRow
-            disabled={!canEdit}
-            actionIcon="archive-outline"
-            actionColor={ink2}
-            onAction={() => {
+          <CategoryCard
+            category={item}
+            currency={currency}
+            index={index}
+            dark={dark}
+            onSwipeAction={() => {
               archiveCategory.mutate(item.id);
               setUndoState({ visible: true, id: item.id });
             }}
-          >
-            <CategoryCard
-              category={item}
-              currency={currency}
-              index={index}
-              dark={dark}
-              onPress={() =>
-                navigation.navigate('ExpenseList', {
-                  categoryId: item.id,
-                  categoryName: item.name,
-                  month,
-                  categoryIndex: index,
-                })
-              }
-            />
-          </SwipeableRow>
+            swipeActionColor={ink2}
+            swipeDisabled={!canEdit}
+            onPress={() =>
+              navigation.navigate('ExpenseList', {
+                categoryId: item.id,
+                categoryName: item.name,
+                month,
+                categoryIndex: index,
+              })
+            }
+          />
         )}
         ListEmptyComponent={
           <Text style={[styles.empty, { color: ink2 }]}>{t('LabelNoCategories')}</Text>

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -577,7 +577,7 @@ const styles = StyleSheet.create({
   timelineLineTop:    { flex: 1, width: 2 },
   timelineDot:        { width: 8, height: 8, borderRadius: 4 },
   timelineLineBottom: { flex: 1, width: 2 },
-  itemBody:    { flex: 1, flexDirection: 'row', alignItems: 'center', paddingVertical: 9, paddingLeft: 10, gap: 10 },
+  itemBody:    { flex: 1, flexDirection: 'row', alignItems: 'center', paddingVertical: 9, paddingLeft: 10, paddingRight: 10, gap: 10 },
   itemLeft:    { flex: 1, gap: 2 },
   itemSubRow:  { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 4 },
   itemName:   { fontSize: 13.5, fontWeight: '600' },

--- a/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
+++ b/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
@@ -16,7 +16,8 @@ import { useProjectStore } from '../../store/projectStore';
 import { useQuickAddStore } from '../../store/quickAddStore';
 import { useAuthStore } from '../../store/authStore';
 import { useProjects } from '../../hooks/useProjects';
-import { useCategoriesForMonth } from '../../hooks/useCategories';
+import { useCategoriesForMonth, useArchiveCategory, useUnarchiveCategory } from '../../hooks/useCategories';
+import { UndoToast } from '../../components/common/UndoToast';
 import { useIncomesForMonth } from '../../hooks/useIncomes';
 import { useTotalSavedForMonth } from '../../hooks/usePlans';
 import { MonthNavigator } from '../../components/common/MonthNavigator';
@@ -54,6 +55,7 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
   const [month, setMonth] = useState(currentMonth());
   const [refreshing, setRefreshing] = useState(false);
   const [dismissedForMonth, setDismissedForMonth] = useState<string | null>(null);
+  const [undoState, setUndoState] = useState<{ visible: boolean; id: string | null }>({ visible: false, id: null });
 
   const setViewedMonth = useQuickAddStore(s => s.setViewedMonth);
   const isFocused = useIsFocused();
@@ -70,6 +72,9 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
     data: categories, isLoading: loadingCats, isFetching: fetchingCats,
     isError: catsError, refetch: refetchCats,
   } = useCategoriesForMonth(projectId, month);
+  const archiveCategory   = useArchiveCategory(projectId, month);
+  const unarchiveCategory = useUnarchiveCategory(projectId, month);
+  const canEdit = selectedProject?.role !== 'Viewer';
   const {
     data: incomes, isLoading: loadingInc, isFetching: fetchingIncs,
     isError: incError, refetch: refetchIncs,
@@ -306,6 +311,12 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
                   currency={currency}
                   index={idx}
                   dark={dark}
+                  onSwipeAction={() => {
+                    archiveCategory.mutate(cat.id);
+                    setUndoState({ visible: true, id: cat.id });
+                  }}
+                  swipeActionColor={ink2}
+                  swipeDisabled={!canEdit}
                   onPress={() => navigation.navigate('ExpenseList', {
                     categoryId: cat.id, categoryName: cat.name, month, categoryIndex: idx,
                   })}
@@ -323,6 +334,15 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
         )}
         </ScrollView>
       </View>
+
+      <UndoToast
+        visible={undoState.visible}
+        message={t('LabelUndoArchive')}
+        onUndo={() => {
+          if (undoState.id) unarchiveCategory.mutate(undoState.id);
+        }}
+        onDismiss={() => setUndoState({ visible: false, id: null })}
+      />
     </GlassScreen>
   );
 };

--- a/econoflow-mobile/src/screens/monthly/__tests__/MonthlyOverviewScreen.test.tsx
+++ b/econoflow-mobile/src/screens/monthly/__tests__/MonthlyOverviewScreen.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests that the archive-category capability added to MonthlyOverviewScreen
+ * (useArchiveCategory + UndoToast + swipe props forwarded to CategoryCard) is
+ * correctly wired for each role.
+ */
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+import { MonthlyOverviewScreen } from '../MonthlyOverviewScreen';
+import type { Category } from '../../../api/types';
+
+// ─── Common UI mocks ──────────────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: () => false,
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+  auroraTokens: () => ({ ink: '#000', ink2: '#666' }),
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c', surface: '#fff' },
+    customColors: { income: '#2ecc71', expense: '#e74c3c' },
+  }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => ({
+  GlassScreen: jest.fn(({ children }: { children: unknown }) => children),
+}));
+
+jest.mock('../../../components/common/GlassCard', () => ({
+  GlassCard: jest.fn(({ children }: { children: unknown }) => children),
+}));
+
+jest.mock('../../../components/common/LoadingIndicator', () => ({
+  LoadingIndicator: () => null,
+}));
+
+jest.mock('../../../components/common/ErrorBanner', () => ({
+  ErrorBanner: () => null,
+}));
+
+jest.mock('../../../components/common/MonthNavigator', () => ({
+  MonthNavigator: () => null,
+}));
+
+jest.mock('../../../components/common/DonutRing', () => ({
+  DonutRing: () => null,
+}));
+
+jest.mock('../../../components/common/UndoToast', () => ({
+  UndoToast: jest.fn(() => null),
+}));
+
+jest.mock('../../../components/budget/CategoryCard', () => ({
+  CategoryCard: jest.fn(() => null),
+}));
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(),
+}));
+
+jest.mock('../../../store/quickAddStore', () => ({
+  useQuickAddStore: jest.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setViewedMonth: jest.fn(), setCategoryId: jest.fn() }),
+  ),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({ user: { id: 'u1', email: 'test@test.com', firstName: 'Test', defaultProjectId: null } })),
+}));
+
+jest.mock('../../../hooks/useProjects', () => ({
+  useProjects: jest.fn(() => ({ data: [] })),
+}));
+
+jest.mock('../../../hooks/useIncomes', () => ({
+  useIncomesForMonth: jest.fn(() => ({
+    data: [], isLoading: false, isFetching: false, isError: false, refetch: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../hooks/usePlans', () => ({
+  useTotalSavedForMonth: jest.fn(() => ({ totalSaved: 0, isLoading: false })),
+}));
+
+const mockArchiveMutate = jest.fn();
+const mockUnarchiveMutate = jest.fn();
+
+jest.mock('../../../hooks/useCategories', () => ({
+  useCategoriesForMonth: jest.fn(() => ({
+    data: [
+      {
+        id: 'cat-1', name: 'Food', isArchived: false,
+        displayOrder: 0, totalBudget: 100, totalWaste: 0, expenses: [],
+      } as Category,
+    ],
+    isLoading: false, isFetching: false, isError: false, refetch: jest.fn(),
+  })),
+  useArchiveCategory: jest.fn(() => ({ mutate: mockArchiveMutate })),
+  useUnarchiveCategory: jest.fn(() => ({ mutate: mockUnarchiveMutate })),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeProjectStore(role: 'Admin' | 'Manager' | 'Viewer') {
+  return {
+    selectedProject: {
+      id: 'up-1',
+      userId: 'u1',
+      userName: 'Test',
+      userEmail: 'test@test.com',
+      accepted: true,
+      role,
+      project: { id: 'proj-1', name: 'Test Project', preferredCurrency: 'EUR', isArchived: false },
+    },
+    currency: 'EUR',
+    setSelectedProject: jest.fn(),
+    clearProject: jest.fn(),
+  };
+}
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: jest.fn() })),
+} as unknown as React.ComponentProps<typeof MonthlyOverviewScreen>['navigation'];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getCategoryCardSpy = (): jest.Mock => (jest.requireMock('../../../components/budget/CategoryCard') as any).CategoryCard;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getUndoToastSpy = (): jest.Mock => (jest.requireMock('../../../components/common/UndoToast') as any).UndoToast;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MonthlyOverviewScreen — archive-category capability', () => {
+  beforeEach(() => {
+    getCategoryCardSpy().mockClear();
+    getUndoToastSpy().mockClear();
+  });
+
+  it('passes onSwipeAction and swipeDisabled=false to CategoryCard for Manager role', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockImplementation(() => makeProjectStore('Manager'));
+
+    await act(async () => {
+      render(<MonthlyOverviewScreen navigation={mockNavigation} />);
+    });
+
+    const calls = getCategoryCardSpy().mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const props = calls[0][0];
+    expect(typeof props.onSwipeAction).toBe('function');
+    expect(props.swipeDisabled).toBe(false);
+  });
+
+  it('passes swipeDisabled=true to CategoryCard for Viewer role', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockImplementation(() => makeProjectStore('Viewer'));
+
+    await act(async () => {
+      render(<MonthlyOverviewScreen navigation={mockNavigation} />);
+    });
+
+    const calls = getCategoryCardSpy().mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const props = calls[0][0];
+    expect(props.swipeDisabled).toBe(true);
+  });
+
+  it('renders UndoToast in the component tree', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockImplementation(() => makeProjectStore('Manager'));
+
+    await act(async () => {
+      render(<MonthlyOverviewScreen navigation={mockNavigation} />);
+    });
+
+    expect(getUndoToastSpy()).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Mobile — CategoryCard**: Restructured so `GlassCard` is the outermost wrapper and `SwipeableRow` is nested inside it (matching the income/expense list item pattern). Added `onSwipeAction`, `swipeActionColor`, and `swipeDisabled` props, so both `MonthlyOverviewScreen` and `CategoryListScreen` can trigger archive-via-swipe without wrapping the card externally.
- **Mobile — MonthlyOverviewScreen**: Wired up `useArchiveCategory` / `useUnarchiveCategory` hooks and an `UndoToast`, making swipe-to-archive available on the overview screen (previously it only worked on the category list page).
- **Mobile — ExpenseListScreen**: Added `paddingRight: 10` to `itemBody` so there is visible spacing between the amount text and the revealed action button after a swipe.
- **Web — list-expenses**: Fixed a prototype-loss bug in `swipeDeleteSubExpense` where `{ ...e, items: ... } as ExpenseDto` created a plain object and Angular's template evaluation threw `TypeError: expense.getSpend is not a function`, preventing the deleted item from disappearing until a page refresh. Fix: `Object.assign(new ExpenseDto(), e)`. Also added explicit `{ horizontalPosition: 'center', verticalPosition: 'bottom' }` to both swipe-delete snackbar calls so the undo toast always appears at the bottom centre.

## Test plan

- [x] `CategoryCard.test.tsx` — no `SwipeableRow` without `onSwipeAction`; `SwipeableRow` rendered when `onSwipeAction` provided
- [x] `MonthlyOverviewScreen.test.tsx` — Manager gets `onSwipeAction` + `swipeDisabled=false`; Viewer gets `swipeDisabled=true`; `UndoToast` always rendered
- [x] `list-expenses.component.spec.ts` — `swipeDeleteSubExpense` preserves `ExpenseDto` prototype; both swipe handlers open snackbar at `center`/`bottom`
- [x] Mobile: 196 tests pass, typecheck clean, lint clean
- [x] Frontend: tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)