### PR TITLE
feat(mobile): Smart Setup wizard — budget allocation, slider, add/delete categories

### DIFF
--- a/econoflow-mobile/.eslintrc.js
+++ b/econoflow-mobile/.eslintrc.js
@@ -5,4 +5,13 @@ module.exports = {
     'no-console': 'warn',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
   },
+  overrides: [
+    {
+      // jest.mock() factories require require() — it is unavoidable due to hoisting
+      files: ['**/__tests__/**/*.{ts,tsx}', '**/*.test.{ts,tsx}'],
+      rules: {
+        '@typescript-eslint/no-require-imports': 'off',
+      },
+    },
+  ],
 };

--- a/econoflow-mobile/src/api/__tests__/smartSetup.api.test.ts
+++ b/econoflow-mobile/src/api/__tests__/smartSetup.api.test.ts
@@ -1,0 +1,39 @@
+import { getDefaultCategories, postSmartSetup } from '../smartSetup.api';
+import { apiClient } from '../client';
+import type { SmartSetupRequest } from '../types';
+
+jest.mock('../client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+describe('smartSetup.api', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('getDefaultCategories', () => {
+    it('GETs the default categories endpoint for a project', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({ data: [] });
+      const result = await getDefaultCategories('proj-1');
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/api/Projects/proj-1/categories/DefaultCategories',
+      );
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe('postSmartSetup', () => {
+    it('POSTs the smart setup payload to the correct endpoint', async () => {
+      (apiClient.post as jest.Mock).mockResolvedValue({ data: undefined });
+      const req: SmartSetupRequest = {
+        annualIncome: 60000,
+        date: '2026-01-01',
+        defaultCategories: [{ id: 'cat-1', name: 'Food', percentage: 100 }],
+        emergencyReserveTarget: 5000,
+      };
+      await postSmartSetup('proj-1', req);
+      expect(apiClient.post).toHaveBeenCalledWith('/api/Projects/proj-1/smart-setup/', req);
+    });
+  });
+});

--- a/econoflow-mobile/src/api/projects.api.ts
+++ b/econoflow-mobile/src/api/projects.api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { UserProject, CreateProjectRequest, PatchOperation } from './types';
+import type { UserProject, CreateProjectRequest, PatchOperation, TaxYearSettingsRequest } from './types';
 
 export const getProjects = () =>
   apiClient.get<UserProject[]>('/api/Projects');
@@ -15,3 +15,6 @@ export const patchProject = (id: string, ops: PatchOperation[]) =>
 
 export const archiveProject = (id: string) =>
   apiClient.put(`/api/Projects/${id}/archive`);
+
+export const putTaxYearSettings = (id: string, data: TaxYearSettingsRequest) =>
+  apiClient.put(`/api/Projects/${id}/settings/tax-year`, data);

--- a/econoflow-mobile/src/api/smartSetup.api.ts
+++ b/econoflow-mobile/src/api/smartSetup.api.ts
@@ -1,0 +1,10 @@
+import { apiClient } from './client';
+import type { DefaultCategory, SmartSetupRequest } from './types';
+
+export const getDefaultCategories = (projectId: string) =>
+  apiClient.get<DefaultCategory[]>(
+    `/api/Projects/${projectId}/categories/DefaultCategories`,
+  );
+
+export const postSmartSetup = (projectId: string, data: SmartSetupRequest) =>
+  apiClient.post<void>(`/api/Projects/${projectId}/smart-setup/`, data);

--- a/econoflow-mobile/src/api/types.ts
+++ b/econoflow-mobile/src/api/types.ts
@@ -153,3 +153,24 @@ export interface CreateExpenseItemRequest {
   date: string;
   amount: number;
 }
+
+export interface TaxYearSettingsRequest {
+  taxYearType: 'CalendarYear' | 'CustomStartMonth';
+  taxYearStartMonth?: number;
+  taxYearStartDay?: number;
+  taxYearLabeling?: 'ByStartYear' | 'ByEndYear';
+}
+
+export interface DefaultCategory {
+  // Backend DTO (CategoryWithPercentageDTO) has no Id field; absent in real responses.
+  id?: string;
+  name: string;
+  percentage: number;
+}
+
+export interface SmartSetupRequest {
+  annualIncome: number;
+  date: string;
+  defaultCategories: DefaultCategory[];
+  emergencyReserveTarget: number;
+}

--- a/econoflow-mobile/src/components/auth/AuroraField.tsx
+++ b/econoflow-mobile/src/components/auth/AuroraField.tsx
@@ -4,7 +4,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 interface Props extends TextInputProps {
   dark: boolean;
-  icon: string;
+  icon?: string;
   /** When set, renders a currency/text symbol instead of the icon. */
   textPrefix?: string;
   placeholder: string;
@@ -29,9 +29,9 @@ export const AuroraField: React.FC<Props> = ({
     ]}>
       {textPrefix ? (
         <Text style={[styles.textPrefix, { color: ink2 }]}>{textPrefix}</Text>
-      ) : (
+      ) : icon ? (
         <MaterialCommunityIcons name={icon as never} size={20} color={ink2} style={styles.icon} />
-      )}
+      ) : null}
       <TextInput
         placeholder={placeholder}
         placeholderTextColor={ink2}

--- a/econoflow-mobile/src/components/auth/AuroraPrimaryButton.tsx
+++ b/econoflow-mobile/src/components/auth/AuroraPrimaryButton.tsx
@@ -8,15 +8,18 @@ interface Props {
   label: string;
   onPress: () => void;
   loading?: boolean;
+  disabled?: boolean;
   icon?: string;
+  testID?: string;
 }
 
-export const AuroraPrimaryButton: React.FC<Props> = ({ label, onPress, loading, icon }) => (
+export const AuroraPrimaryButton: React.FC<Props> = ({ label, onPress, loading, disabled, icon, testID }) => (
   <TouchableOpacity
+    testID={testID}
     onPress={onPress}
-    disabled={loading}
+    disabled={loading || disabled}
     activeOpacity={0.82}
-    style={[styles.btn, loading && styles.btnDisabled]}
+    style={[styles.btn, (loading || disabled) && styles.btnDisabled]}
   >
     {/* Teal → green gradient from the design */}
     <LinearGradient

--- a/econoflow-mobile/src/components/auth/__tests__/AuroraPrimaryButton.test.tsx
+++ b/econoflow-mobile/src/components/auth/__tests__/AuroraPrimaryButton.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { AuroraPrimaryButton } from '../AuroraPrimaryButton';
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return { Text: ({ children }: { children: React.ReactNode }) => React.createElement(Text, null, children) };
+});
+
+jest.mock('expo-linear-gradient', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+describe('AuroraPrimaryButton', () => {
+  it('calls onPress when pressed and not disabled', async () => {
+    const mockOnPress = jest.fn();
+    await render(<AuroraPrimaryButton label="Go" onPress={mockOnPress} />);
+    await fireEvent.press(screen.getByText('Go'));
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onPress when disabled prop is true', async () => {
+    const mockOnPress = jest.fn();
+    await render(<AuroraPrimaryButton label="Go" onPress={mockOnPress} disabled />);
+    await fireEvent.press(screen.getByText('Go'));
+    expect(mockOnPress).not.toHaveBeenCalled();
+  });
+
+  it('shows loading indicator and hides label when loading is true', async () => {
+    await render(<AuroraPrimaryButton label="Go" onPress={jest.fn()} loading />);
+    expect(screen.queryByText('Go')).toBeNull();
+  });
+
+  it('applies reduced opacity style when disabled prop is true', async () => {
+    await render(<AuroraPrimaryButton label="Go" onPress={jest.fn()} disabled testID="test-btn" />);
+    const btn = screen.getByTestId('test-btn');
+    const flatStyle = StyleSheet.flatten(btn.props.style);
+    expect(flatStyle?.opacity).toBe(0.6);
+  });
+});

--- a/econoflow-mobile/src/hooks/__tests__/useSmartSetup.test.ts
+++ b/econoflow-mobile/src/hooks/__tests__/useSmartSetup.test.ts
@@ -1,0 +1,96 @@
+import * as SmartSetupApi from '../../api/smartSetup.api';
+import { useDefaultCategories, usePostSmartSetup } from '../useSmartSetup';
+
+jest.mock('../../api/smartSetup.api');
+
+const mockInvalidateQueries = jest.fn();
+
+beforeEach(() => {
+  mockInvalidateQueries.mockReset();
+});
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn((opts) => ({ data: undefined, isSuccess: false, _opts: opts })),
+  useMutation: jest.fn((opts) => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+    _opts: opts,
+  })),
+  useQueryClient: jest.fn(() => ({ invalidateQueries: mockInvalidateQueries })),
+}));
+
+describe('useDefaultCategories', () => {
+  it('passes correct queryKey and staleTime to useQuery', () => {
+    const { useQuery } = jest.requireMock('@tanstack/react-query') as { useQuery: jest.Mock };
+    useDefaultCategories('proj-1');
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['defaultCategories', 'proj-1'],
+        staleTime: 60_000,
+      }),
+    );
+  });
+
+  it('queryFn calls getDefaultCategories and unwraps response data', async () => {
+    const mockData = [{ id: 'c1', name: 'Food', percentage: 30 }];
+    (SmartSetupApi.getDefaultCategories as jest.Mock).mockResolvedValue({ data: mockData });
+
+    const { useQuery } = jest.requireMock('@tanstack/react-query') as { useQuery: jest.Mock };
+    let capturedQueryFn!: () => Promise<unknown>;
+    useQuery.mockImplementationOnce((opts: { queryFn: typeof capturedQueryFn }) => {
+      capturedQueryFn = opts.queryFn;
+      return { data: undefined, isSuccess: false };
+    });
+
+    useDefaultCategories('proj-1');
+    const result = await capturedQueryFn();
+
+    expect(SmartSetupApi.getDefaultCategories).toHaveBeenCalledWith('proj-1');
+    expect(result).toEqual(mockData);
+  });
+});
+
+describe('usePostSmartSetup', () => {
+  it('mutationFn calls postSmartSetup with projectId and data', async () => {
+    (SmartSetupApi.postSmartSetup as jest.Mock).mockResolvedValue({ data: undefined });
+
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedMutationFn!: (vars: { projectId: string; data: unknown }) => Promise<unknown>;
+    useMutation.mockImplementationOnce(
+      (opts: { mutationFn: typeof capturedMutationFn }) => {
+        capturedMutationFn = opts.mutationFn;
+        return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+      },
+    );
+
+    usePostSmartSetup();
+
+    const vars = {
+      projectId: 'proj-1',
+      data: { annualIncome: 60000, date: '2026-01-01', defaultCategories: [], emergencyReserveTarget: 5000 },
+    };
+    await capturedMutationFn(vars);
+
+    expect(SmartSetupApi.postSmartSetup).toHaveBeenCalledWith(vars.projectId, vars.data);
+  });
+
+  it('onSuccess invalidates categories queries for the project', async () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedOnSuccess!: (result: unknown, vars: { projectId: string; data: unknown }) => void;
+    useMutation.mockImplementationOnce(
+      (opts: { onSuccess: typeof capturedOnSuccess }) => {
+        capturedOnSuccess = opts.onSuccess;
+        return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+      },
+    );
+
+    usePostSmartSetup();
+
+    capturedOnSuccess(undefined, { projectId: 'proj-1', data: {} });
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['categories', 'proj-1'],
+    });
+  });
+});

--- a/econoflow-mobile/src/hooks/useSmartSetup.ts
+++ b/econoflow-mobile/src/hooks/useSmartSetup.ts
@@ -1,0 +1,21 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as SmartSetupApi from '../api/smartSetup.api';
+import type { SmartSetupRequest } from '../api/types';
+
+export const useDefaultCategories = (projectId: string) =>
+  useQuery({
+    queryKey: ['defaultCategories', projectId],
+    queryFn: () => SmartSetupApi.getDefaultCategories(projectId).then((r) => r.data),
+    staleTime: 60_000,
+  });
+
+export const usePostSmartSetup = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ projectId, data }: { projectId: string; data: SmartSetupRequest }) =>
+      SmartSetupApi.postSmartSetup(projectId, data).then((r) => r.data),
+    onSuccess: (_result, { projectId }) => {
+      queryClient.invalidateQueries({ queryKey: ['categories', projectId] });
+    },
+  });
+};

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -98,6 +98,7 @@
   "ButtonTryAgain": "Try Again",
   "ButtonSaveAndContinue": "Save and continue",
   "ButtonAccept": "Accept",
+  "ButtonNewProject": "New project",
 
   "MenuAccount": "Account",
   "MenuPasswordAuthentication": "Password and Authentication",
@@ -558,5 +559,30 @@
   "Optional": "optional",
   "LabelUndoDelete": "Deleted. Undo?",
   "LabelUndoArchive": "Archived. Undo?",
-  "ButtonUndo": "Undo"
+  "ButtonUndo": "Undo",
+
+  "TaxYearTypeCalendar": "Calendar Year",
+  "TaxYearTypeCustom": "Custom Start Month",
+  "TaxYearLabelingByStart": "By Start Year",
+  "TaxYearLabelingByEnd": "By End Year",
+
+  "SmartSetupTitle": "Smart Setup",
+  "SmartSetupSubtitle": "Let's configure your budget in a few quick steps.",
+  "SmartSetupStep1Title": "Annual Income",
+  "SmartSetupStep1Description": "Enter your average annual income. We use this to distribute your monthly budget.",
+  "SmartSetupStep2Title": "Budget Allocation",
+  "SmartSetupStep2Description": "Assign a percentage of your monthly income to each category.",
+  "SmartSetupPercentageRemaining": "{{amount}} remaining",
+  "SmartSetupPercentageExceeded": "{{amount}} exceeded",
+  "SmartSetupMonthlyBudgetPreview": "≈ {{amount}}/month",
+  "SmartSetupStep3Title": "Emergency Reserve",
+  "SmartSetupStep3Description": "We suggest saving 6 months of your fixed expenses as an emergency reserve.",
+  "SmartSetupEmergencyReserveLabel": "Emergency Reserve Target",
+  "SmartSetupEmergencyReserveHint": "Suggested: 6 months of expenses. You can adjust this value.",
+  "SmartSetupSkip": "Skip",
+  "SmartSetupNext": "Next",
+  "SmartSetupBack": "Back",
+  "SmartSetupFinish": "Finish",
+  "SmartSetupAddCategory": "Add Category",
+  "SmartSetupCategoryNamePlaceholder": "Category name"
 }

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -98,6 +98,7 @@
   "ButtonTryAgain": "Tentar novamente",
   "ButtonSaveAndContinue": "Salvar e continuar",
   "ButtonAccept": "Aceitar",
+  "ButtonNewProject": "Novo projeto",
 
   "MenuAccount": "Conta",
   "MenuPasswordAuthentication": "Senhas e Autenticação",
@@ -557,6 +558,31 @@
   "Optional": "opcional",
   "LabelUndoDelete": "Excluído. Desfazer?",
   "LabelUndoArchive": "Arquivado. Desfazer?",
-  "ButtonUndo": "Desfazer"
+  "ButtonUndo": "Desfazer",
+
+  "TaxYearTypeCalendar": "Ano civil",
+  "TaxYearTypeCustom": "Mês de início personalizado",
+  "TaxYearLabelingByStart": "Pelo ano de início",
+  "TaxYearLabelingByEnd": "Pelo ano de fim",
+
+  "SmartSetupTitle": "Configuração Inteligente",
+  "SmartSetupSubtitle": "Vamos configurar seu orçamento em poucos passos.",
+  "SmartSetupStep1Title": "Renda Anual",
+  "SmartSetupStep1Description": "Informe sua renda anual média. Usaremos isso para distribuir seu orçamento mensal.",
+  "SmartSetupStep2Title": "Alocação do Orçamento",
+  "SmartSetupStep2Description": "Atribua uma porcentagem da sua renda mensal a cada categoria.",
+  "SmartSetupPercentageRemaining": "{{amount}} restante",
+  "SmartSetupPercentageExceeded": "{{amount}} excedido",
+  "SmartSetupMonthlyBudgetPreview": "≈ {{amount}}/mês",
+  "SmartSetupStep3Title": "Reserva de Emergência",
+  "SmartSetupStep3Description": "Sugerimos guardar 6 meses de despesas fixas como reserva de emergência.",
+  "SmartSetupEmergencyReserveLabel": "Meta de Reserva de Emergência",
+  "SmartSetupEmergencyReserveHint": "Sugestão: 6 meses de despesas. Você pode ajustar esse valor.",
+  "SmartSetupSkip": "Pular",
+  "SmartSetupNext": "Próximo",
+  "SmartSetupBack": "Voltar",
+  "SmartSetupFinish": "Concluir",
+  "SmartSetupAddCategory": "Adicionar Categoria",
+  "SmartSetupCategoryNamePlaceholder": "Nome da categoria"
 }
 

--- a/econoflow-mobile/src/navigation/MainNavigator.tsx
+++ b/econoflow-mobile/src/navigation/MainNavigator.tsx
@@ -12,6 +12,7 @@ import { OverviewStackNavigator } from './OverviewStackNavigator';
 import { ProfileScreen } from '../screens/profile/ProfileScreen';
 import { QuickAddModal } from '../screens/quick-add/QuickAddModal';
 import { useQuickAddStore } from '../store/quickAddStore';
+import { useUIStore } from '../store/uiStore';
 import { currentMonth } from '../utils/date';
 
 type IconName = ComponentProps<typeof MaterialCommunityIcons>['name'];
@@ -34,6 +35,7 @@ export const MainNavigator: React.FC = () => {
   const dark   = useColorScheme() === 'dark';
   const barBg  = dark ? 'rgba(6,30,51,0.92)' : 'rgba(230,239,246,0.92)';
   const barBorder = dark ? 'rgba(255,255,255,0.08)' : 'rgba(13,33,55,0.08)';
+  const hideTabBar = useUIStore((s) => s.hideTabBar);
   const [quickAddVisible, setQuickAddVisible] = useState(false);
   const quickAddCategoryId = useQuickAddStore(s => s.categoryId);
   const quickAddDefaultType = useQuickAddStore(s => s.defaultType);
@@ -45,14 +47,16 @@ export const MainNavigator: React.FC = () => {
       initialRouteName="Overview"
       screenOptions={({ route }) => ({
         headerShown: false,
-        tabBarStyle: {
-          backgroundColor: barBg,
-          borderTopColor: barBorder,
-          borderTopWidth: StyleSheet.hairlineWidth,
-          height: 64,
-          paddingBottom: 8,
-          paddingTop: 6,
-        },
+        tabBarStyle: hideTabBar
+          ? { display: 'none' as const }
+          : {
+            backgroundColor: barBg,
+            borderTopColor: barBorder,
+            borderTopWidth: StyleSheet.hairlineWidth,
+            height: 64,
+            paddingBottom: 8,
+            paddingTop: 6,
+          },
         tabBarActiveTintColor:   '#0f76a8',
         tabBarInactiveTintColor: dark ? '#8aa0b6' : '#9aa9b8',
         tabBarIcon: ({ color, size }) => {

--- a/econoflow-mobile/src/navigation/ProjectStackNavigator.tsx
+++ b/econoflow-mobile/src/navigation/ProjectStackNavigator.tsx
@@ -3,10 +3,12 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { ProjectListScreen } from '../screens/projects/ProjectListScreen';
 import { CreateProjectScreen } from '../screens/projects/CreateProjectScreen';
+import { SmartSetupScreen } from '../screens/projects/SmartSetupScreen';
 
 export type ProjectStackParamList = {
   ProjectList: undefined;
   CreateProject: undefined;
+  SmartSetup: { projectId: string };
 };
 
 const Stack = createNativeStackNavigator<ProjectStackParamList>();
@@ -24,7 +26,12 @@ export const ProjectStackNavigator: React.FC = () => {
       <Stack.Screen
         name="CreateProject"
         component={CreateProjectScreen}
-        options={{ title: t('CreateEditProject') }}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="SmartSetup"
+        component={SmartSetupScreen}
+        options={{ headerShown: false, title: t('SmartSetupTitle') }}
       />
     </Stack.Navigator>
   );

--- a/econoflow-mobile/src/screens/projects/CreateProjectScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/CreateProjectScreen.tsx
@@ -1,108 +1,341 @@
-import React from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
-import { Button, Text, TextInput, HelperText } from 'react-native-paper';
+import React, { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { HelperText } from 'react-native-paper';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { ProjectStackParamList } from '../../navigation/ProjectStackNavigator';
-import type { MainTabParamList } from '../../navigation/MainNavigator';
 import { useCreateProject } from '../../hooks/useProjects';
+import { putTaxYearSettings } from '../../api/projects.api';
 import { useProjectStore } from '../../store/projectStore';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { useAppTheme } from '../../theme/useAppTheme';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { GlassCard } from '../../components/common/GlassCard';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { AuthHero } from '../../components/auth/AuthHero';
+import { AuroraField } from '../../components/auth/AuroraField';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 
 type Props = {
   navigation: NativeStackNavigationProp<ProjectStackParamList, 'CreateProject'>;
 };
 
+type TaxYearType = 'CalendarYear' | 'CustomStartMonth';
+type TaxYearLabeling = 'ByStartYear' | 'ByEndYear';
+
 interface FormValues {
   name: string;
   preferredCurrency: string;
+  taxYearStartMonth: string;
+  taxYearStartDay: string;
 }
 
 export const CreateProjectScreen: React.FC<Props> = ({ navigation }) => {
   const { t } = useTranslation();
+  const { dark, ink, ink2, hair } = useAuroraSkin();
+  const { colors } = useAppTheme();
+  const insets = useSafeAreaInsets();
   const createProject = useCreateProject();
   const { setSelectedProject } = useProjectStore();
 
-  const { control, handleSubmit, formState: { errors } } = useForm<FormValues>({
-    defaultValues: { name: '', preferredCurrency: 'EUR' },
+  const [taxYearType, setTaxYearType] = useState<TaxYearType>('CalendarYear');
+  const [taxYearLabeling, setTaxYearLabeling] = useState<TaxYearLabeling>('ByStartYear');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      name: '',
+      preferredCurrency: 'EUR',
+      taxYearStartMonth: '',
+      taxYearStartDay: '',
+    },
   });
 
-  const onSubmit = (values: FormValues) => {
-    createProject.mutate(values, {
-      onSuccess: (project) => {
-        setSelectedProject(project);
-        navigation.getParent<BottomTabNavigationProp<MainTabParamList>>()?.navigate('Overview');
-      },
-    });
+  const onSubmit = async (values: FormValues) => {
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const userProject = await createProject.mutateAsync({
+        name: values.name,
+        preferredCurrency: values.preferredCurrency.toUpperCase(),
+      });
+
+      await putTaxYearSettings(userProject.project.id, {
+        taxYearType,
+        ...(taxYearType === 'CustomStartMonth' && {
+          taxYearStartMonth: parseInt(values.taxYearStartMonth, 10),
+          taxYearStartDay: parseInt(values.taxYearStartDay, 10),
+          taxYearLabeling,
+        }),
+      });
+
+      setSelectedProject(userProject);
+      navigation.navigate('SmartSetup', { projectId: userProject.project.id });
+    } catch {
+      setError(t('ErrorGeneric'));
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
+  const toggleBg = dark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.52)';
+  const toggleBorder = dark ? 'rgba(255,255,255,0.14)' : 'rgba(255,255,255,0.86)';
+  const activeBg = colors.primary;
+
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text variant="headlineSmall" style={styles.title}>
-        {t('CreateEditProject')}
-      </Text>
-
-      <Controller
-        control={control}
-        name="name"
-        rules={{ required: t('RequiredField') }}
-        render={({ field: { onChange, value } }) => (
-          <TextInput
-            label={t('FieldProjectName')}
-            value={value}
-            onChangeText={onChange}
-            style={styles.input}
-            error={!!errors.name}
-          />
-        )}
-      />
-      {errors.name && <HelperText type="error">{errors.name.message}</HelperText>}
-
-      <Controller
-        control={control}
-        name="preferredCurrency"
-        rules={{ required: t('RequiredField') }}
-        render={({ field: { onChange, value } }) => (
-          <TextInput
-            label={t('FieldCurrency')}
-            value={value}
-            onChangeText={(text) => onChange(text.toUpperCase())}
-            autoCapitalize="characters"
-            maxLength={3}
-            style={styles.input}
-            error={!!errors.preferredCurrency}
-          />
-        )}
-      />
-      {errors.preferredCurrency && (
-        <HelperText type="error">{errors.preferredCurrency.message}</HelperText>
-      )}
-      <HelperText type="info">
-        {t('LabelCommonCurrencies')}
-      </HelperText>
-
-      <Button
-        mode="contained"
-        onPress={handleSubmit(onSubmit)}
-        loading={createProject.isPending}
-        disabled={createProject.isPending}
-        style={styles.button}
+    <GlassScreen dark={dark}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
-        {t('ButtonCreate')}
-      </Button>
+        <ScrollView
+          contentContainerStyle={[
+            styles.scroll,
+            { paddingTop: insets.top + 16, paddingBottom: insets.bottom + 24 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          <AuthHero dark={dark} subtitle={t('CreateEditProject')} />
 
-      <Button mode="text" onPress={() => navigation.goBack()} style={styles.link}>
-        {t('ButtonCancel')}
-      </Button>
-    </ScrollView>
+          <GlassCard dark={dark} radius={26} style={styles.card}>
+            <Text style={[styles.cardTitle, { color: ink }]}>
+              {t('CreateEditProject')}
+            </Text>
+
+            {/* Project name */}
+            <Controller
+              control={control}
+              name="name"
+              rules={{
+                required: t('RequiredField'),
+                maxLength: { value: 60, message: t('PropertyMaxLength', { field: t('FieldProjectName'), max: 60 }) },
+              }}
+              render={({ field: { onChange, value } }) => (
+                <AuroraField
+                  dark={dark}
+                  icon="folder-outline"
+                  testID={t('PlaceholderProjectName')}
+                  placeholder={t('PlaceholderProjectName')}
+                  value={value}
+                  onChangeText={onChange}
+                  hasError={!!errors.name}
+                  autoCorrect={false}
+                />
+              )}
+            />
+            {errors.name && (
+              <HelperText type="error">{errors.name.message}</HelperText>
+            )}
+
+            {/* Currency */}
+            <Controller
+              control={control}
+              name="preferredCurrency"
+              rules={{ required: t('RequiredField') }}
+              render={({ field: { onChange, value } }) => (
+                <AuroraField
+                  dark={dark}
+                  icon="currency-usd"
+                  testID={t('FieldCurrency')}
+                  placeholder={t('FieldCurrency')}
+                  value={value}
+                  onChangeText={(text) => onChange(text.toUpperCase())}
+                  autoCapitalize="characters"
+                  maxLength={3}
+                  hasError={!!errors.preferredCurrency}
+                />
+              )}
+            />
+            {errors.preferredCurrency && (
+              <HelperText type="error">{errors.preferredCurrency.message}</HelperText>
+            )}
+            <Text style={[styles.hint, { color: ink2 }]}>{t('LabelCommonCurrencies')}</Text>
+
+            {/* Tax year type toggle */}
+            <Text style={[styles.sectionLabel, { color: ink2 }]}>
+              {t('FieldTaxYearType')}
+            </Text>
+            <View style={[styles.toggleRow, { borderColor: hair }]}>
+              {(['CalendarYear', 'CustomStartMonth'] as const).map((type) => (
+                <TouchableOpacity
+                  key={type}
+                  style={[
+                    styles.toggleBtn,
+                    {
+                      backgroundColor: taxYearType === type ? activeBg : toggleBg,
+                      borderColor: taxYearType === type ? activeBg : toggleBorder,
+                    },
+                  ]}
+                  onPress={() => setTaxYearType(type)}
+                >
+                  <Text
+                    style={[
+                      styles.toggleBtnText,
+                      { color: taxYearType === type ? '#fff' : ink },
+                    ]}
+                  >
+                    {t(type === 'CalendarYear' ? 'TaxYearTypeCalendar' : 'TaxYearTypeCustom')}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            {/* Conditional custom tax year fields */}
+            {taxYearType === 'CustomStartMonth' && (
+              <>
+                <Controller
+                  control={control}
+                  name="taxYearStartMonth"
+                  rules={{
+                    required: t('RequiredField'),
+                    validate: (v) => {
+                      const n = parseInt(v, 10);
+                      return (n >= 1 && n <= 12) || t('OnlyNumbersIsValid');
+                    },
+                  }}
+                  render={({ field: { onChange, value } }) => (
+                    <AuroraField
+                      dark={dark}
+                      icon="calendar-month-outline"
+                      testID={t('FieldTaxYearStartMonth')}
+                      placeholder={t('FieldTaxYearStartMonth')}
+                      value={value}
+                      onChangeText={onChange}
+                      keyboardType="number-pad"
+                      maxLength={2}
+                      hasError={!!errors.taxYearStartMonth}
+                    />
+                  )}
+                />
+                {errors.taxYearStartMonth && (
+                  <HelperText type="error">{errors.taxYearStartMonth.message}</HelperText>
+                )}
+
+                <Controller
+                  control={control}
+                  name="taxYearStartDay"
+                  rules={{
+                    required: t('RequiredField'),
+                    validate: (v) => {
+                      const n = parseInt(v, 10);
+                      return (n >= 1 && n <= 31) || t('OnlyNumbersIsValid');
+                    },
+                  }}
+                  render={({ field: { onChange, value } }) => (
+                    <AuroraField
+                      dark={dark}
+                      icon="calendar-today"
+                      testID={t('FieldTaxYearStartDay')}
+                      placeholder={t('FieldTaxYearStartDay')}
+                      value={value}
+                      onChangeText={onChange}
+                      keyboardType="number-pad"
+                      maxLength={2}
+                      hasError={!!errors.taxYearStartDay}
+                    />
+                  )}
+                />
+                {errors.taxYearStartDay && (
+                  <HelperText type="error">{errors.taxYearStartDay.message}</HelperText>
+                )}
+
+                {/* Year labeling toggle */}
+                <Text style={[styles.sectionLabel, { color: ink2 }]}>
+                  {t('FieldTaxYearLabeling')}
+                </Text>
+                <View style={[styles.toggleRow, { borderColor: hair }]}>
+                  {(['ByStartYear', 'ByEndYear'] as const).map((label) => (
+                    <TouchableOpacity
+                      key={label}
+                      style={[
+                        styles.toggleBtn,
+                        {
+                          backgroundColor: taxYearLabeling === label ? activeBg : toggleBg,
+                          borderColor: taxYearLabeling === label ? activeBg : toggleBorder,
+                        },
+                      ]}
+                      onPress={() => setTaxYearLabeling(label)}
+                    >
+                      <Text
+                        style={[
+                          styles.toggleBtnText,
+                          { color: taxYearLabeling === label ? '#fff' : ink },
+                        ]}
+                      >
+                        {t(label === 'ByStartYear' ? 'TaxYearLabelingByStart' : 'TaxYearLabelingByEnd')}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </>
+            )}
+
+            <ErrorBanner
+              visible={!!error}
+              message={error ?? undefined}
+              onDismiss={() => setError(null)}
+            />
+
+            <AuroraPrimaryButton
+              testID={t('ButtonCreate')}
+              label={t('ButtonCreate')}
+              onPress={handleSubmit(onSubmit)}
+              loading={isSubmitting}
+              icon="arrow-right"
+            />
+          </GlassCard>
+
+          {/* Cancel */}
+          <TouchableOpacity
+            style={[styles.cancelBtn, { backgroundColor: toggleBg, borderColor: toggleBorder }]}
+            onPress={() => navigation.goBack()}
+          >
+            <Text style={[styles.cancelText, { color: ink2 }]}>{t('ButtonCancel')}</Text>
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </GlassScreen>
   );
 };
 
 const styles = StyleSheet.create({
-  container: { flexGrow: 1, padding: 24, gap: 4 },
-  title: { marginBottom: 16, fontWeight: 'bold' },
-  input: { marginBottom: 4 },
-  button: { marginTop: 16 },
-  link: { marginTop: 4 },
+  flex: { flex: 1 },
+  scroll: { flexGrow: 1, paddingHorizontal: 20 },
+  card: { padding: 22, marginBottom: 16 },
+  cardTitle: { fontSize: 19, fontWeight: '800', marginBottom: 12 },
+  hint: { fontSize: 12, marginTop: 4, marginBottom: 8 },
+  sectionLabel: { fontSize: 13, fontWeight: '600', marginTop: 16, marginBottom: 6 },
+  toggleRow: { flexDirection: 'row', gap: 8 },
+  toggleBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    alignItems: 'center',
+  },
+  toggleBtnText: { fontSize: 13, fontWeight: '600' },
+  cancelBtn: {
+    marginHorizontal: 20,
+    paddingVertical: 14,
+    borderRadius: 14,
+    borderWidth: 1,
+    alignItems: 'center',
+  },
+  cancelText: { fontSize: 14, fontWeight: '600' },
 });

--- a/econoflow-mobile/src/screens/projects/ProjectListScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/ProjectListScreen.tsx
@@ -16,6 +16,7 @@ import { LoadingIndicator } from '../../components/common/LoadingIndicator';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import type { UserProject } from '../../api/types';
 
 type Props = {
@@ -77,13 +78,6 @@ export const ProjectListScreen: React.FC<Props> = ({ navigation }) => {
           <View style={styles.emptyWrap}>
             <MaterialCommunityIcons name="folder-open-outline" size={52} color={ink2} />
             <Text style={[styles.emptyText, { color: ink2 }]}>{t('LabelNoProjects')}</Text>
-            <TouchableOpacity
-              onPress={() => navigation.navigate('CreateProject')}
-              style={styles.emptyBtn}
-              activeOpacity={0.85}
-            >
-              <Text style={styles.emptyBtnText}>{t('ButtonCreate') ?? 'Create project'}</Text>
-            </TouchableOpacity>
           </View>
         ) : (
           (projects ?? []).map((item, idx) => {
@@ -138,6 +132,14 @@ export const ProjectListScreen: React.FC<Props> = ({ navigation }) => {
           })
         )}
       </ScrollView>
+
+      <View style={[styles.addBtnWrap, { paddingBottom: insets.bottom + 8 }]}>
+        <AuroraPrimaryButton
+          label={t('ButtonNewProject')}
+          onPress={() => navigation.navigate('CreateProject')}
+          icon="plus"
+        />
+      </View>
     </GlassScreen>
   );
 };
@@ -159,11 +161,8 @@ const styles = StyleSheet.create({
 
   emptyWrap: { alignItems: 'center', paddingTop: 80, gap: 12 },
   emptyText: { fontSize: 15, textAlign: 'center', opacity: 0.7 },
-  emptyBtn: {
-    marginTop: 8, paddingHorizontal: 22, paddingVertical: 13,
-    borderRadius: 14, backgroundColor: '#0f76a8',
-  },
-  emptyBtnText: { color: '#fff', fontWeight: '800', fontSize: 14.5 },
+
+  addBtnWrap: { paddingHorizontal: 22, paddingTop: 4 },
 
   card: { overflow: 'hidden' },
   cardRow: {

--- a/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
@@ -1,0 +1,531 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { CommonActions } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RouteProp } from '@react-navigation/native';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import dayjs from 'dayjs';
+import type { ProjectStackParamList } from '../../navigation/ProjectStackNavigator';
+import type { MainTabParamList } from '../../navigation/MainNavigator';
+import { useDefaultCategories, usePostSmartSetup } from '../../hooks/useSmartSetup';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { useAppTheme } from '../../theme/useAppTheme';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { GlassCard } from '../../components/common/GlassCard';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { AuroraField } from '../../components/auth/AuroraField';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
+
+type Props = {
+  navigation: NativeStackNavigationProp<ProjectStackParamList, 'SmartSetup'>;
+  route: RouteProp<ProjectStackParamList, 'SmartSetup'>;
+};
+
+interface CategoryAllocation {
+  id: string;
+  name: string;
+  percentage: number;
+  percentageStr: string;
+}
+
+const TOTAL_STEPS = 3;
+const THUMB_HALF = 10;
+
+// ─── CategorySlider ─────────────────────────────────────────────────────────
+// Extracted as a standalone component so each slider owns its width ref.
+// This prevents stale-closure bugs that occur when handlers are inlined
+// inside a parent .map() where React may share closure state across items.
+
+interface CategorySliderProps {
+  testID: string;
+  value: number;
+  onValueChange: (v: number) => void;
+  fillColor: string;
+  trackColor: string;
+}
+
+const CategorySlider: React.FC<CategorySliderProps> = ({
+  testID,
+  value,
+  onValueChange,
+  fillColor,
+  trackColor,
+}) => {
+  const widthRef = useRef(0);
+  const fillPct = Math.min(100, Math.max(0, value));
+
+  const handleTouch = (locationX: number) => {
+    const pct = Math.min(100, Math.max(0, Math.round((locationX / (widthRef.current || 1)) * 100)));
+    onValueChange(pct);
+  };
+
+  return (
+    <View
+      testID={testID}
+      style={sliderStyles.wrapper}
+      onLayout={(e) => { widthRef.current = e.nativeEvent.layout.width; }}
+      onStartShouldSetResponder={() => true}
+      onMoveShouldSetResponder={() => true}
+      onResponderGrant={(e) => handleTouch(e.nativeEvent.locationX)}
+      onResponderMove={(e) => handleTouch(e.nativeEvent.locationX)}
+    >
+      <View style={[sliderStyles.track, { backgroundColor: trackColor }]}>
+        <View style={[sliderStyles.fill, { width: `${fillPct}%`, backgroundColor: fillColor }]} />
+      </View>
+      <View
+        style={[
+          sliderStyles.thumb,
+          { left: `${fillPct}%`, backgroundColor: fillColor, transform: [{ translateX: -THUMB_HALF }] },
+        ]}
+      />
+    </View>
+  );
+};
+
+const sliderStyles = StyleSheet.create({
+  wrapper: { flex: 1, height: 24, justifyContent: 'center' },
+  track: { height: 6, borderRadius: 3, overflow: 'hidden' },
+  fill: { height: 6, borderRadius: 3 },
+  thumb: {
+    position: 'absolute',
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    top: 2,
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOpacity: 0.18,
+    shadowRadius: 3,
+    shadowOffset: { width: 0, height: 1 },
+  },
+});
+
+const getCurrencySymbol = (code: string): string => {
+  try {
+    const parts = new Intl.NumberFormat('en', { style: 'currency', currency: code }).formatToParts(0);
+    return parts.find((p) => p.type === 'currency')?.value ?? code;
+  } catch {
+    return code;
+  }
+};
+
+export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
+  const { projectId } = route.params;
+  const { t } = useTranslation();
+  const { dark, ink, ink2, hair } = useAuroraSkin();
+  const { colors, customColors } = useAppTheme();
+  const insets = useSafeAreaInsets();
+
+  const [step, setStep] = useState(0);
+  const [annualIncomeStr, setAnnualIncomeStr] = useState('');
+  const [categories, setCategories] = useState<CategoryAllocation[]>([]);
+  const [emergencyInput, setEmergencyInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const initialized = useRef(false);
+
+  const { currency } = useProjectStore();
+  const setHideTabBar = useUIStore((s) => s.setHideTabBar);
+  const { data: defaultCategoriesData } = useDefaultCategories(projectId);
+  const postSmartSetupMutation = usePostSmartSetup();
+
+  useEffect(() => {
+    setHideTabBar(true);
+    return () => { setHideTabBar(false); };
+  }, [setHideTabBar]);
+
+  useEffect(() => {
+    if (defaultCategoriesData && !initialized.current) {
+      initialized.current = true;
+      setCategories(
+        defaultCategoriesData.map((c, idx) => ({
+          id: c.id ?? `default-${idx}`,
+          name: c.name,
+          percentage: c.percentage,
+          percentageStr: String(c.percentage),
+        })),
+      );
+    }
+  }, [defaultCategoriesData]);
+
+  const annualIncome = parseFloat(annualIncomeStr) || 0;
+  const monthlyIncome = annualIncome / 12;
+
+  const percentageTotal = categories.reduce(
+    (sum, c) => sum + (parseFloat(c.percentageStr) || 0),
+    0,
+  );
+
+  const navigateToOverview = () => {
+    navigation.dispatch(
+      CommonActions.reset({ index: 0, routes: [{ name: 'ProjectList' }] }),
+    );
+    navigation.getParent<BottomTabNavigationProp<MainTabParamList>>()?.navigate('Overview');
+  };
+
+  const goToStep = (next: number) => {
+    if (next === 2) {
+      const reserve = (monthlyIncome * 6).toFixed(2);
+      setEmergencyInput(reserve);
+    }
+    setStep(next);
+  };
+
+  const handleFinish = async () => {
+    setError(null);
+    try {
+      await postSmartSetupMutation.mutateAsync({
+        projectId,
+        data: {
+          annualIncome,
+          date: dayjs().format('YYYY-MM-DD'),
+          defaultCategories: categories.map((c) => ({
+            id: c.id,
+            name: c.name,
+            percentage: parseFloat(c.percentageStr) || 0,
+          })),
+          emergencyReserveTarget: parseFloat(emergencyInput) || 0,
+        },
+      });
+      navigateToOverview();
+    } catch {
+      setError(t('ErrorGeneric'));
+    }
+  };
+
+  const updateCategoryPct = (id: string, pctStr: string) => {
+    const pct = Math.min(100, Math.max(0, parseFloat(pctStr) || 0));
+    setCategories((prev) =>
+      prev.map((c) => (c.id === id ? { ...c, percentageStr: pctStr, percentage: pct } : c)),
+    );
+  };
+
+  const updateCategoryName = (id: string, name: string) => {
+    setCategories((prev) => prev.map((c) => (c.id === id ? { ...c, name } : c)));
+  };
+
+  const removeCategory = (id: string) => {
+    setCategories((prev) => prev.filter((c) => c.id !== id));
+  };
+
+  const addCategory = () => {
+    const newId = `new-${Date.now()}`;
+    setCategories((prev) => [
+      ...prev,
+      { id: newId, name: '', percentage: 0, percentageStr: '0' },
+    ]);
+  };
+
+  const toggleBg = dark ? 'rgba(255,255,255,0.07)' : 'rgba(255,255,255,0.52)';
+  const toggleBorder = dark ? 'rgba(255,255,255,0.14)' : 'rgba(255,255,255,0.86)';
+
+  const percentageDiff = percentageTotal - 100;
+  const percentageDiffAbs = Math.abs((percentageDiff * monthlyIncome) / 100);
+  const percentageDiffFormatted = percentageDiffAbs.toFixed(2);
+
+  const step1Valid = annualIncome > 0;
+  // Allow any total ≤ 100% — only block when the user has over-allocated.
+  const step2Valid = percentageDiff <= 0.5;
+
+  // ─── Header ────────────────────────────────────────────────────────────────
+
+  const renderHeader = () => (
+    <View style={[styles.header, { paddingTop: insets.top + 8, borderBottomColor: hair }]}>
+      <View style={styles.headerLeft}>
+        {step > 0 && (
+          <TouchableOpacity onPress={() => setStep((s) => s - 1)}>
+            <Text style={[styles.headerAction, { color: ink2 }]}>{t('SmartSetupBack')}</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+      <Text style={[styles.headerTitle, { color: ink }]}>{t('SmartSetupTitle')}</Text>
+      <TouchableOpacity onPress={navigateToOverview} style={styles.headerRight}>
+        <Text style={[styles.headerAction, { color: colors.primary }]}>{t('SmartSetupSkip')}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  // ─── Progress bar ──────────────────────────────────────────────────────────
+
+  const renderProgress = () => (
+    <View style={[styles.progressRow, { paddingHorizontal: 20 }]}>
+      {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
+        <View
+          key={i}
+          testID={`progress-step-${i}`}
+          style={[
+            styles.progressPill,
+            { backgroundColor: colors.primary, opacity: i <= step ? 1 : 0.25 },
+          ]}
+        />
+      ))}
+    </View>
+  );
+
+  // ─── Step 1 ────────────────────────────────────────────────────────────────
+
+  const renderStep1 = () => (
+    <View style={styles.stepContent}>
+      <Text style={[styles.stepTitle, { color: ink }]}>{t('SmartSetupStep1Title')}</Text>
+      <Text style={[styles.stepDescription, { color: ink2 }]}>
+        {t('SmartSetupStep1Description')}
+      </Text>
+      <GlassCard dark={dark} radius={18} style={styles.fieldCard}>
+        <AuroraField
+          dark={dark}
+          textPrefix={getCurrencySymbol(currency)}
+          testID={t('FieldAnnualIncome')}
+          placeholder={t('FieldAnnualIncome')}
+          value={annualIncomeStr}
+          onChangeText={setAnnualIncomeStr}
+          keyboardType="decimal-pad"
+        />
+      </GlassCard>
+      <AuroraPrimaryButton
+        testID={t('SmartSetupNext')}
+        label={t('SmartSetupNext')}
+        onPress={() => goToStep(1)}
+        disabled={!step1Valid}
+        icon="arrow-right"
+      />
+    </View>
+  );
+
+  // ─── Step 2 ────────────────────────────────────────────────────────────────
+
+  const renderStep2 = () => {
+    let footerColor: string;
+    let footerMessage: string;
+
+    if (percentageDiff > 0.5) {
+      footerColor = colors.error;
+      footerMessage = t('SmartSetupPercentageExceeded', {
+        amount: percentageDiffFormatted,
+      });
+    } else if (percentageDiff < -0.5) {
+      footerColor = customColors.warning;
+      footerMessage = t('SmartSetupPercentageRemaining', {
+        amount: percentageDiffFormatted,
+      });
+    } else {
+      footerColor = customColors.success;
+      footerMessage = t('FullDistribution');
+    }
+
+    return (
+      <View style={styles.stepContent}>
+        <Text style={[styles.stepTitle, { color: ink }]}>{t('SmartSetupStep2Title')}</Text>
+        <Text style={[styles.stepDescription, { color: ink2 }]}>
+          {t('SmartSetupStep2Description')}
+        </Text>
+
+        {categories.map((cat, index) => {
+          const monthly = (monthlyIncome * (parseFloat(cat.percentageStr) || 0)) / 100;
+          return (
+            <GlassCard key={cat.id || String(index)} dark={dark} radius={18} style={styles.categoryCard}>
+              {/* Name + delete row */}
+              <View style={styles.categoryNameRow}>
+                <View style={styles.categoryNameField}>
+                  <AuroraField
+                    dark={dark}
+                    testID={`${cat.id}-name`}
+                    placeholder={t('SmartSetupCategoryNamePlaceholder')}
+                    value={cat.name}
+                    onChangeText={(v) => updateCategoryName(cat.id, v)}
+                  />
+                </View>
+                <TouchableOpacity
+                  testID={`${cat.id}-delete`}
+                  onPress={() => removeCategory(cat.id)}
+                  style={styles.deleteBtn}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                >
+                  <MaterialCommunityIcons name="close-circle" size={20} color={colors.error} />
+                </TouchableOpacity>
+              </View>
+
+              {/* Slider + percentage input row */}
+              <View style={styles.sliderRow}>
+                <CategorySlider
+                  testID={`${cat.id}-pct-slider`}
+                  value={cat.percentage}
+                  onValueChange={(v) => updateCategoryPct(cat.id, String(v))}
+                  fillColor={colors.primary}
+                  trackColor={dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.10)'}
+                />
+                <View style={styles.pctInputWrapper}>
+                  <AuroraField
+                    dark={dark}
+                    textPrefix="%"
+                    placeholder="0"
+                    testID={`${cat.id}-pct`}
+                    value={cat.percentageStr}
+                    onChangeText={(v) => updateCategoryPct(cat.id, v)}
+                    keyboardType="decimal-pad"
+                  />
+                </View>
+              </View>
+
+              <Text style={[styles.monthlyPreview, { color: ink2 }]}>
+                {t('SmartSetupMonthlyBudgetPreview', { amount: monthly.toFixed(2) })}
+              </Text>
+            </GlassCard>
+          );
+        })}
+
+        {/* Add category */}
+        <TouchableOpacity
+          testID="add-category-btn"
+          style={[styles.addCategoryBtn, { borderColor: colors.primary }]}
+          onPress={addCategory}
+        >
+          <MaterialCommunityIcons name="plus" size={16} color={colors.primary} />
+          <Text style={[styles.addCategoryLabel, { color: colors.primary }]}>
+            {t('SmartSetupAddCategory')}
+          </Text>
+        </TouchableOpacity>
+
+        {/* Sticky footer total */}
+        <View style={[styles.totalRow, { backgroundColor: toggleBg, borderColor: toggleBorder }]}>
+          <Text style={[styles.totalLabel, { color: ink }]}>{t('Total')}</Text>
+          <Text style={[styles.totalValue, { color: footerColor }]}>
+            {percentageTotal.toFixed(1)}% — {footerMessage}
+          </Text>
+        </View>
+
+        <AuroraPrimaryButton
+          testID={t('SmartSetupNext')}
+          label={t('SmartSetupNext')}
+          onPress={() => goToStep(2)}
+          disabled={!step2Valid}
+          icon="arrow-right"
+        />
+      </View>
+    );
+  };
+
+  // ─── Step 3 ────────────────────────────────────────────────────────────────
+
+  const renderStep3 = () => (
+    <View style={styles.stepContent}>
+      <Text style={[styles.stepTitle, { color: ink }]}>{t('SmartSetupStep3Title')}</Text>
+      <Text style={[styles.stepDescription, { color: ink2 }]}>
+        {t('SmartSetupStep3Description')}
+      </Text>
+      <GlassCard dark={dark} radius={18} style={styles.fieldCard}>
+        <AuroraField
+          dark={dark}
+          textPrefix={getCurrencySymbol(currency)}
+          testID={t('SmartSetupEmergencyReserveLabel')}
+          placeholder={t('SmartSetupEmergencyReserveLabel')}
+          value={emergencyInput}
+          onChangeText={setEmergencyInput}
+          keyboardType="decimal-pad"
+        />
+      </GlassCard>
+      <Text style={[styles.hint, { color: ink2 }]}>{t('SmartSetupEmergencyReserveHint')}</Text>
+
+      <ErrorBanner
+        visible={!!error}
+        message={error ?? undefined}
+        onDismiss={() => setError(null)}
+      />
+
+      <AuroraPrimaryButton
+        testID={t('SmartSetupFinish')}
+        label={t('SmartSetupFinish')}
+        onPress={handleFinish}
+        loading={postSmartSetupMutation.isPending}
+        icon="check"
+      />
+    </View>
+  );
+
+  return (
+    <GlassScreen dark={dark}>
+      {renderHeader()}
+      {renderProgress()}
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={[
+            styles.scroll,
+            { paddingBottom: insets.bottom + 24 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          {step === 0 && renderStep1()}
+          {step === 1 && renderStep2()}
+          {step === 2 && renderStep3()}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </GlassScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerLeft: { flex: 1 },
+  headerTitle: { fontSize: 16, fontWeight: '700' },
+  headerRight: { flex: 1, alignItems: 'flex-end' },
+  headerAction: { fontSize: 14, fontWeight: '600' },
+  progressRow: { flexDirection: 'row', gap: 6, paddingVertical: 12 },
+  progressPill: { flex: 1, height: 4, borderRadius: 2 },
+  scroll: { flexGrow: 1, paddingHorizontal: 20 },
+  stepContent: { gap: 12, paddingTop: 4 },
+  stepTitle: { fontSize: 20, fontWeight: '800', marginBottom: 2 },
+  stepDescription: { fontSize: 13, fontWeight: '500', marginBottom: 8 },
+  fieldCard: { padding: 4 },
+  categoryCard: { padding: 14, gap: 8 },
+  categoryNameRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  categoryNameField: { flex: 1 },
+  deleteBtn: { padding: 2 },
+  sliderRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  pctInputWrapper: { width: 90 },
+  addCategoryBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 10,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+  },
+  addCategoryLabel: { fontSize: 13, fontWeight: '600' },
+  monthlyPreview: { fontSize: 12, marginTop: 2 },
+  totalRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginVertical: 4,
+  },
+  totalLabel: { fontSize: 14, fontWeight: '700' },
+  totalValue: { fontSize: 13, fontWeight: '600' },
+  hint: { fontSize: 12, marginTop: 4 },
+});

--- a/econoflow-mobile/src/screens/projects/__tests__/CreateProjectScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/CreateProjectScreen.test.tsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { CreateProjectScreen } from '../CreateProjectScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c', surface: '#fff' },
+    customColors: { success: '#2ecc71', warning: '#f39c12' },
+  }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
+  };
+});
+
+jest.mock('../../../components/auth/AuthHero', () => ({
+  AuthHero: jest.fn(() => null),
+}));
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({ testID, placeholder, value, onChangeText }: {
+      testID?: string;
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? placeholder,
+        value,
+        onChangeText,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading,
+    }: { label: string; onPress: () => void; loading?: boolean }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+jest.mock('expo-linear-gradient', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+const mockMutateAsync = jest.fn();
+const mockSetSelectedProject = jest.fn();
+
+jest.mock('../../../hooks/useProjects', () => ({
+  useCreateProject: jest.fn(() => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../api/projects.api', () => ({
+  putTaxYearSettings: jest.fn(),
+}));
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    setSelectedProject: mockSetSelectedProject,
+  })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+  goBack: mockGoBack,
+  dispatch: jest.fn(),
+} as unknown as React.ComponentProps<typeof CreateProjectScreen>['navigation'];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const MOCK_USER_PROJECT = {
+  id: 'up-1',
+  userId: 'u1',
+  userName: 'Test',
+  userEmail: 'test@test.com',
+  accepted: true,
+  role: 'Admin' as const,
+  project: { id: 'proj-1', name: 'My Project', preferredCurrency: 'EUR', isArchived: false },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getPutTaxYearMock = (): jest.Mock =>
+  (jest.requireMock('../../../api/projects.api') as any).putTaxYearSettings;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('CreateProjectScreen', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    mockNavigate.mockReset();
+    mockGoBack.mockReset();
+    mockSetSelectedProject.mockReset();
+    getPutTaxYearMock().mockReset();
+  });
+
+  it('shows required field error when name is empty on submit', async () => {
+    await render(<CreateProjectScreen navigation={mockNavigation} />);
+
+    await fireEvent.press(screen.getByTestId('ButtonCreate'));
+
+    expect(await screen.findByText('RequiredField')).toBeTruthy();
+  });
+
+  it('shows conditional tax year fields when Custom Start Month is selected', async () => {
+    await render(<CreateProjectScreen navigation={mockNavigation} />);
+
+    await fireEvent.press(screen.getByText('TaxYearTypeCustom'));
+
+    expect(screen.getByTestId('FieldTaxYearStartMonth')).toBeTruthy();
+    expect(screen.getByTestId('FieldTaxYearStartDay')).toBeTruthy();
+  });
+
+  it('hides conditional fields when Calendar Year is selected', async () => {
+    await render(<CreateProjectScreen navigation={mockNavigation} />);
+
+    await fireEvent.press(screen.getByText('TaxYearTypeCustom'));
+    await fireEvent.press(screen.getByText('TaxYearTypeCalendar'));
+
+    expect(screen.queryByTestId('FieldTaxYearStartMonth')).toBeNull();
+    expect(screen.queryByTestId('FieldTaxYearStartDay')).toBeNull();
+  });
+
+  it('calls createProject, putTaxYearSettings, sets project, and navigates to SmartSetup on success', async () => {
+    mockMutateAsync.mockResolvedValue(MOCK_USER_PROJECT);
+    getPutTaxYearMock().mockResolvedValue({ data: undefined });
+
+    await render(<CreateProjectScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderProjectName'), 'My Budget');
+    await fireEvent.changeText(screen.getByTestId('FieldCurrency'), 'EUR');
+    await fireEvent.press(screen.getByTestId('ButtonCreate'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'My Budget', preferredCurrency: 'EUR' }),
+      );
+      expect(getPutTaxYearMock()).toHaveBeenCalledWith(
+        'proj-1',
+        expect.objectContaining({ taxYearType: 'CalendarYear' }),
+      );
+      expect(mockSetSelectedProject).toHaveBeenCalledWith(MOCK_USER_PROJECT);
+      expect(mockNavigate).toHaveBeenCalledWith('SmartSetup', { projectId: 'proj-1' });
+    });
+  });
+
+  it('shows ErrorBanner when createProject API call fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+
+    await render(<CreateProjectScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderProjectName'), 'My Budget');
+    await fireEvent.changeText(screen.getByTestId('FieldCurrency'), 'EUR');
+    await fireEvent.press(screen.getByTestId('ButtonCreate'));
+
+    expect(await screen.findByTestId('error-banner', {}, { timeout: 3000 })).toBeTruthy();
+  });
+
+  it('calls goBack when cancel is pressed', async () => {
+    await render(<CreateProjectScreen navigation={mockNavigation} />);
+    await fireEvent.press(screen.getByText('ButtonCancel'));
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/econoflow-mobile/src/screens/projects/__tests__/ProjectListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/ProjectListScreen.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { ProjectListScreen } from '../ProjectListScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/LoadingIndicator', () => ({
+  LoadingIndicator: jest.fn(() => null),
+}));
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress,
+    }: { label: string; onPress: () => void }) =>
+      React.createElement(
+        TouchableOpacity,
+        { onPress, testID: `btn-${label}` },
+        React.createElement(Text, null, label),
+      ),
+  };
+});
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+const mockSetSelectedProject = jest.fn();
+
+jest.mock('../../../hooks/useProjects', () => ({
+  useProjects: jest.fn(() => ({ data: [], isLoading: false, refetch: jest.fn() })),
+}));
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: null,
+    setSelectedProject: mockSetSelectedProject,
+  })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+const mockGetParent = jest.fn(() => ({ navigate: jest.fn() }));
+
+const mockNavigation = {
+  navigate: mockNavigate,
+  getParent: mockGetParent,
+} as unknown as React.ComponentProps<typeof ProjectListScreen>['navigation'];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const MOCK_PROJECT = {
+  id: 'up-1',
+  userId: 'u1',
+  userName: 'Test',
+  userEmail: 'test@test.com',
+  accepted: true,
+  role: 'Admin' as const,
+  project: { id: 'proj-1', name: 'My Project', preferredCurrency: 'EUR', isArchived: false },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getUseProjectsMock = (): jest.Mock =>
+  (jest.requireMock('../../../hooks/useProjects') as any).useProjects;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ProjectListScreen', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockSetSelectedProject.mockReset();
+    mockGetParent.mockReturnValue({ navigate: jest.fn() });
+  });
+
+  it('shows the new project button when the list is empty', async () => {
+    getUseProjectsMock().mockReturnValue({ data: [], isLoading: false, refetch: jest.fn() });
+
+    await render(<ProjectListScreen navigation={mockNavigation} />);
+
+    expect(screen.getByTestId('btn-ButtonNewProject')).toBeTruthy();
+  });
+
+  it('shows the new project button when projects exist', async () => {
+    getUseProjectsMock().mockReturnValue({
+      data: [MOCK_PROJECT],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    await render(<ProjectListScreen navigation={mockNavigation} />);
+
+    expect(screen.getByTestId('btn-ButtonNewProject')).toBeTruthy();
+  });
+
+  it('navigates to CreateProject when the new project button is pressed', async () => {
+    getUseProjectsMock().mockReturnValue({
+      data: [MOCK_PROJECT],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    await render(<ProjectListScreen navigation={mockNavigation} />);
+
+    fireEvent.press(screen.getByTestId('btn-ButtonNewProject'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('CreateProject');
+  });
+});

--- a/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
@@ -1,0 +1,494 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { CommonActions } from '@react-navigation/native';
+import { SmartSetupScreen } from '../SmartSetupScreen';
+import type { DefaultCategory } from '../../../api/types';
+import { useUIStore } from '../../../store/uiStore';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c', surface: '#fff' },
+    customColors: { success: '#2ecc71', warning: '#f39c12' },
+  }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
+  };
+});
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput, Text, View } = require('react-native');
+  return {
+    AuroraField: ({ testID, placeholder, value, onChangeText, textPrefix }: {
+      testID?: string;
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+      textPrefix?: string;
+    }) =>
+      React.createElement(View, null,
+        textPrefix
+          ? React.createElement(Text, { testID: `${testID ?? placeholder}-prefix` }, textPrefix)
+          : null,
+        React.createElement(TextInput, {
+          testID: testID ?? placeholder,
+          value,
+          onChangeText,
+        }),
+      ),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading, disabled,
+    }: { label: string; onPress: () => void; loading?: boolean; disabled?: boolean }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: label, accessibilityState: { disabled: !!disabled } },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+jest.mock('expo-linear-gradient', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  CommonActions: {
+    reset: jest.fn((payload) => ({ type: 'RESET', payload })),
+  },
+}));
+
+jest.mock('dayjs', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dayjs = (): any => ({ format: () => '2026-01-01' });
+  return dayjs;
+});
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({ currency: 'EUR' })),
+}));
+
+// ─── Hook mocks ───────────────────────────────────────────────────────────────
+
+const MOCK_CATEGORIES: DefaultCategory[] = [
+  { id: 'cat-1', name: 'Housing', percentage: 60 },
+  { id: 'cat-2', name: 'Food', percentage: 40 },
+];
+
+const mockMutateAsync = jest.fn();
+
+jest.mock('../../../hooks/useSmartSetup', () => ({
+  useDefaultCategories: jest.fn(() => ({
+    data: MOCK_CATEGORIES,
+    isLoading: false,
+  })),
+  usePostSmartSetup: jest.fn(() => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+const mockDispatch = jest.fn();
+const mockParentNavigate = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+  dispatch: mockDispatch,
+  getParent: jest.fn(() => ({ navigate: mockParentNavigate })),
+} as unknown as React.ComponentProps<typeof SmartSetupScreen>['navigation'];
+
+const mockRoute = {
+  params: { projectId: 'proj-1' },
+} as unknown as React.ComponentProps<typeof SmartSetupScreen>['route'];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const goToStep2 = async () => {
+  await fireEvent.changeText(screen.getByTestId('FieldAnnualIncome'), '60000');
+  await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+  await screen.findByText('SmartSetupStep2Title');
+};
+
+const goToStep3 = async () => {
+  await goToStep2();
+  await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+  await screen.findByText('SmartSetupStep3Title');
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SmartSetupScreen', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    mockNavigate.mockReset();
+    mockDispatch.mockReset();
+    mockParentNavigate.mockReset();
+    (CommonActions.reset as jest.Mock).mockClear();
+    useUIStore.setState({ hideTabBar: false });
+  });
+
+  it('renders step 1 with annual income field by default', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByText('SmartSetupStep1Title')).toBeTruthy();
+    expect(screen.getByTestId('FieldAnnualIncome')).toBeTruthy();
+  });
+
+  it('shows Skip button on step 1', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByText('SmartSetupSkip')).toBeTruthy();
+  });
+
+  it('sets hideTabBar true on mount and false on unmount', async () => {
+    const { unmount } = await render(
+      <SmartSetupScreen navigation={mockNavigation} route={mockRoute} />,
+    );
+
+    expect(useUIStore.getState().hideTabBar).toBe(true);
+
+    await act(async () => { unmount(); });
+
+    expect(useUIStore.getState().hideTabBar).toBe(false);
+  });
+
+  it('Skip on step 1 resets the project stack and navigates to Overview', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await fireEvent.press(screen.getByText('SmartSetupSkip'));
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'RESET' }),
+    );
+    expect(mockParentNavigate).toHaveBeenCalledWith('Overview');
+  });
+
+  it('Next on step 1 is disabled when income field is empty', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    const nextBtn = screen.getByTestId('SmartSetupNext');
+    expect(nextBtn.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('Next on step 1 is enabled after entering a positive income', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await fireEvent.changeText(screen.getByTestId('FieldAnnualIncome'), '60000');
+
+    expect(screen.getByTestId('SmartSetupNext').props.accessibilityState?.disabled).toBe(false);
+  });
+
+  it('navigates to step 2 after entering income and pressing Next', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep2();
+
+    expect(screen.getByText('SmartSetupStep2Title')).toBeTruthy();
+  });
+
+  it('renders category list in step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep2();
+
+    expect(screen.getByTestId('cat-1-name').props.value).toBe('Housing');
+    expect(screen.getByTestId('cat-2-name').props.value).toBe('Food');
+  });
+
+  it('Next on step 2 is disabled when total exceeds 100', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep2();
+
+    // 80 + 40 = 120 — over 100
+    await fireEvent.changeText(screen.getByTestId('cat-1-pct'), '80');
+
+    expect(screen.getByTestId('SmartSetupNext').props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('Next on step 2 is enabled when percentages sum to 100', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep2();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('SmartSetupNext').props.accessibilityState?.disabled).toBe(false);
+    });
+  });
+
+  it('Next on step 2 is enabled when total is less than 100', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep2();
+
+    // 30 + 40 = 70 — under 100 should now be allowed
+    await fireEvent.changeText(screen.getByTestId('cat-1-pct'), '30');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('SmartSetupNext').props.accessibilityState?.disabled).toBe(false);
+    });
+  });
+
+  it('navigates to step 3 from step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep3();
+
+    expect(screen.getByText('SmartSetupStep3Title')).toBeTruthy();
+  });
+
+  it('pre-fills emergency reserve in step 3 based on income', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await fireEvent.changeText(screen.getByTestId('FieldAnnualIncome'), '12000');
+    await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+    await screen.findByText('SmartSetupStep2Title');
+    await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+    await screen.findByText('SmartSetupStep3Title');
+
+    // 6 × (12000 / 12) = 6000
+    const reserveField = screen.getByTestId('SmartSetupEmergencyReserveLabel');
+    expect(reserveField.props.value).toBe('6000.00');
+  });
+
+  it('Finish calls postSmartSetup and navigates to Overview on success', async () => {
+    mockMutateAsync.mockResolvedValue(undefined);
+
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep3();
+    await fireEvent.press(screen.getByTestId('SmartSetupFinish'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        data: expect.objectContaining({
+          annualIncome: 60000,
+          date: '2026-01-01',
+          defaultCategories: expect.arrayContaining([
+            expect.objectContaining({ id: 'cat-1', percentage: 60 }),
+            expect.objectContaining({ id: 'cat-2', percentage: 40 }),
+          ]),
+        }),
+      });
+      expect(mockParentNavigate).toHaveBeenCalledWith('Overview');
+    });
+  });
+
+  it('shows ErrorBanner when Finish API call fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Server error'));
+
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep3();
+    await fireEvent.press(screen.getByTestId('SmartSetupFinish'));
+
+    expect(await screen.findByTestId('error-banner', {}, { timeout: 3000 })).toBeTruthy();
+  });
+
+  it('Skip on step 2 navigates to Overview', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep2();
+    await fireEvent.press(screen.getAllByText('SmartSetupSkip')[0]);
+
+    expect(mockParentNavigate).toHaveBeenCalledWith('Overview');
+  });
+
+  it('Back on step 2 returns to step 1', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep2();
+
+    await fireEvent.press(screen.getByText('SmartSetupBack'));
+
+    expect(await screen.findByText('SmartSetupStep1Title')).toBeTruthy();
+  });
+
+  it('Back on step 3 returns to step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep3();
+
+    await fireEvent.press(screen.getByText('SmartSetupBack'));
+
+    expect(await screen.findByText('SmartSetupStep2Title')).toBeTruthy();
+  });
+
+  it('progress bar step 0 is active on initial render', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    const pill = screen.getByTestId('progress-step-0');
+    const flatStyle = Array.isArray(pill.props.style)
+      ? Object.assign({}, ...pill.props.style)
+      : pill.props.style;
+    expect(flatStyle.opacity).toBe(1);
+  });
+
+  it('shows currency symbol from project store as prefix for income field', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    const prefix = screen.queryByTestId('FieldAnnualIncome-prefix');
+    expect(prefix?.props.children).toBe('€');
+  });
+
+  it('renders editable name input for each category in step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+
+    expect(screen.getByTestId('cat-1-name')).toBeTruthy();
+    expect(screen.getByTestId('cat-2-name')).toBeTruthy();
+  });
+
+  it('category name can be changed in step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+
+    await fireEvent.changeText(screen.getByTestId('cat-1-name'), 'Rent');
+
+    expect(screen.getByTestId('cat-1-name').props.value).toBe('Rent');
+  });
+
+  it('category can be deleted in step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+
+    await fireEvent.press(screen.getByTestId('cat-1-delete'));
+
+    expect(screen.queryByTestId('cat-1-name')).toBeNull();
+    expect(screen.getByTestId('cat-2-name')).toBeTruthy();
+  });
+
+  it('new category can be added in step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+
+    const beforeCount = screen.getAllByTestId(/-name$/).length;
+    await fireEvent.press(screen.getByTestId('add-category-btn'));
+
+    expect(screen.getAllByTestId(/-name$/).length).toBe(beforeCount + 1);
+  });
+
+  it('renders percentage slider alongside numeric input in step 2', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+
+    expect(screen.getByTestId('cat-1-pct-slider')).toBeTruthy();
+    expect(screen.getByTestId('cat-1-pct')).toBeTruthy();
+  });
+
+  it('updated category name is submitted in Finish payload', async () => {
+    mockMutateAsync.mockResolvedValue(undefined);
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+
+    await fireEvent.changeText(screen.getByTestId('cat-1-name'), 'Rent');
+    await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+    await screen.findByText('SmartSetupStep3Title');
+    await fireEvent.press(screen.getByTestId('SmartSetupFinish'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            defaultCategories: expect.arrayContaining([
+              expect.objectContaining({ id: 'cat-1', name: 'Rent' }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+
+  it('categories from API without ids get unique local ids so sliders are independent', async () => {
+    // The real API returns CategoryWithPercentageDTO which has no Id field.
+    // Without a local-id fallback every category gets id=undefined and all
+    // sliders share the same key, making every percentage update hit them all.
+    const hookMocks = require('../../../hooks/useSmartSetup') as {
+      useDefaultCategories: jest.Mock;
+    };
+    hookMocks.useDefaultCategories.mockReturnValueOnce({
+      data: [
+        { name: 'Housing', percentage: 60 } as import('../../../api/types').DefaultCategory,
+        { name: 'Food', percentage: 40 } as import('../../../api/types').DefaultCategory,
+      ],
+      isLoading: false,
+    });
+
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+
+    const nameInputs = screen.getAllByTestId(/-name$/);
+    const ids = nameInputs.map((el) => el.props.testID.replace('-name', ''));
+
+    // Each category must have a unique, non-"undefined" id
+    expect(ids[0]).not.toBe('undefined');
+    expect(ids[1]).not.toBe('undefined');
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+});

--- a/econoflow-mobile/src/store/__tests__/uiStore.test.ts
+++ b/econoflow-mobile/src/store/__tests__/uiStore.test.ts
@@ -1,0 +1,22 @@
+import { useUIStore } from '../uiStore';
+
+describe('uiStore', () => {
+  beforeEach(() => {
+    useUIStore.setState({ hideTabBar: false });
+  });
+
+  it('initializes with hideTabBar false', () => {
+    expect(useUIStore.getState().hideTabBar).toBe(false);
+  });
+
+  it('setHideTabBar(true) sets hideTabBar to true', () => {
+    useUIStore.getState().setHideTabBar(true);
+    expect(useUIStore.getState().hideTabBar).toBe(true);
+  });
+
+  it('setHideTabBar(false) restores hideTabBar to false', () => {
+    useUIStore.setState({ hideTabBar: true });
+    useUIStore.getState().setHideTabBar(false);
+    expect(useUIStore.getState().hideTabBar).toBe(false);
+  });
+});

--- a/econoflow-mobile/src/store/uiStore.ts
+++ b/econoflow-mobile/src/store/uiStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface UIState {
+  hideTabBar: boolean;
+  setHideTabBar: (hide: boolean) => void;
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  hideTabBar: false,
+  setHideTabBar: (hide) => set({ hideTabBar: hide }),
+}));


### PR DESCRIPTION
## Summary

- Adds the 3-step Smart Setup wizard (`SmartSetupScreen`) guiding users through annual income, budget-category percentage allocation, and emergency reserve target
- **Fixed linked-slider bug**: `CategoryWithPercentageDTO` has no `Id` field, so every default category arrived with `id = undefined`; local IDs are now generated as `` `default-{idx}` `` when absent — `DefaultCategory.id` also corrected to `id?: string`
- **Fixed validation rule**: budget allocation step now allows ≤ 100% (only blocks when over-allocated), so users can proceed with partial allocations or after adding a new empty category
- Category names are editable inline; categories can be added and deleted per row
- Custom touch-based percentage slider (no new package) paired with a numeric input for precise entry; each slider is an isolated component with its own `widthRef` to prevent cross-contamination
- i18n keys added to `en.json` and `pt.json` (`SmartSetupAddCategory`, `SmartSetupCategoryNamePlaceholder`)

## Test plan

- [ ] Open Smart Setup from Project List → enter annual income → tap Next
- [ ] Budget allocation step: drag each slider independently and confirm only that category's percentage changes
- [ ] Edit a category name inline
- [ ] Add a new category row; verify Next is still enabled (total ≤ 100%)
- [ ] Delete a category row
- [ ] Set total > 100% → Next button disables; reduce below 100% → re-enables
- [ ] Proceed to Emergency Reserve step → value pre-filled as 6 × monthly income
- [ ] Complete wizard → lands on Overview
- [ ] Skip button on any step → lands on Overview
- [ ] Back button navigates between steps correctly
- [ ] 245 Jest tests, typecheck, and lint all green (`cd econoflow-mobile && npm test && npm run typecheck && npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)