### PR TITLE
feat(mobile): hero-label inputs, slider fix, Accept-Language header

### DIFF
--- a/econoflow-mobile/src/api/__tests__/client.test.ts
+++ b/econoflow-mobile/src/api/__tests__/client.test.ts
@@ -18,6 +18,11 @@ jest.mock('../../store/authStore', () => ({
   },
 }));
 
+jest.mock('../../i18n', () => ({
+  __esModule: true,
+  default: { language: 'en' },
+}));
+
 // ---------------------------------------------------------------------------
 // Minimal axios adapter helpers
 // ---------------------------------------------------------------------------
@@ -41,6 +46,37 @@ const errorAdapter = (status: number, url = '/api/test'): AnyAdapter =>
       config: { url, method: 'get', headers: {} },
     }),
   );
+
+describe('apiClient interceptors – Accept-Language header', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let savedAdapter: any;
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    savedAdapter = (apiClient.defaults as any).adapter;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = savedAdapter;
+  });
+
+  it('sets Accept-Language header from i18n language on every request', async () => {
+    const adapter: AnyAdapter = jest.fn().mockResolvedValue({
+      data: {},
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: { url: '/api/test', method: 'get', headers: {} },
+      request: {},
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = adapter;
+    await apiClient.get('/api/test');
+    const [config] = adapter.mock.calls[0] as [{ headers: Record<string, string> }];
+    expect(config.headers['Accept-Language']).toBe('en');
+  });
+});
 
 describe('apiClient interceptors – Sentry breadcrumbs', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/econoflow-mobile/src/api/client.ts
+++ b/econoflow-mobile/src/api/client.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { useAuthStore } from '../store/authStore';
 import { addBreadcrumb } from '../monitoring/sentry';
+import i18n from '../i18n';
 
 const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://localhost:7003';
 
@@ -28,6 +29,7 @@ apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+  config.headers['Accept-Language'] = i18n.language;
   // Breadcrumb: method + URL only — never the body or the auth token.
   addBreadcrumb(
     `${(config.method ?? 'GET').toUpperCase()} ${config.url ?? ''}`,

--- a/econoflow-mobile/src/api/client.ts
+++ b/econoflow-mobile/src/api/client.ts
@@ -29,7 +29,7 @@ apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
-  config.headers['Accept-Language'] = i18n.language;
+  config.headers['Accept-Language'] = i18n.language ?? 'en';
   // Breadcrumb: method + URL only — never the body or the auth token.
   addBreadcrumb(
     `${(config.method ?? 'GET').toUpperCase()} ${config.url ?? ''}`,

--- a/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -79,6 +81,7 @@ const CategorySlider: React.FC<CategorySliderProps> = ({
       onLayout={(e) => { widthRef.current = e.nativeEvent.layout.width; }}
       onStartShouldSetResponder={() => true}
       onMoveShouldSetResponder={() => true}
+      onResponderTerminationRequest={() => false}
       onResponderGrant={(e) => handleTouch(e.nativeEvent.locationX)}
       onResponderMove={(e) => handleTouch(e.nativeEvent.locationX)}
     >
@@ -136,6 +139,8 @@ export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
   const [error, setError] = useState<string | null>(null);
 
   const initialized = useRef(false);
+  const annualIncomeInputRef = useRef<TextInput>(null);
+  const emergencyInputRef = useRef<TextInput>(null);
 
   const { currency } = useProjectStore();
   const setHideTabBar = useUIStore((s) => s.setHideTabBar);
@@ -163,6 +168,14 @@ export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
 
   const annualIncome = parseFloat(annualIncomeStr) || 0;
   const monthlyIncome = annualIncome / 12;
+
+  const incomeParts = annualIncomeStr ? annualIncomeStr.split('.') : [];
+  const incomeIntStr = incomeParts[0] || '0';
+  const incomeDecStr = `.${(incomeParts[1] ?? '00').padEnd(2, '0').slice(0, 2)}`;
+
+  const reserveParts = emergencyInput ? emergencyInput.split('.') : [];
+  const reserveIntStr = reserveParts[0] || '0';
+  const reserveDecStr = `.${(reserveParts[1] ?? '00').padEnd(2, '0').slice(0, 2)}`;
 
   const percentageTotal = categories.reduce(
     (sum, c) => sum + (parseFloat(c.percentageStr) || 0),
@@ -283,16 +296,34 @@ export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
       <Text style={[styles.stepDescription, { color: ink2 }]}>
         {t('SmartSetupStep1Description')}
       </Text>
-      <GlassCard dark={dark} radius={18} style={styles.fieldCard}>
-        <AuroraField
-          dark={dark}
-          textPrefix={getCurrencySymbol(currency)}
-          testID={t('FieldAnnualIncome')}
-          placeholder={t('FieldAnnualIncome')}
-          value={annualIncomeStr}
-          onChangeText={setAnnualIncomeStr}
-          keyboardType="decimal-pad"
-        />
+      <GlassCard dark={dark} radius={18} style={styles.heroCard}>
+        <Pressable style={styles.incomeHero} onPress={() => annualIncomeInputRef.current?.focus()}>
+          <Text style={[styles.heroLabel, { color: ink2 }]}>
+            {t('SmartSetupStep1Title').toUpperCase()}
+          </Text>
+          <View style={styles.heroRow}>
+            <Text testID="FieldAnnualIncome-prefix" style={[styles.heroSym, { color: colors.primary }]}>
+              {getCurrencySymbol(currency)}
+            </Text>
+            <Text testID="income-hero-int" style={[styles.heroInt, { color: ink }]}>
+              {incomeIntStr}
+            </Text>
+            <Text testID="income-hero-dec" style={[styles.heroDec, { color: ink2 }]}>
+              {incomeDecStr}
+            </Text>
+          </View>
+          <TextInput
+            ref={annualIncomeInputRef}
+            testID="FieldAnnualIncome"
+            value={annualIncomeStr}
+            onChangeText={setAnnualIncomeStr}
+            keyboardType="decimal-pad"
+            caretHidden
+            accessible={false}
+            importantForAccessibility="no"
+            style={styles.hiddenInput}
+          />
+        </Pressable>
       </GlassCard>
       <AuroraPrimaryButton
         testID={t('SmartSetupNext')}
@@ -425,16 +456,34 @@ export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
       <Text style={[styles.stepDescription, { color: ink2 }]}>
         {t('SmartSetupStep3Description')}
       </Text>
-      <GlassCard dark={dark} radius={18} style={styles.fieldCard}>
-        <AuroraField
-          dark={dark}
-          textPrefix={getCurrencySymbol(currency)}
-          testID={t('SmartSetupEmergencyReserveLabel')}
-          placeholder={t('SmartSetupEmergencyReserveLabel')}
-          value={emergencyInput}
-          onChangeText={setEmergencyInput}
-          keyboardType="decimal-pad"
-        />
+      <GlassCard dark={dark} radius={18} style={styles.heroCard}>
+        <Pressable style={styles.incomeHero} onPress={() => emergencyInputRef.current?.focus()}>
+          <Text style={[styles.heroLabel, { color: ink2 }]}>
+            {t('SmartSetupEmergencyReserveLabel').toUpperCase()}
+          </Text>
+          <View style={styles.heroRow}>
+            <Text style={[styles.heroSym, { color: colors.primary }]}>
+              {getCurrencySymbol(currency)}
+            </Text>
+            <Text testID="reserve-hero-int" style={[styles.heroInt, { color: ink }]}>
+              {reserveIntStr}
+            </Text>
+            <Text testID="reserve-hero-dec" style={[styles.heroDec, { color: ink2 }]}>
+              {reserveDecStr}
+            </Text>
+          </View>
+          <TextInput
+            ref={emergencyInputRef}
+            testID="SmartSetupEmergencyReserveLabel"
+            value={emergencyInput}
+            onChangeText={setEmergencyInput}
+            keyboardType="decimal-pad"
+            caretHidden
+            accessible={false}
+            importantForAccessibility="no"
+            style={styles.hiddenInput}
+          />
+        </Pressable>
       </GlassCard>
       <Text style={[styles.hint, { color: ink2 }]}>{t('SmartSetupEmergencyReserveHint')}</Text>
 
@@ -497,7 +546,14 @@ const styles = StyleSheet.create({
   stepContent: { gap: 12, paddingTop: 4 },
   stepTitle: { fontSize: 20, fontWeight: '800', marginBottom: 2 },
   stepDescription: { fontSize: 13, fontWeight: '500', marginBottom: 8 },
-  fieldCard: { padding: 4 },
+  heroCard: { padding: 0 },
+  incomeHero: { alignItems: 'center', paddingVertical: 20, paddingHorizontal: 16 },
+  heroLabel: { fontSize: 11, fontWeight: '700', letterSpacing: 0.9, marginBottom: 10 },
+  heroRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 2 },
+  heroSym: { fontSize: 22, fontWeight: '600', paddingBottom: 10 },
+  heroInt: { fontSize: 48, fontWeight: '800', letterSpacing: -1 },
+  heroDec: { fontSize: 24, fontWeight: '700', letterSpacing: -0.5, paddingBottom: 10 },
+  hiddenInput: { position: 'absolute', width: 1, height: 1, opacity: 0 },
   categoryCard: { padding: 14, gap: 8 },
   categoryNameRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   categoryNameField: { flex: 1 },

--- a/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
@@ -488,6 +488,17 @@ describe('SmartSetupScreen', () => {
     expect(screen.getByTestId('reserve-hero-int').props.children).toBe('6000');
   });
 
+  it('emergency reserve hero shows decimal part of pre-filled value', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await fireEvent.changeText(screen.getByTestId('FieldAnnualIncome'), '12000');
+    await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+    await screen.findByText('SmartSetupStep2Title');
+    await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+    await screen.findByText('SmartSetupStep3Title');
+    // 6 × (12000 / 12) = 6000.00 → decimal part ".00"
+    expect(screen.getByTestId('reserve-hero-dec').props.children).toBe('.00');
+  });
+
   it('slider does not release responder once granted', async () => {
     await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
     await goToStep2();

--- a/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
@@ -465,6 +465,37 @@ describe('SmartSetupScreen', () => {
     });
   });
 
+  it('income hero renders integer part of entered amount', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await fireEvent.changeText(screen.getByTestId('FieldAnnualIncome'), '60000.50');
+    expect(screen.getByTestId('income-hero-int').props.children).toBe('60000');
+  });
+
+  it('income hero renders decimal part of entered amount', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await fireEvent.changeText(screen.getByTestId('FieldAnnualIncome'), '60000.50');
+    expect(screen.getByTestId('income-hero-dec').props.children).toBe('.50');
+  });
+
+  it('emergency reserve hero shows integer part of pre-filled value', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await fireEvent.changeText(screen.getByTestId('FieldAnnualIncome'), '12000');
+    await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+    await screen.findByText('SmartSetupStep2Title');
+    await fireEvent.press(screen.getByTestId('SmartSetupNext'));
+    await screen.findByText('SmartSetupStep3Title');
+    // 6 × (12000 / 12) = 6000 → integer part "6000"
+    expect(screen.getByTestId('reserve-hero-int').props.children).toBe('6000');
+  });
+
+  it('slider does not release responder once granted', async () => {
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+    await goToStep2();
+    const slider = screen.getByTestId('cat-1-pct-slider');
+    expect(typeof slider.props.onResponderTerminationRequest).toBe('function');
+    expect(slider.props.onResponderTerminationRequest()).toBe(false);
+  });
+
   it('categories from API without ids get unique local ids so sliders are independent', async () => {
     // The real API returns CategoryWithPercentageDTO which has no Id field.
     // Without a local-id fallback every category gets id=undefined and all


### PR DESCRIPTION
- SmartSetup Step 1 (annual income) and Step 3 (emergency reserve) now
  display as a large hero number (currency symbol + integer + decimal) with
  a hidden TextInput behind a Pressable, matching the QuickAdd amount style.
  All existing testIDs are preserved so no tests break.

- CategorySlider: add onResponderTerminationRequest={() => false} so the
  ScrollView cannot steal the responder mid-drag. This fixes the slider
  jumping back to 0% during selection.

- All Axios requests now include Accept-Language: <i18n.language> in the
  request interceptor (src/api/client.ts), letting the backend respond in
  the user's selected locale.

- Tests: 5 new tests (hero int/dec display, slider termination request,
  Accept-Language header). All 250 tests pass; typecheck and lint clean.

https://claude.ai/code/session_01TKa3ywdBo7rVGWUwPitVYq