### PR TITLE
fix: normalize user language code to two-letter ISO on registration

### DIFF
--- a/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
+++ b/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
@@ -67,6 +67,9 @@ namespace EasyFinance.Server.Tests.Controllers
         public async Task Register_NormalizesLanguageCodeToTwoLetterISOCode(string uiCulture, string expectedCode)
         {
             // Arrange
+            var originalCulture = CultureInfo.CurrentUICulture;
+            try
+            {
             CultureInfo.CurrentUICulture = new CultureInfo(uiCulture);
 
             User? capturedUser = null;
@@ -99,6 +102,11 @@ namespace EasyFinance.Server.Tests.Controllers
             // Assert
             capturedUser.ShouldNotBeNull();
             capturedUser!.LanguageCode.ShouldBe(expectedCode);
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = originalCulture;
+            }
         }
     }
 }

--- a/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
+++ b/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+using System.Threading;
+using EasyFinance.Application.DTOs.AccessControl;
+using EasyFinance.Application.Features.AccessControlService;
+using EasyFinance.Application.Features.FeatureRolloutService;
+using EasyFinance.Application.Features.NotificationService;
+using EasyFinance.Application.Features.TurnstileService;
+using EasyFinance.Application.Features.UserService;
+using EasyFinance.Domain.AccessControl;
+using EasyFinance.Infrastructure.Authentication;
+using EasyFinance.Server.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+namespace EasyFinance.Server.Tests.Controllers
+{
+    public class AccessControlControllerRegisterTests
+    {
+        private readonly Mock<IUserStore<User>> _userStoreMock;
+        private readonly Mock<UserManager<User>> _userManagerMock;
+        private readonly AccessControlController _controller;
+
+        public AccessControlControllerRegisterTests()
+        {
+            _userStoreMock = new Mock<IUserStore<User>>();
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+            _userManagerMock = new Mock<UserManager<User>>(
+                _userStoreMock.Object,
+                null, null, null, null, null, null, null, null);
+
+            var signInManagerMock = new Mock<SignInManager<User>>(
+                _userManagerMock.Object,
+                Mock.Of<IHttpContextAccessor>(),
+                Mock.Of<IUserClaimsPrincipalFactory<User>>(),
+                null, null, null, null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+            _controller = new AccessControlController(
+                userManager: _userManagerMock.Object,
+                signInManager: signInManagerMock.Object,
+                emailSender: Mock.Of<IEmailSender<User>>(),
+                userService: Mock.Of<IUserService>(),
+                linkGenerator: Mock.Of<LinkGenerator>(),
+                accessControlService: Mock.Of<IAccessControlService>(),
+                featureRolloutService: Mock.Of<IFeatureRolloutService>(),
+                tokenSettings: new TokenSettings { SecretKey = Guid.NewGuid().ToString() },
+                notificationService: Mock.Of<INotificationService>(),
+                turnstileService: Mock.Of<ITurnstileService>(),
+                turnstileSettings: Options.Create(new TurnstileSettings()),
+                logger: Mock.Of<ILogger<AccessControlController>>());
+        }
+
+        [Theory]
+        [InlineData("en-US", "en")]
+        [InlineData("pt-BR", "pt")]
+        [InlineData("en-GB", "en")]
+        [InlineData("pt", "pt")]
+        [InlineData("en", "en")]
+        public async Task Register_NormalizesLanguageCodeToTwoLetterISOCode(string uiCulture, string expectedCode)
+        {
+            // Arrange
+            CultureInfo.CurrentUICulture = new CultureInfo(uiCulture);
+
+            User? capturedUser = null;
+            _userManagerMock.Setup(u => u.SupportsUserEmail).Returns(true);
+            _userManagerMock
+                .Setup(u => u.CreateAsync(It.IsAny<User>(), It.IsAny<string>()))
+                .Callback<User, string>((user, _) => capturedUser = user)
+                .ReturnsAsync(IdentityResult.Success);
+
+            _userStoreMock.As<IUserEmailStore<User>>()
+                .Setup(s => s.SetUserNameAsync(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            _userStoreMock.As<IUserEmailStore<User>>()
+                .Setup(s => s.SetEmailAsync(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var registration = new RegisterRequestDTO { Email = "test@example.com", Password = "Password1!" };
+
+            // Act — NotSupportedException from link generation is expected in unit tests
+            // that don't set up the full routing infrastructure; language code is already
+            // captured via the CreateAsync callback before that path is reached.
+            try { await _controller.Register(_userStoreMock.Object, registration); }
+            catch (NotSupportedException) { }
+
+            // Assert
+            capturedUser.ShouldNotBeNull();
+            capturedUser!.LanguageCode.ShouldBe(expectedCode);
+        }
+    }
+}
+#pragma warning restore CS8602 // Dereference of a possibly null reference.

--- a/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
+++ b/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
@@ -30,6 +30,9 @@ namespace EasyFinance.Server.Tests.Controllers
         public AccessControlControllerRegisterTests()
         {
             _userStoreMock = new Mock<IUserStore<User>>();
+            // Extend the mock to implement IUserEmailStore<User> BEFORE Object is first
+            // accessed (Moq requires As<T>() to be called before the first Object access).
+            _userStoreMock.As<IUserEmailStore<User>>();
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             _userManagerMock = new Mock<UserManager<User>>(

--- a/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
+++ b/EasyFinance.Server.Tests/Controllers/AccessControlControllerRegisterTests.cs
@@ -81,6 +81,9 @@ namespace EasyFinance.Server.Tests.Controllers
                 .Setup(u => u.CreateAsync(It.IsAny<User>(), It.IsAny<string>()))
                 .Callback<User, string>((user, _) => capturedUser = user)
                 .ReturnsAsync(IdentityResult.Success);
+            _userManagerMock
+                .Setup(u => u.GenerateEmailConfirmationTokenAsync(It.IsAny<User>()))
+                .ReturnsAsync("token");
 
             _userStoreMock.As<IUserEmailStore<User>>()
                 .Setup(s => s.SetUserNameAsync(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/EasyFinance.Server/Controllers/AccessControlController.cs
+++ b/EasyFinance.Server/Controllers/AccessControlController.cs
@@ -222,7 +222,7 @@ namespace EasyFinance.Server.Controllers
             }
 
             var user = new User();
-            user.SetLanguageCode(CultureInfo.CurrentUICulture.Name);
+            user.SetLanguageCode(CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
             await userStore.SetUserNameAsync(user, email, CancellationToken.None);
             await emailStore.SetEmailAsync(user, email, CancellationToken.None);
             user.SetNotificationChannels(NotificationChannels.Push | NotificationChannels.Email);

--- a/easyfinance.client/src/app/core/services/global.service.spec.ts
+++ b/easyfinance.client/src/app/core/services/global.service.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { GlobalService } from './global.service';
+
+describe('GlobalService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+    });
+  });
+
+  it('should default currentLanguage to en', () => {
+    const service = TestBed.inject(GlobalService);
+
+    expect(service.currentLanguage).toBe('en');
+  });
+});

--- a/easyfinance.client/src/app/core/services/global.service.ts
+++ b/easyfinance.client/src/app/core/services/global.service.ts
@@ -11,7 +11,7 @@ import { SupportedLanguage } from '../types/supported-language';
 export class GlobalService {
   private translateService = inject(TranslateService);
 
-  private languageLoaded = 'en-US';
+  private languageLoaded = 'en';
   public languageStorageKey = "language-key";
   public groupSeparator = '.';
   public decimalSeparator = ',';

--- a/easyfinance.client/src/assets/version.json
+++ b/easyfinance.client/src/assets/version.json
@@ -1,3 +1,3 @@
 {
-  "versionNumber": "1.1.63"
+  "versionNumber": "1.1.64"
 }

--- a/econoflow-mobile/src/api/__tests__/client.test.ts
+++ b/econoflow-mobile/src/api/__tests__/client.test.ts
@@ -18,6 +18,11 @@ jest.mock('../../store/authStore', () => ({
   },
 }));
 
+jest.mock('../../i18n', () => ({
+  __esModule: true,
+  default: { language: 'en' },
+}));
+
 // ---------------------------------------------------------------------------
 // Minimal axios adapter helpers
 // ---------------------------------------------------------------------------
@@ -41,6 +46,43 @@ const errorAdapter = (status: number, url = '/api/test'): AnyAdapter =>
       config: { url, method: 'get', headers: {} },
     }),
   );
+
+describe('apiClient interceptors – Accept-Language header', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let savedAdapter: any;
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    savedAdapter = (apiClient.defaults as any).adapter;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = savedAdapter;
+    jest.clearAllMocks();
+  });
+
+  it('adds Accept-Language header derived from i18n.language to every request', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let capturedConfig: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = (config: any) => {
+      capturedConfig = config;
+      return Promise.resolve({
+        data: {},
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+        request: {},
+      });
+    };
+
+    await apiClient.get('/api/test');
+
+    expect(capturedConfig?.headers?.['Accept-Language']).toBe('en');
+  });
+});
 
 describe('apiClient interceptors – Sentry breadcrumbs', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/econoflow-mobile/src/api/client.ts
+++ b/econoflow-mobile/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import i18n from '../i18n';
 import { useAuthStore } from '../store/authStore';
 import { addBreadcrumb } from '../monitoring/sentry';
 
@@ -28,6 +29,7 @@ apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+  config.headers['Accept-Language'] = i18n.language;
   // Breadcrumb: method + URL only — never the body or the auth token.
   addBreadcrumb(
     `${(config.method ?? 'GET').toUpperCase()} ${config.url ?? ''}`,

--- a/econoflow-mobile/src/api/client.ts
+++ b/econoflow-mobile/src/api/client.ts
@@ -4,7 +4,6 @@ import { useAuthStore } from '../store/authStore';
 import { useProjectStore } from '../store/projectStore';
 import { addBreadcrumb } from '../monitoring/sentry';
 import { queryClient } from './queryClient';
-import i18n from '../i18n';
 
 const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://localhost:7003';
 


### PR DESCRIPTION
Language was being stored as "en-US" instead of "en" for new users
across all clients, because:

- Backend used CultureInfo.CurrentUICulture.Name ("en-US") instead of
  TwoLetterISOLanguageName ("en") when creating the user record.
- Web GlobalService defaulted languageLoaded to 'en-US', so the
  Accept-Language header sent during registration was "en-US" before
  any user session was loaded.
- Mobile sent no Accept-Language header at all, so the server always
  fell back to its default culture "en-US".

Fixes:
- Backend: use TwoLetterISOLanguageName so any region-qualified culture
  (en-US, pt-BR, en-GB) is normalised to the supported two-letter code.
- Web: change GlobalService default from 'en-US' to 'en', matching what
  setLocale() would produce for English.
- Mobile: add Accept-Language header (from i18n.language) to the Axios
  request interceptor so the device locale is sent during registration.

https://claude.ai/code/session_01BHSS6daQ2XqWvaFLZwT6TQ