### PR TITLE
fix: clear React Query cache on logout to prevent data leak between users

### DIFF
--- a/econoflow-mobile/App.tsx
+++ b/econoflow-mobile/App.tsx
@@ -9,7 +9,8 @@ import {
   DefaultTheme as NavDefaultTheme,
   createNavigationContainerRef,
 } from '@react-navigation/native';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './src/api/queryClient';
 import { Provider as PaperProvider, MD3LightTheme, MD3DarkTheme } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
@@ -27,15 +28,6 @@ const navigationRef = createNavigationContainerRef();
 // Keep the splash screen visible while the JS bundle and stores hydrate.
 // hideAsync() is called in onLayout once the root View is measured.
 void SplashScreen.preventAutoHideAsync();
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      staleTime: 30_000,
-    },
-  },
-});
 
 // ── Common semantic colour tokens ─────────────────────────────────────────────
 const commonCustom = {

--- a/econoflow-mobile/package.json
+++ b/econoflow-mobile/package.json
@@ -63,7 +63,11 @@
     "preset": "jest-expo",
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|@sentry/.*|native-base|react-native-svg)"
-    ]
+    ],
+    "moduleNameMapper": {
+      "@react-native-async-storage/async-storage": "@react-native-async-storage/async-storage/jest/async-storage-mock",
+      "/queryClient$": "<rootDir>/src/api/__mocks__/queryClient"
+    }
   },
   "private": true,
   "devDependencies": {

--- a/econoflow-mobile/src/api/__mocks__/queryClient.ts
+++ b/econoflow-mobile/src/api/__mocks__/queryClient.ts
@@ -1,0 +1,1 @@
+export const queryClient = { clear: jest.fn() };

--- a/econoflow-mobile/src/api/__tests__/client.test.ts
+++ b/econoflow-mobile/src/api/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 // All imports first — Jest hoists jest.mock() calls before any imports at
 // runtime regardless of their position in source, so this ordering is safe.
+import axios from 'axios';
 import { apiClient } from '../client';
 import { addBreadcrumb } from '../../monitoring/sentry';
 
@@ -16,6 +17,18 @@ jest.mock('../../store/authStore', () => ({
       clearAuth: jest.fn(),
     }),
   },
+}));
+
+jest.mock('../../store/projectStore', () => ({
+  useProjectStore: {
+    getState: jest.fn().mockReturnValue({
+      clearProject: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('../queryClient', () => ({
+  queryClient: { clear: jest.fn() },
 }));
 
 // ---------------------------------------------------------------------------
@@ -41,6 +54,13 @@ const errorAdapter = (status: number, url = '/api/test'): AnyAdapter =>
       config: { url, method: 'get', headers: {} },
     }),
   );
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getAuthStoreMock = () => (jest.requireMock('../../store/authStore') as any).useAuthStore;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getProjectStoreMock = () => (jest.requireMock('../../store/projectStore') as any).useProjectStore;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getQueryClientMock = () => (jest.requireMock('../queryClient') as any).queryClient;
 
 describe('apiClient interceptors – Sentry breadcrumbs', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -91,5 +111,112 @@ describe('apiClient interceptors – Sentry breadcrumbs', () => {
     const calls = (addBreadcrumb as jest.Mock).mock.calls as [string, string][];
     const errorCrumbs = calls.filter(([msg]) => msg.includes('401'));
     expect(errorCrumbs).toHaveLength(0);
+  });
+});
+
+describe('apiClient interceptors – auto-logout data cleanup', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let savedAdapter: any;
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    savedAdapter = (apiClient.defaults as any).adapter;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = savedAdapter;
+    jest.clearAllMocks();
+    getAuthStoreMock().getState.mockReturnValue({
+      accessToken: null,
+      refreshToken: null,
+      setTokens: jest.fn(),
+      clearAuth: jest.fn(),
+    });
+    getProjectStoreMock().getState.mockReturnValue({ clearProject: jest.fn() });
+  });
+
+  it('clears the React Query cache on 401 when there is no refresh token', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = errorAdapter(401, '/api/categories');
+    getAuthStoreMock().getState.mockReturnValue({
+      accessToken: 'tok',
+      refreshToken: null,
+      setTokens: jest.fn(),
+      clearAuth: jest.fn(),
+    });
+
+    await expect(apiClient.get('/api/categories')).rejects.toBeDefined();
+
+    expect(getQueryClientMock().clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the React Query cache before clearAuth on the no-refresh-token path', async () => {
+    const callOrder: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = errorAdapter(401, '/api/categories');
+    const mockClearAuth = jest.fn(() => { callOrder.push('clearAuth'); });
+    getAuthStoreMock().getState.mockReturnValue({
+      accessToken: 'tok',
+      refreshToken: null,
+      setTokens: jest.fn(),
+      clearAuth: mockClearAuth,
+    });
+    getQueryClientMock().clear.mockImplementation(() => { callOrder.push('queryClient.clear'); });
+
+    await expect(apiClient.get('/api/categories')).rejects.toBeDefined();
+
+    expect(callOrder).toEqual(['queryClient.clear', 'clearAuth']);
+  });
+
+  it('clears the React Query cache when the token refresh request fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = errorAdapter(401, '/api/expenses');
+    getAuthStoreMock().getState.mockReturnValue({
+      accessToken: 'old-tok',
+      refreshToken: 'old-refresh',
+      setTokens: jest.fn(),
+      clearAuth: jest.fn(),
+    });
+    jest.spyOn(axios, 'post').mockRejectedValueOnce(new Error('Refresh failed'));
+
+    await expect(apiClient.get('/api/expenses')).rejects.toBeDefined();
+
+    expect(getQueryClientMock().clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears clearProject on 401 when there is no refresh token', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = errorAdapter(401, '/api/categories');
+    const mockClearProject = jest.fn();
+    getAuthStoreMock().getState.mockReturnValue({
+      accessToken: 'tok',
+      refreshToken: null,
+      setTokens: jest.fn(),
+      clearAuth: jest.fn(),
+    });
+    getProjectStoreMock().getState.mockReturnValue({ clearProject: mockClearProject });
+
+    await expect(apiClient.get('/api/categories')).rejects.toBeDefined();
+
+    expect(mockClearProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears clearProject when the token refresh request fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (apiClient.defaults as any).adapter = errorAdapter(401, '/api/expenses');
+    const mockClearProject = jest.fn();
+    getAuthStoreMock().getState.mockReturnValue({
+      accessToken: 'old-tok',
+      refreshToken: 'old-refresh',
+      setTokens: jest.fn(),
+      clearAuth: jest.fn(),
+    });
+    getProjectStoreMock().getState.mockReturnValue({ clearProject: mockClearProject });
+    jest.spyOn(axios, 'post').mockRejectedValueOnce(new Error('Refresh failed'));
+
+    await expect(apiClient.get('/api/expenses')).rejects.toBeDefined();
+
+    expect(mockClearProject).toHaveBeenCalledTimes(1);
   });
 });

--- a/econoflow-mobile/src/api/client.ts
+++ b/econoflow-mobile/src/api/client.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { useAuthStore } from '../store/authStore';
+import { useProjectStore } from '../store/projectStore';
 import { addBreadcrumb } from '../monitoring/sentry';
+import { queryClient } from './queryClient';
 
 const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://localhost:7003';
 
@@ -71,10 +73,13 @@ apiClient.interceptors.response.use(
     isRefreshing = true;
 
     const { refreshToken, setTokens, clearAuth } = useAuthStore.getState();
+    const { clearProject } = useProjectStore.getState();
 
     if (!refreshToken) {
       isRefreshing = false;
+      queryClient.clear();
       clearAuth();
+      clearProject();
       return Promise.reject(error);
     }
 
@@ -94,7 +99,9 @@ apiClient.interceptors.response.use(
       return apiClient(originalRequest);
     } catch (refreshError) {
       processQueue(refreshError, null);
+      queryClient.clear();
       clearAuth();
+      clearProject();
       return Promise.reject(refreshError);
     } finally {
       isRefreshing = false;

--- a/econoflow-mobile/src/api/queryClient.ts
+++ b/econoflow-mobile/src/api/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
+    },
+  },
+});

--- a/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { MainTabParamList } from '../../navigation/MainNavigator';
 import { useAuthStore } from '../../store/authStore';
@@ -52,8 +53,10 @@ export const ProfileScreen: React.FC<Props> = () => {
   const insets = useSafeAreaInsets();
   const { user, clearAuth } = useAuthStore();
   const { clearProject, selectedProject } = useProjectStore();
+  const queryClient = useQueryClient();
 
   const handleSignOut = () => {
+    queryClient.clear();
     clearAuth();
     clearProject();
   };

--- a/econoflow-mobile/src/screens/profile/__tests__/ProfileScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { ProfileScreen } from '../ProfileScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+  };
+});
+
+jest.mock('expo-linear-gradient', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+// ─── Store / React Query mocks ────────────────────────────────────────────────
+
+const mockClearAuth = jest.fn();
+const mockClearProject = jest.fn();
+const mockQueryClientClear = jest.fn();
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({
+    user: {
+      id: 'u1',
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      fullName: 'Alice Smith',
+      enabled: true,
+      isFirstLogin: false,
+      emailConfirmed: true,
+      twoFactorEnabled: false,
+      defaultProjectId: null,
+      notificationChannels: [],
+      languageCode: 'en',
+      isBetaTester: false,
+    },
+    clearAuth: mockClearAuth,
+  })),
+}));
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: null,
+    clearProject: mockClearProject,
+  })),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: jest.fn(() => ({ clear: mockQueryClientClear })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigation = {} as React.ComponentProps<typeof ProfileScreen>['navigation'];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ProfileScreen – sign out', () => {
+  beforeEach(() => {
+    mockClearAuth.mockReset();
+    mockClearProject.mockReset();
+    mockQueryClientClear.mockReset();
+  });
+
+  it('calls clearAuth when the sign-out button is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} />);
+    fireEvent.press(screen.getByText('ButtonSignOut'));
+    expect(mockClearAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls clearProject when the sign-out button is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} />);
+    fireEvent.press(screen.getByText('ButtonSignOut'));
+    expect(mockClearProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the React Query cache when the sign-out button is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} />);
+    fireEvent.press(screen.getByText('ButtonSignOut'));
+    expect(mockQueryClientClear).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
When a user logged out and a new user logged in, the React Query cache
still held the previous user's projects, categories, expenses, and
incomes. The new user would see stale data until the 30 s staleTime
expired. Calling queryClient.clear() in handleSignOut drops the entire
in-memory cache the moment the session ends.

https://claude.ai/code/session_016MK4WevWS3rxhNfY843Fqv