### PR TITLE
fix(mobile): use pageX instead of locationX in budget slider to stop flicker

### DIFF
--- a/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
@@ -66,24 +66,36 @@ const CategorySlider: React.FC<CategorySliderProps> = ({
   fillColor,
   trackColor,
 }) => {
+  const wrapperRef = useRef<View>(null);
   const widthRef = useRef(0);
+  const pageXRef = useRef(0);
   const fillPct = Math.min(100, Math.max(0, value));
 
-  const handleTouch = (locationX: number) => {
-    const pct = Math.min(100, Math.max(0, Math.round((locationX / (widthRef.current || 1)) * 100)));
-    onValueChange(pct);
-  };
+  const computePct = (pageX: number) =>
+    Math.min(100, Math.max(0, Math.round(((pageX - pageXRef.current) / (widthRef.current || 1)) * 100)));
 
   return (
     <View
+      ref={wrapperRef}
       testID={testID}
       style={sliderStyles.wrapper}
-      onLayout={(e) => { widthRef.current = e.nativeEvent.layout.width; }}
+      onLayout={(e) => {
+        widthRef.current = e.nativeEvent.layout.width;
+        wrapperRef.current?.measure((_x, _y, _w, _h, px) => {
+          pageXRef.current = px;
+        });
+      }}
       onStartShouldSetResponder={() => true}
       onMoveShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}
-      onResponderGrant={(e) => handleTouch(e.nativeEvent.locationX)}
-      onResponderMove={(e) => handleTouch(e.nativeEvent.locationX)}
+      onResponderGrant={(e) => {
+        const { pageX } = e.nativeEvent;
+        onValueChange(computePct(pageX));
+        wrapperRef.current?.measure((_x, _y, _w, _h, px) => {
+          pageXRef.current = px;
+        });
+      }}
+      onResponderMove={(e) => onValueChange(computePct(e.nativeEvent.pageX))}
     >
       <View style={[sliderStyles.track, { backgroundColor: trackColor }]}>
         <View style={[sliderStyles.fill, { width: `${fillPct}%`, backgroundColor: fillColor }]} />

--- a/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
@@ -507,6 +507,53 @@ describe('SmartSetupScreen', () => {
     expect(slider.props.onResponderTerminationRequest()).toBe(false);
   });
 
+  it('slider grant uses pageX not locationX to compute percentage', async () => {
+    const { getByTestId: localGet } = await render(
+      <SmartSetupScreen navigation={mockNavigation} route={mockRoute} />,
+    );
+    await goToStep2();
+
+    const slider = localGet('cat-1-pct-slider');
+
+    // Inform the slider of its width (View.measure is a no-op in tests so wrapperPageX=0)
+    await act(async () => {
+      slider.props.onLayout({ nativeEvent: { layout: { width: 300 } } });
+    });
+
+    // Simulate touching the thumb: pageX=150 (absolute, 50% of 300px track) but
+    // locationX=5 (5px from the thumb's own left edge). Old code using locationX
+    // would compute round(5/300*100)=2%. The fix using pageX gives 50%.
+    await act(async () => {
+      slider.props.onResponderGrant({ nativeEvent: { pageX: 150, locationX: 5 } });
+    });
+
+    expect(localGet('cat-1-pct').props.value).toBe('50');
+  });
+
+  it('slider move uses pageX not locationX to compute percentage', async () => {
+    const { getByTestId: localGet } = await render(
+      <SmartSetupScreen navigation={mockNavigation} route={mockRoute} />,
+    );
+    await goToStep2();
+
+    const slider = localGet('cat-1-pct-slider');
+
+    await act(async () => {
+      slider.props.onLayout({ nativeEvent: { layout: { width: 300 } } });
+    });
+    await act(async () => {
+      slider.props.onResponderGrant({ nativeEvent: { pageX: 150, locationX: 5 } });
+    });
+
+    // Drag to 75% (225px): locationX stays near the thumb edge (5px) as in the bug,
+    // but pageX correctly reflects the finger's absolute screen position.
+    await act(async () => {
+      slider.props.onResponderMove({ nativeEvent: { pageX: 225, locationX: 5 } });
+    });
+
+    expect(localGet('cat-1-pct').props.value).toBe('75');
+  });
+
   it('categories from API without ids get unique local ids so sliders are independent', async () => {
     // The real API returns CategoryWithPercentageDTO which has no Id field.
     // Without a local-id fallback every category gets id=undefined and all


### PR DESCRIPTION
React Native's locationX in responder events is relative to the touch
target (the thumb View), not the responder (the wrapper). Touching the
thumb produced a locationX of 0–20 px regardless of its position in the
track, causing the slider to jump near 0% on every touch-start.

Switch to pageX (absolute screen coordinates) minus the wrapper's stored
absolute pageX (cached via View.measure on layout and refreshed on each
gesture start). The grant handler fires onValueChange immediately using
the cached offset so the response stays synchronous in tests where
View.measure is a no-op.

https://claude.ai/code/session_012yhUPPzkYeAAsPQByARD3s