### PR TITLE
feat(mobile): post-registration onboarding — profile setup + direct CreateProject routing (#752)

### DIFF
--- a/econoflow-mobile/src/hooks/__tests__/useUpdateProfile.test.ts
+++ b/econoflow-mobile/src/hooks/__tests__/useUpdateProfile.test.ts
@@ -1,0 +1,93 @@
+import * as UserApi from '../../api/user.api';
+import { useUpdateProfile } from '../useUpdateProfile';
+import { useAuthStore } from '../../store/authStore';
+import type { User } from '../../api/types';
+
+jest.mock('../../api/user.api');
+jest.mock('../../store/authStore');
+
+const mockSetUser = jest.fn();
+const mockInvalidateQueries = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: jest.fn((opts) => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+    _opts: opts,
+  })),
+  useQueryClient: jest.fn(() => ({ invalidateQueries: mockInvalidateQueries })),
+}));
+
+(useAuthStore as unknown as jest.Mock).mockReturnValue({ setUser: mockSetUser });
+
+const mockUser: User = {
+  id: 'user-1',
+  email: 'test@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  fullName: 'John Doe',
+  enabled: true,
+  isFirstLogin: false,
+  emailConfirmed: true,
+  twoFactorEnabled: false,
+  defaultProjectId: null,
+  notificationChannels: [],
+  languageCode: 'en',
+  isBetaTester: false,
+};
+
+beforeEach(() => {
+  mockSetUser.mockReset();
+  mockInvalidateQueries.mockReset();
+});
+
+describe('useUpdateProfile', () => {
+  it('mutationFn calls patchUser with the provided patches', async () => {
+    (UserApi.patchUser as jest.Mock).mockResolvedValue({ data: mockUser });
+
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedMutationFn!: (patches: unknown[]) => Promise<User>;
+    useMutation.mockImplementationOnce((opts: { mutationFn: typeof capturedMutationFn }) => {
+      capturedMutationFn = opts.mutationFn;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    useUpdateProfile();
+
+    const patches = [{ op: 'replace', path: '/firstName', value: 'John' }];
+    await capturedMutationFn(patches);
+
+    expect(UserApi.patchUser).toHaveBeenCalledWith(patches);
+  });
+
+  it('onSuccess calls setUser with the returned user', () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedOnSuccess!: (user: User) => void;
+    useMutation.mockImplementationOnce((opts: { onSuccess: typeof capturedOnSuccess }) => {
+      capturedOnSuccess = opts.onSuccess;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    useUpdateProfile();
+
+    capturedOnSuccess(mockUser);
+
+    expect(mockSetUser).toHaveBeenCalledWith(mockUser);
+  });
+
+  it('onSuccess invalidates the currentUser query', () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedOnSuccess!: (user: User) => void;
+    useMutation.mockImplementationOnce((opts: { onSuccess: typeof capturedOnSuccess }) => {
+      capturedOnSuccess = opts.onSuccess;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    useUpdateProfile();
+
+    capturedOnSuccess(mockUser);
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['currentUser'] });
+  });
+});

--- a/econoflow-mobile/src/hooks/useUpdateProfile.ts
+++ b/econoflow-mobile/src/hooks/useUpdateProfile.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchUser } from '../api/user.api';
+import { useAuthStore } from '../store/authStore';
+import type { PatchOperation, User } from '../api/types';
+
+export const useUpdateProfile = () => {
+  const queryClient = useQueryClient();
+  const { setUser } = useAuthStore();
+
+  return useMutation<User, Error, PatchOperation[]>({
+    mutationFn: (patches) => patchUser(patches).then((r) => r.data),
+    onSuccess: (updatedUser) => {
+      setUser(updatedUser);
+      queryClient.invalidateQueries({ queryKey: ['currentUser'] });
+    },
+  });
+};

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -115,4 +115,44 @@ describe('i18n locale completeness', () => {
   it('pt.json contains ButtonUndo', () => {
     expect((pt as LocaleMap)['ButtonUndo']).toBeTruthy();
   });
+
+  it('en.json contains ProfileSetupTitle', () => {
+    expect((en as LocaleMap)['ProfileSetupTitle']).toBeTruthy();
+  });
+
+  it('pt.json contains ProfileSetupTitle', () => {
+    expect((pt as LocaleMap)['ProfileSetupTitle']).toBeTruthy();
+  });
+
+  it('en.json contains ErrorAutoLoginFailed', () => {
+    expect((en as LocaleMap)['ErrorAutoLoginFailed']).toBeTruthy();
+  });
+
+  it('pt.json contains ErrorAutoLoginFailed', () => {
+    expect((pt as LocaleMap)['ErrorAutoLoginFailed']).toBeTruthy();
+  });
+
+  it('en.json contains ProfileSetupSubtitle', () => {
+    expect((en as LocaleMap)['ProfileSetupSubtitle']).toBeTruthy();
+  });
+
+  it('pt.json contains ProfileSetupSubtitle', () => {
+    expect((pt as LocaleMap)['ProfileSetupSubtitle']).toBeTruthy();
+  });
+
+  it('en.json contains ErrorProfileUpdateFailed', () => {
+    expect((en as LocaleMap)['ErrorProfileUpdateFailed']).toBeTruthy();
+  });
+
+  it('pt.json contains ErrorProfileUpdateFailed', () => {
+    expect((pt as LocaleMap)['ErrorProfileUpdateFailed']).toBeTruthy();
+  });
+
+  it('en.json contains OnboardingSkip', () => {
+    expect((en as LocaleMap)['OnboardingSkip']).toBeTruthy();
+  });
+
+  it('pt.json contains OnboardingSkip', () => {
+    expect((pt as LocaleMap)['OnboardingSkip']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -585,5 +585,11 @@
   "SmartSetupBack": "Back",
   "SmartSetupFinish": "Finish",
   "SmartSetupAddCategory": "Add Category",
-  "SmartSetupCategoryNamePlaceholder": "Category name"
+  "SmartSetupCategoryNamePlaceholder": "Category name",
+
+  "ProfileSetupTitle": "Tell us about yourself",
+  "ProfileSetupSubtitle": "Help us personalise your experience",
+  "ErrorProfileUpdateFailed": "Failed to update your profile. Please try again.",
+  "ErrorAutoLoginFailed": "Account created, but sign-in failed. Please sign in manually.",
+  "OnboardingSkip": "Skip"
 }

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -584,6 +584,12 @@
   "SmartSetupBack": "Voltar",
   "SmartSetupFinish": "Concluir",
   "SmartSetupAddCategory": "Adicionar Categoria",
-  "SmartSetupCategoryNamePlaceholder": "Nome da categoria"
+  "SmartSetupCategoryNamePlaceholder": "Nome da categoria",
+
+  "ProfileSetupTitle": "Fale-nos sobre você",
+  "ProfileSetupSubtitle": "Ajude-nos a personalizar sua experiência",
+  "ErrorProfileUpdateFailed": "Falha ao actualizar o seu perfil. Por favor, tente novamente.",
+  "ErrorAutoLoginFailed": "Conta criada, mas o login automático falhou. Por favor, entre manualmente.",
+  "OnboardingSkip": "Pular"
 }
 

--- a/econoflow-mobile/src/navigation/AppNavigator.tsx
+++ b/econoflow-mobile/src/navigation/AppNavigator.tsx
@@ -3,9 +3,11 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useAuthStore } from '../store/authStore';
 import { AuthNavigator } from './AuthNavigator';
 import { MainNavigator } from './MainNavigator';
+import { OnboardingNavigator } from './OnboardingNavigator';
 
-type RootParamList = {
+export type RootParamList = {
   Auth: undefined;
+  Onboarding: undefined;
   Main: undefined;
 };
 
@@ -13,11 +15,16 @@ const Root = createNativeStackNavigator<RootParamList>();
 
 export const AppNavigator: React.FC = () => {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const needsOnboarding = useAuthStore((s) => s.needsOnboarding);
 
   return (
     <Root.Navigator screenOptions={{ headerShown: false }}>
       {isAuthenticated ? (
-        <Root.Screen name="Main" component={MainNavigator} />
+        needsOnboarding ? (
+          <Root.Screen name="Onboarding" component={OnboardingNavigator} />
+        ) : (
+          <Root.Screen name="Main" component={MainNavigator} />
+        )
       ) : (
         <Root.Screen name="Auth" component={AuthNavigator} />
       )}

--- a/econoflow-mobile/src/navigation/MainNavigator.tsx
+++ b/econoflow-mobile/src/navigation/MainNavigator.tsx
@@ -14,6 +14,7 @@ import { ProfileScreen } from '../screens/profile/ProfileScreen';
 import { QuickAddModal } from '../screens/quick-add/QuickAddModal';
 import { useQuickAddStore } from '../store/quickAddStore';
 import { useUIStore } from '../store/uiStore';
+import { useAuthStore } from '../store/authStore';
 import { currentMonth } from '../utils/date';
 
 type IconName = ComponentProps<typeof MaterialCommunityIcons>['name'];
@@ -37,6 +38,7 @@ export const MainNavigator: React.FC = () => {
   const barBg  = dark ? 'rgba(6,30,51,0.92)' : 'rgba(230,239,246,0.92)';
   const barBorder = dark ? 'rgba(255,255,255,0.08)' : 'rgba(13,33,55,0.08)';
   const hideTabBar = useUIStore((s) => s.hideTabBar);
+  const openCreateProjectOnStart = useAuthStore((s) => s.openCreateProjectOnStart);
   const [quickAddVisible, setQuickAddVisible] = useState(false);
   const quickAddCategoryId = useQuickAddStore(s => s.categoryId);
   const quickAddDefaultType = useQuickAddStore(s => s.defaultType);
@@ -45,7 +47,7 @@ export const MainNavigator: React.FC = () => {
   return (
     <>
     <Tab.Navigator
-      initialRouteName="Overview"
+      initialRouteName={openCreateProjectOnStart ? 'Projects' : 'Overview'}
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarStyle: hideTabBar

--- a/econoflow-mobile/src/navigation/OnboardingNavigator.tsx
+++ b/econoflow-mobile/src/navigation/OnboardingNavigator.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ProfileSetupScreen } from '../screens/onboarding/ProfileSetupScreen';
+
+export type OnboardingParamList = {
+  ProfileSetup: undefined;
+};
+
+const Stack = createNativeStackNavigator<OnboardingParamList>();
+
+export const OnboardingNavigator: React.FC = () => (
+  <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Screen name="ProfileSetup" component={ProfileSetupScreen} />
+  </Stack.Navigator>
+);

--- a/econoflow-mobile/src/navigation/ProjectStackNavigator.tsx
+++ b/econoflow-mobile/src/navigation/ProjectStackNavigator.tsx
@@ -5,10 +5,13 @@ import { ProjectListScreen } from '../screens/projects/ProjectListScreen';
 import { CreateProjectScreen } from '../screens/projects/CreateProjectScreen';
 import { SmartSetupScreen } from '../screens/projects/SmartSetupScreen';
 
+export type CreateProjectParams = { fromOnboarding?: boolean };
+export type SmartSetupParams = { projectId: string; fromOnboarding?: boolean };
+
 export type ProjectStackParamList = {
   ProjectList: undefined;
-  CreateProject: undefined;
-  SmartSetup: { projectId: string };
+  CreateProject: CreateProjectParams;
+  SmartSetup: SmartSetupParams;
 };
 
 const Stack = createNativeStackNavigator<ProjectStackParamList>();

--- a/econoflow-mobile/src/navigation/__tests__/MainNavigator.test.tsx
+++ b/econoflow-mobile/src/navigation/__tests__/MainNavigator.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { MainNavigator } from '../MainNavigator';
+
+// ─── Icon / gradient mocks ────────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: 'LinearGradient',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const insets = { top: 0, right: 0, bottom: 0, left: 0 };
+  const SafeAreaInsetsContext = React.createContext(insets);
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+    SafeAreaInsetsContext,
+    useSafeAreaInsets: () => insets,
+    useSafeAreaFrame: () => ({ width: 0, height: 0, x: 0, y: 0 }),
+  };
+});
+
+// ─── Tab screen mocks ─────────────────────────────────────────────────────────
+
+jest.mock('../ProjectStackNavigator', () => ({
+  ProjectStackNavigator: () => {
+    const React = require('react');
+    const { Text } = require('react-native');
+    return React.createElement(Text, { testID: 'projects-stack' }, 'Projects');
+  },
+}));
+
+jest.mock('../OverviewStackNavigator', () => ({
+  OverviewStackNavigator: () => {
+    const React = require('react');
+    const { Text } = require('react-native');
+    return React.createElement(Text, { testID: 'overview-stack' }, 'Overview');
+  },
+}));
+
+jest.mock('../PlansStackNavigator', () => ({
+  PlansStackNavigator: () => null,
+}));
+
+jest.mock('../../screens/profile/ProfileScreen', () => ({
+  ProfileScreen: () => null,
+}));
+
+jest.mock('../../screens/quick-add/QuickAddModal', () => ({
+  QuickAddModal: () => null,
+}));
+
+// ─── Store mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('../../store/uiStore', () => ({
+  useUIStore: jest.fn((selector: (s: { hideTabBar: boolean }) => unknown) =>
+    selector({ hideTabBar: false }),
+  ),
+}));
+
+jest.mock('../../store/quickAddStore', () => ({
+  useQuickAddStore: jest.fn(
+    (selector: (s: { categoryId: string | null; defaultType: string | null; viewedMonth: string | null }) => unknown) =>
+      selector({ categoryId: null, defaultType: null, viewedMonth: null }),
+  ),
+}));
+
+jest.mock('../../utils/date', () => ({
+  currentMonth: jest.fn(() => '2026-06'),
+}));
+
+let mockOpenCreateProjectOnStart = false;
+
+jest.mock('../../store/authStore', () => ({
+  useAuthStore: jest.fn((selector: (s: { openCreateProjectOnStart: boolean }) => unknown) =>
+    selector({ openCreateProjectOnStart: mockOpenCreateProjectOnStart }),
+  ),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MainNavigator – initial tab based on openCreateProjectOnStart', () => {
+  afterEach(() => {
+    mockOpenCreateProjectOnStart = false;
+  });
+
+  it('starts on Overview tab when openCreateProjectOnStart is false', async () => {
+    mockOpenCreateProjectOnStart = false;
+    await render(
+      <NavigationContainer>
+        <MainNavigator />
+      </NavigationContainer>,
+    );
+    // Verify via tab bar aria state (robust: survives lazy=false config changes)
+    const overviewTab = screen.getByLabelText(/TabOverview/);
+    expect(overviewTab.props.accessibilityState?.selected).toBe(true);
+    const projectsTab = screen.getByLabelText(/TabProjects/);
+    expect(projectsTab.props.accessibilityState?.selected).toBe(false);
+  });
+
+  it('starts on Projects tab when openCreateProjectOnStart is true', async () => {
+    mockOpenCreateProjectOnStart = true;
+    await render(
+      <NavigationContainer>
+        <MainNavigator />
+      </NavigationContainer>,
+    );
+    // Verify via tab bar aria state (robust: survives lazy=false config changes)
+    const projectsTab = screen.getByLabelText(/TabProjects/);
+    expect(projectsTab.props.accessibilityState?.selected).toBe(true);
+    const overviewTab = screen.getByLabelText(/TabOverview/);
+    expect(overviewTab.props.accessibilityState?.selected).toBe(false);
+  });
+});

--- a/econoflow-mobile/src/screens/auth/RegisterScreen.tsx
+++ b/econoflow-mobile/src/screens/auth/RegisterScreen.tsx
@@ -8,7 +8,9 @@ import { useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../../navigation/AuthNavigator';
-import { register } from '../../api/auth.api';
+import { register, mobileLogin, getCurrentUser } from '../../api/auth.api';
+import { useAuthStore } from '../../store/authStore';
+import i18n from '../../i18n';
 import { AuthHero } from '../../components/auth/AuthHero';
 import { AuroraField } from '../../components/auth/AuroraField';
 import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
@@ -31,8 +33,9 @@ const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z0-9]).{8,}$/
 export const RegisterScreen: React.FC<Props> = ({ navigation }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2 } = useAuroraSkin();
+  const { setTokens, setUser } = useAuthStore();
   const [serverError, setServerError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
+  const [autoLoginFailed, setAutoLoginFailed] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
   const { control, handleSubmit, watch, formState: { errors } } = useForm<FormValues>({
@@ -43,19 +46,54 @@ export const RegisterScreen: React.FC<Props> = ({ navigation }) => {
 
   const registerMutation = useMutation({
     mutationFn: (values: FormValues) => register(values.email, values.password),
-    onSuccess: () => setSuccess(true),
+    onSuccess: async (_data, variables) => {
+      try {
+        const loginResponse = await mobileLogin({ email: variables.email, password: variables.password });
+        const { accessToken, refreshToken } = loginResponse.data;
+
+        if (typeof accessToken !== 'string' || !accessToken) {
+          const body = loginResponse.data as unknown as { requiresTwoFactor?: boolean };
+          if (body?.requiresTwoFactor) {
+            navigation.navigate('TwoFactor', { email: variables.email, password: variables.password });
+            return;
+          }
+          setAutoLoginFailed(true);
+          return;
+        }
+
+        setTokens(accessToken, refreshToken);
+        try {
+          const userResponse = await getCurrentUser();
+          setUser(userResponse.data);
+          if (userResponse.data.languageCode) {
+            const lang = userResponse.data.languageCode.startsWith('pt') ? 'pt' : 'en';
+            i18n.changeLanguage(lang);
+          }
+        } catch { /* proceed without user profile */ }
+      } catch (err: unknown) {
+        const e = err as { response?: { data?: { requiresTwoFactor?: boolean } } };
+        if (e?.response?.data?.requiresTwoFactor) {
+          navigation.navigate('TwoFactor', { email: variables.email, password: variables.password });
+          return;
+        }
+        setAutoLoginFailed(true);
+      }
+    },
     onError: () => setServerError(t('ErrorRegistrationFailed')),
   });
 
-  if (success) {
+  if (autoLoginFailed) {
     return (
       <GlassScreen dark={dark}>
         <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
-          <AuthHero dark={dark} subtitle={t('LabelCheckYourEmail')} />
+          <AuthHero dark={dark} subtitle={t('PleaseSignIn')} />
           <GlassCard dark={dark} radius={28} style={styles.card}>
-            <Text style={[styles.successTitle, { color: ink }]}>{t('LabelCheckYourEmail')}</Text>
-            <Text style={[styles.successSub, { color: ink2 }]}>{t('LabelConfirmEmailSent')}</Text>
-            <AuroraPrimaryButton label={t('ButtonSignIn')} onPress={() => navigation.navigate('Login')} icon="arrow-right" />
+            <Text style={[styles.cardTitle, { color: ink }]}>{t('ErrorAutoLoginFailed')}</Text>
+            <AuroraPrimaryButton
+              label={t('ButtonSignIn')}
+              onPress={() => navigation.navigate('Login')}
+              icon="arrow-right"
+            />
           </GlassCard>
         </ScrollView>
       </GlassScreen>
@@ -70,81 +108,81 @@ export const RegisterScreen: React.FC<Props> = ({ navigation }) => {
 
           <GlassCard dark={dark} radius={28} style={styles.card}>
             <Text style={[styles.cardTitle, { color: ink }]}>{t('ButtonRegister')}</Text>
-          <Text style={[styles.cardSubtitle, { color: ink2 }]}>
-            {t('LabelStartOrganizing') ?? 'Start organising your money today'}
-          </Text>
-
-          <Controller
-            control={control}
-            name="email"
-            rules={{ required: t('RequiredField'), pattern: { value: /\S+@\S+\.\S+/, message: t('InvalidEmail') } }}
-            render={({ field: { onChange, value } }) => (
-              <AuroraField dark={dark} icon="email-outline" placeholder={t('FieldEmailAddress')}
-                value={value} onChangeText={onChange} keyboardType="email-address"
-                autoCapitalize="none" autoCorrect={false} hasError={!!errors.email} />
-            )}
-          />
-          {errors.email && <HelperText type="error">{errors.email.message}</HelperText>}
-
-          <Controller
-            control={control}
-            name="password"
-            rules={{ required: t('RequiredField'), pattern: { value: PASSWORD_REGEX, message: t('PasswordRequirements') } }}
-            render={({ field: { onChange, value } }) => (
-              <AuroraField dark={dark} icon="lock-outline" placeholder={t('FieldPassword')}
-                value={value} onChangeText={onChange} secureTextEntry={!showPassword}
-                onToggleSecure={() => setShowPassword(v => !v)} showSecure={showPassword}
-                hasError={!!errors.password} />
-            )}
-          />
-          {errors.password && <HelperText type="error">{errors.password.message}</HelperText>}
-
-          <Controller
-            control={control}
-            name="confirmPassword"
-            rules={{ required: t('RequiredField'), validate: v => v === passwordValue || t('PasswordsMustMatch') }}
-            render={({ field: { onChange, value } }) => (
-              <AuroraField dark={dark} icon="lock-reset" placeholder={t('FieldConfirmPassword')}
-                value={value} onChangeText={onChange} secureTextEntry hasError={!!errors.confirmPassword} />
-            )}
-          />
-          {errors.confirmPassword && <HelperText type="error">{errors.confirmPassword.message}</HelperText>}
-          {serverError && <HelperText type="error">{serverError}</HelperText>}
-
-          <AuroraPrimaryButton
-            label={t('ButtonRegister')}
-            onPress={handleSubmit(v => { setServerError(null); registerMutation.mutate(v); })}
-            loading={registerMutation.isPending}
-            icon="arrow-right"
-          />
-
-          <Text style={[styles.terms, { color: ink2 }]}>
-            {t('LabelTermsPrefix')}{' '}
-            <Text
-              style={styles.termsLink}
-              onPress={() => Linking.openURL('https://econoflow.pt/use-terms')}
-            >
-              {t('UseTerms')}
+            <Text style={[styles.cardSubtitle, { color: ink2 }]}>
+              {t('LabelStartOrganizing') ?? 'Start organising your money today'}
             </Text>
-            {t('LabelTermsMid')}{' '}
-            <Text
-              style={styles.termsLink}
-              onPress={() => Linking.openURL('https://econoflow.pt/privacy-policy')}
-            >
-              {t('PrivacyPolicy')}
+
+            <Controller
+              control={control}
+              name="email"
+              rules={{ required: t('RequiredField'), pattern: { value: /\S+@\S+\.\S+/, message: t('InvalidEmail') } }}
+              render={({ field: { onChange, value } }) => (
+                <AuroraField dark={dark} icon="email-outline" placeholder={t('FieldEmailAddress')}
+                  value={value} onChangeText={onChange} keyboardType="email-address"
+                  autoCapitalize="none" autoCorrect={false} hasError={!!errors.email} />
+              )}
+            />
+            {errors.email && <HelperText type="error">{errors.email.message}</HelperText>}
+
+            <Controller
+              control={control}
+              name="password"
+              rules={{ required: t('RequiredField'), pattern: { value: PASSWORD_REGEX, message: t('PasswordRequirements') } }}
+              render={({ field: { onChange, value } }) => (
+                <AuroraField dark={dark} icon="lock-outline" placeholder={t('FieldPassword')}
+                  value={value} onChangeText={onChange} secureTextEntry={!showPassword}
+                  onToggleSecure={() => setShowPassword(v => !v)} showSecure={showPassword}
+                  hasError={!!errors.password} />
+              )}
+            />
+            {errors.password && <HelperText type="error">{errors.password.message}</HelperText>}
+
+            <Controller
+              control={control}
+              name="confirmPassword"
+              rules={{ required: t('RequiredField'), validate: v => v === passwordValue || t('PasswordsMustMatch') }}
+              render={({ field: { onChange, value } }) => (
+                <AuroraField dark={dark} icon="lock-reset" placeholder={t('FieldConfirmPassword')}
+                  value={value} onChangeText={onChange} secureTextEntry hasError={!!errors.confirmPassword} />
+              )}
+            />
+            {errors.confirmPassword && <HelperText type="error">{errors.confirmPassword.message}</HelperText>}
+            {serverError && <HelperText type="error">{serverError}</HelperText>}
+
+            <AuroraPrimaryButton
+              label={t('ButtonRegister')}
+              onPress={handleSubmit(v => { setServerError(null); registerMutation.mutate(v); })}
+              loading={registerMutation.isPending}
+              icon="arrow-right"
+            />
+
+            <Text style={[styles.terms, { color: ink2 }]}>
+              {t('LabelTermsPrefix')}{' '}
+              <Text
+                style={styles.termsLink}
+                onPress={() => Linking.openURL('https://econoflow.pt/use-terms')}
+              >
+                {t('UseTerms')}
+              </Text>
+              {t('LabelTermsMid')}{' '}
+              <Text
+                style={styles.termsLink}
+                onPress={() => Linking.openURL('https://econoflow.pt/privacy-policy')}
+              >
+                {t('PrivacyPolicy')}
+              </Text>
+              {t('LabelTermsSuffix')}
             </Text>
-            {t('LabelTermsSuffix')}
-          </Text>
           </GlassCard>
 
           <View style={styles.bottomRow}>
-          <Text style={[styles.bottomText, { color: ink2 }]}>
-            {t('LabelAlreadyHaveAccount') ?? 'Already have an account?'}
-          </Text>
-          <Text style={[styles.link, { color: '#0f76a8' }]} onPress={() => navigation.navigate('Login')}>
-            {' '}{t('ButtonSignIn')}
-          </Text>
-        </View>
+            <Text style={[styles.bottomText, { color: ink2 }]}>
+              {t('LabelAlreadyHaveAccount') ?? 'Already have an account?'}
+            </Text>
+            <Text style={[styles.link, { color: '#0f76a8' }]} onPress={() => navigation.navigate('Login')}>
+              {' '}{t('ButtonSignIn')}
+            </Text>
+          </View>
         </ScrollView>
       </KeyboardAvoidingView>
     </GlassScreen>
@@ -160,8 +198,6 @@ const styles = StyleSheet.create({
   },
   cardTitle:    { fontSize: 19, fontWeight: '800', marginBottom: 2 },
   cardSubtitle: { fontSize: 13, fontWeight: '600', marginBottom: 4 },
-  successTitle: { fontSize: 22, fontWeight: '800', textAlign: 'center', marginBottom: 10 },
-  successSub:   { fontSize: 13.5, textAlign: 'center', lineHeight: 20, marginBottom: 6 },
   bottomRow:    { flexDirection: 'row', justifyContent: 'center', marginTop: 22 },
   bottomText:   { fontSize: 13.5 },
   link:         { fontSize: 13.5, fontWeight: '800' },

--- a/econoflow-mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx
+++ b/econoflow-mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RegisterScreen } from '../RegisterScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/auth/AuthHero', () => ({
+  AuthHero: jest.fn(() => null),
+}));
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({
+      placeholder, value, onChangeText, secureTextEntry,
+    }: {
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+      secureTextEntry?: boolean;
+    }) =>
+      React.createElement(TextInput, {
+        testID: placeholder,
+        value,
+        onChangeText,
+        secureTextEntry,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading,
+    }: { label: string; onPress: () => void; loading?: boolean }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+    Text: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn(),
+}));
+
+// ─── API / store mocks ────────────────────────────────────────────────────────
+
+const mockRegister = jest.fn();
+const mockMobileLogin = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockSetTokens = jest.fn();
+const mockSetUser = jest.fn();
+
+jest.mock('../../../api/auth.api', () => ({
+  register: (...args: unknown[]) => mockRegister(...args),
+  mobileLogin: (...args: unknown[]) => mockMobileLogin(...args),
+  getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({
+    setTokens: mockSetTokens,
+    setUser: mockSetUser,
+  })),
+}));
+
+jest.mock('../../../i18n', () => ({
+  __esModule: true,
+  default: { changeLanguage: jest.fn() },
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+} as unknown as React.ComponentProps<typeof RegisterScreen>['navigation'];
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+
+const renderScreen = async (queryClient: QueryClient) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RegisterScreen navigation={mockNavigation} />
+    </QueryClientProvider>,
+  );
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('RegisterScreen — auto-login after registration', () => {
+  let queryClient: QueryClient;
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    mockRegister.mockReset();
+    mockMobileLogin.mockReset();
+    mockGetCurrentUser.mockReset();
+    mockSetTokens.mockReset();
+    mockSetUser.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  const fillAndSubmitForm = async () => {
+    await fireEvent.changeText(screen.getByTestId('FieldEmailAddress'), 'user@example.com');
+    await fireEvent.changeText(screen.getByTestId('FieldPassword'), 'Passw0rd!');
+    await fireEvent.changeText(screen.getByTestId('FieldConfirmPassword'), 'Passw0rd!');
+    await fireEvent.press(screen.getByTestId('ButtonRegister'));
+  };
+
+  it('does not show a "Check your email" success state after registration', async () => {
+    mockRegister.mockResolvedValue({ data: {} });
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: { id: 'u1', firstName: '', languageCode: 'en' } });
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() => expect(mockMobileLogin).toHaveBeenCalled());
+    expect(screen.queryByText('LabelCheckYourEmail')).toBeNull();
+  });
+
+  it('calls mobileLogin with the same credentials after successful registration', async () => {
+    mockRegister.mockResolvedValue({ data: {} });
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: { id: 'u1', firstName: '', languageCode: 'en' } });
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() =>
+      expect(mockMobileLogin).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'Passw0rd!',
+      }),
+    );
+  });
+
+  it('saves tokens and user when auto-login succeeds', async () => {
+    const mockUser = { id: 'u1', firstName: '', languageCode: 'en' };
+    mockRegister.mockResolvedValue({ data: {} });
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: mockUser });
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() => {
+      expect(mockSetTokens).toHaveBeenCalledWith('at', 'rt');
+      expect(mockSetUser).toHaveBeenCalledWith(mockUser);
+    });
+  });
+
+  it('navigates to TwoFactor when auto-login returns requiresTwoFactor', async () => {
+    mockRegister.mockResolvedValue({ data: {} });
+    mockMobileLogin.mockResolvedValue({ data: { requiresTwoFactor: true } });
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('TwoFactor', {
+        email: 'user@example.com',
+        password: 'Passw0rd!',
+      }),
+    );
+  });
+
+  it('shows error banner with sign-in link when auto-login fails', async () => {
+    mockRegister.mockResolvedValue({ data: {} });
+    mockMobileLogin.mockRejectedValue(new Error('server error'));
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() => expect(screen.queryByText('ErrorAutoLoginFailed')).toBeTruthy());
+    expect(screen.queryByText('ButtonSignIn')).toBeTruthy();
+  });
+
+  it('shows registration error when register API call fails', async () => {
+    mockRegister.mockRejectedValue(new Error('server error'));
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() => expect(screen.queryByText('ErrorRegistrationFailed')).toBeTruthy());
+  });
+});

--- a/econoflow-mobile/src/screens/onboarding/ProfileSetupScreen.tsx
+++ b/econoflow-mobile/src/screens/onboarding/ProfileSetupScreen.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { HelperText } from 'react-native-paper';
+import { useForm, Controller, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { OnboardingParamList } from '../../navigation/OnboardingNavigator';
+import { useUpdateProfile } from '../../hooks/useUpdateProfile';
+import { useAuthStore } from '../../store/authStore';
+import i18n from '../../i18n';
+import { AuthHero } from '../../components/auth/AuthHero';
+import { AuroraField } from '../../components/auth/AuroraField';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
+import { GlassCard } from '../../components/common/GlassCard';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+
+export type Props = {
+  navigation: NativeStackNavigationProp<OnboardingParamList, 'ProfileSetup'>;
+};
+
+interface FormValues {
+  firstName: string;
+  lastName: string;
+  languageCode: string;
+}
+
+const SUPPORTED_LANGUAGES = [
+  { code: 'en', label: 'English' },
+  { code: 'pt', label: 'Português' },
+];
+
+export const ProfileSetupScreen: React.FC<Props> = () => {
+  const { t } = useTranslation();
+  const { dark, ink, ink2 } = useAuroraSkin();
+  const insets = useSafeAreaInsets();
+  const [error, setError] = useState<string | null>(null);
+  const [langOpen, setLangOpen] = useState(false);
+
+  const updateProfile = useUpdateProfile();
+  const setOpenCreateProjectOnStart = useAuthStore((s) => s.setOpenCreateProjectOnStart);
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      languageCode: i18n.language?.startsWith('pt') ? 'pt' : 'en',
+    },
+  });
+
+  const selectedLang = useWatch({ control, name: 'languageCode' });
+
+  const onSubmit = async (values: FormValues) => {
+    setError(null);
+    setOpenCreateProjectOnStart(true);
+    try {
+      await updateProfile.mutateAsync([
+        { op: 'replace', path: '/firstName', value: values.firstName },
+        { op: 'replace', path: '/lastName', value: values.lastName },
+        { op: 'replace', path: '/languageCode', value: values.languageCode },
+      ]);
+      if (values.languageCode) {
+        i18n.changeLanguage(values.languageCode.startsWith('pt') ? 'pt' : 'en');
+      }
+    } catch {
+      setOpenCreateProjectOnStart(false);
+      setError(t('ErrorProfileUpdateFailed'));
+    }
+  };
+
+  return (
+    <GlassScreen dark={dark}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={[
+            styles.scroll,
+            { paddingTop: insets.top + 16, paddingBottom: insets.bottom + 24 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          <AuthHero dark={dark} subtitle={t('ProfileSetupSubtitle')} />
+
+          <GlassCard dark={dark} radius={28} style={styles.card}>
+            <Text style={[styles.cardTitle, { color: ink }]}>{t('ProfileSetupTitle')}</Text>
+
+            <Controller
+              control={control}
+              name="firstName"
+              rules={{
+                required: t('RequiredField'),
+                maxLength: { value: 100, message: t('PropertyMaxLength', { field: t('FieldFirstName'), max: 100 }) },
+              }}
+              render={({ field: { onChange, value } }) => (
+                <AuroraField
+                  dark={dark}
+                  testID={t('PlaceholderFirstName')}
+                  icon="account-outline"
+                  placeholder={t('PlaceholderFirstName')}
+                  value={value}
+                  onChangeText={onChange}
+                  autoCapitalize="words"
+                  hasError={!!errors.firstName}
+                />
+              )}
+            />
+            {errors.firstName && <HelperText type="error">{errors.firstName.message}</HelperText>}
+
+            <Controller
+              control={control}
+              name="lastName"
+              rules={{
+                required: t('RequiredField'),
+                maxLength: { value: 100, message: t('PropertyMaxLength', { field: t('FieldLastName'), max: 100 }) },
+              }}
+              render={({ field: { onChange, value } }) => (
+                <AuroraField
+                  dark={dark}
+                  testID={t('PlaceholderLastName')}
+                  icon="account-outline"
+                  placeholder={t('PlaceholderLastName')}
+                  value={value}
+                  onChangeText={onChange}
+                  autoCapitalize="words"
+                  hasError={!!errors.lastName}
+                />
+              )}
+            />
+            {errors.lastName && <HelperText type="error">{errors.lastName.message}</HelperText>}
+
+            {/* Language picker */}
+            <Text style={[styles.sectionLabel, { color: ink2 }]}>{t('FieldLanguage')}</Text>
+            <Controller
+              control={control}
+              name="languageCode"
+              rules={{ required: t('RequiredField') }}
+              render={() => (
+                <View>
+                  <TouchableOpacity
+                    style={[styles.langSelector, { borderColor: ink2 }]}
+                    onPress={() => setLangOpen((v) => !v)}
+                  >
+                    <Text style={[styles.langValue, { color: ink }]}>
+                      {SUPPORTED_LANGUAGES.find((l) => l.code === selectedLang)?.label ?? t('PlaceholderLanguage')}
+                    </Text>
+                  </TouchableOpacity>
+                  {langOpen && (
+                    <View style={[styles.langDropdown, { borderColor: ink2 }]}>
+                      {SUPPORTED_LANGUAGES.map((lang) => (
+                        <TouchableOpacity
+                          key={lang.code}
+                          style={styles.langOption}
+                          onPress={() => {
+                            setValue('languageCode', lang.code);
+                            setLangOpen(false);
+                          }}
+                        >
+                          <Text style={[styles.langOptionText, { color: ink }]}>{lang.label}</Text>
+                        </TouchableOpacity>
+                      ))}
+                    </View>
+                  )}
+                </View>
+              )}
+            />
+            {errors.languageCode && <HelperText type="error">{errors.languageCode.message}</HelperText>}
+
+            <ErrorBanner
+              visible={!!error}
+              message={error ?? undefined}
+              onDismiss={() => setError(null)}
+            />
+
+            <AuroraPrimaryButton
+              testID={t('ButtonSaveAndContinue')}
+              label={t('ButtonSaveAndContinue')}
+              onPress={handleSubmit(onSubmit)}
+              loading={updateProfile.isPending}
+              icon="arrow-right"
+            />
+          </GlassCard>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </GlassScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  scroll: { flexGrow: 1, paddingHorizontal: 20 },
+  card: { padding: 22, marginBottom: 16 },
+  cardTitle: { fontSize: 19, fontWeight: '800', marginBottom: 12 },
+  sectionLabel: { fontSize: 13, fontWeight: '600', marginTop: 16, marginBottom: 6 },
+  langSelector: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  langValue: { fontSize: 14 },
+  langDropdown: {
+    borderWidth: 1,
+    borderRadius: 12,
+    marginTop: 4,
+    overflow: 'hidden',
+  },
+  langOption: {
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  langOptionText: { fontSize: 14 },
+});

--- a/econoflow-mobile/src/screens/onboarding/__tests__/ProfileSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/onboarding/__tests__/ProfileSetupScreen.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { ProfileSetupScreen } from '../ProfileSetupScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c', surface: '#fff' },
+    customColors: {},
+  }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
+  };
+});
+
+jest.mock('../../../components/auth/AuthHero', () => ({
+  AuthHero: jest.fn(() => null),
+}));
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({ testID, placeholder, value, onChangeText }: {
+      testID?: string;
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? placeholder,
+        value,
+        onChangeText,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading, testID,
+    }: { label: string; onPress: () => void; loading?: boolean; testID?: string }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: testID ?? label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+jest.mock('../../../i18n', () => ({
+  __esModule: true,
+  default: { language: 'en', changeLanguage: jest.fn() },
+}));
+
+// ─── Hook / store mocks ───────────────────────────────────────────────────────
+
+const mockMutateAsync = jest.fn();
+const mockSetOpenCreateProjectOnStart = jest.fn();
+
+jest.mock('../../../hooks/useUpdateProfile', () => ({
+  useUpdateProfile: jest.fn(() => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(
+    (selector: (s: { openCreateProjectOnStart: boolean; setOpenCreateProjectOnStart: jest.Mock }) => unknown) =>
+      selector({ openCreateProjectOnStart: false, setOpenCreateProjectOnStart: mockSetOpenCreateProjectOnStart }),
+  ),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+  goBack: jest.fn(),
+  dispatch: jest.fn(),
+} as unknown as React.ComponentProps<typeof ProfileSetupScreen>['navigation'];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ProfileSetupScreen', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    mockNavigate.mockReset();
+    mockSetOpenCreateProjectOnStart.mockReset();
+  });
+
+  it('renders first name, last name, and language fields', async () => {
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+    expect(screen.getByTestId('PlaceholderFirstName')).toBeTruthy();
+    expect(screen.getByTestId('PlaceholderLastName')).toBeTruthy();
+  });
+
+  it('shows required field error when first name is empty on submit', async () => {
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+
+    await fireEvent.press(screen.getByTestId('ButtonSaveAndContinue'));
+
+    expect((await screen.findAllByText('RequiredField')).length).toBeGreaterThan(0);
+  });
+
+  it('shows required field error when last name is empty on submit', async () => {
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderFirstName'), 'John');
+    await fireEvent.press(screen.getByTestId('ButtonSaveAndContinue'));
+
+    expect(await screen.findByText('RequiredField')).toBeTruthy();
+  });
+
+  it('calls patchUser with correct JSON patch on submit', async () => {
+    mockMutateAsync.mockResolvedValue({});
+
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderFirstName'), 'John');
+    await fireEvent.changeText(screen.getByTestId('PlaceholderLastName'), 'Doe');
+    await fireEvent.press(screen.getByTestId('ButtonSaveAndContinue'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ op: 'replace', path: '/firstName', value: 'John' }),
+          expect.objectContaining({ op: 'replace', path: '/lastName', value: 'Doe' }),
+        ]),
+      );
+    });
+  });
+
+  it('sets openCreateProjectOnStart on successful submit', async () => {
+    mockMutateAsync.mockResolvedValue({});
+
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+
+    await act(async () => {
+      await fireEvent.changeText(screen.getByTestId('PlaceholderFirstName'), 'John');
+      await fireEvent.changeText(screen.getByTestId('PlaceholderLastName'), 'Doe');
+      await fireEvent.press(screen.getByTestId('ButtonSaveAndContinue'));
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    await waitFor(() => {
+      expect(mockSetOpenCreateProjectOnStart).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('shows error banner when patchUser API fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderFirstName'), 'John');
+    await fireEvent.changeText(screen.getByTestId('PlaceholderLastName'), 'Doe');
+    await fireEvent.press(screen.getByTestId('ButtonSaveAndContinue'));
+
+    expect(await screen.findByTestId('error-banner', {}, { timeout: 3000 })).toBeTruthy();
+  });
+
+  it('resets openCreateProjectOnStart when patchUser API fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderFirstName'), 'John');
+    await fireEvent.changeText(screen.getByTestId('PlaceholderLastName'), 'Doe');
+    await fireEvent.press(screen.getByTestId('ButtonSaveAndContinue'));
+
+    await waitFor(() => {
+      expect(mockSetOpenCreateProjectOnStart).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('does not render a skip or back button', async () => {
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+    expect(screen.queryByText('SmartSetupSkip')).toBeNull();
+    expect(screen.queryByText('ButtonCancel')).toBeNull();
+    expect(screen.queryByText('SmartSetupBack')).toBeNull();
+  });
+});

--- a/econoflow-mobile/src/screens/projects/CreateProjectScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/CreateProjectScreen.tsx
@@ -12,8 +12,11 @@ import { HelperText } from 'react-native-paper';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { CommonActions } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RouteProp } from '@react-navigation/native';
 import type { ProjectStackParamList } from '../../navigation/ProjectStackNavigator';
+import type { RootParamList } from '../../navigation/AppNavigator';
 import { useCreateProject } from '../../hooks/useProjects';
 import { putTaxYearSettings } from '../../api/projects.api';
 import { useProjectStore } from '../../store/projectStore';
@@ -29,6 +32,7 @@ import { CurrencyPickerField } from '../../components/common/CurrencyPickerField
 
 type Props = {
   navigation: NativeStackNavigationProp<ProjectStackParamList, 'CreateProject'>;
+  route?: RouteProp<ProjectStackParamList, 'CreateProject'>;
 };
 
 type TaxYearType = 'CalendarYear' | 'CustomStartMonth';
@@ -41,13 +45,14 @@ interface FormValues {
   taxYearStartDay: string;
 }
 
-export const CreateProjectScreen: React.FC<Props> = ({ navigation }) => {
+export const CreateProjectScreen: React.FC<Props> = ({ navigation, route }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2, hair } = useAuroraSkin();
   const { colors } = useAppTheme();
   const insets = useSafeAreaInsets();
   const createProject = useCreateProject();
   const { setSelectedProject } = useProjectStore();
+  const fromOnboarding = route?.params?.fromOnboarding ?? false;
 
   const [taxYearType, setTaxYearType] = useState<TaxYearType>('CalendarYear');
   const [taxYearLabeling, setTaxYearLabeling] = useState<TaxYearLabeling>('ByStartYear');
@@ -86,7 +91,7 @@ export const CreateProjectScreen: React.FC<Props> = ({ navigation }) => {
       });
 
       setSelectedProject(userProject);
-      navigation.navigate('SmartSetup', { projectId: userProject.project.id });
+      navigation.navigate('SmartSetup', { projectId: userProject.project.id, fromOnboarding });
     } catch {
       setError(t('ErrorGeneric'));
     } finally {
@@ -296,13 +301,30 @@ export const CreateProjectScreen: React.FC<Props> = ({ navigation }) => {
             />
           </GlassCard>
 
-          {/* Cancel */}
-          <TouchableOpacity
-            style={[styles.cancelBtn, { backgroundColor: toggleBg, borderColor: toggleBorder }]}
-            onPress={() => navigation.goBack()}
-          >
-            <Text style={[styles.cancelText, { color: ink2 }]}>{t('ButtonCancel')}</Text>
-          </TouchableOpacity>
+          {fromOnboarding ? (
+            /* Skip — exits onboarding entirely */
+            <TouchableOpacity
+              style={[styles.cancelBtn, { backgroundColor: toggleBg, borderColor: toggleBorder }]}
+              onPress={() =>
+                navigation
+                  .getParent()
+                  ?.getParent<NativeStackNavigationProp<RootParamList>>()
+                  ?.dispatch(
+                    CommonActions.reset({ index: 0, routes: [{ name: 'Main' }] }),
+                  )
+              }
+            >
+              <Text style={[styles.cancelText, { color: ink2 }]}>{t('OnboardingSkip')}</Text>
+            </TouchableOpacity>
+          ) : (
+            /* Cancel — goes back in ProjectStack */
+            <TouchableOpacity
+              style={[styles.cancelBtn, { backgroundColor: toggleBg, borderColor: toggleBorder }]}
+              onPress={() => navigation.goBack()}
+            >
+              <Text style={[styles.cancelText, { color: ink2 }]}>{t('ButtonCancel')}</Text>
+            </TouchableOpacity>
+          )}
         </ScrollView>
       </KeyboardAvoidingView>
     </GlassScreen>

--- a/econoflow-mobile/src/screens/projects/ProjectListScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/ProjectListScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   ScrollView, StyleSheet, TouchableOpacity, View, RefreshControl,
 } from 'react-native';
@@ -12,6 +12,7 @@ import type { ProjectStackParamList } from '../../navigation/ProjectStackNavigat
 import type { MainTabParamList } from '../../navigation/MainNavigator';
 import { useProjects } from '../../hooks/useProjects';
 import { useProjectStore } from '../../store/projectStore';
+import { useAuthStore } from '../../store/authStore';
 import { LoadingIndicator } from '../../components/common/LoadingIndicator';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
@@ -39,7 +40,16 @@ export const ProjectListScreen: React.FC<Props> = ({ navigation }) => {
   const insets = useSafeAreaInsets();
   const { data: projects, isLoading, refetch } = useProjects();
   const { selectedProject, setSelectedProject } = useProjectStore();
+  const openCreateProjectOnStart = useAuthStore((s) => s.openCreateProjectOnStart);
+  const setOpenCreateProjectOnStart = useAuthStore((s) => s.setOpenCreateProjectOnStart);
   const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (openCreateProjectOnStart) {
+      setOpenCreateProjectOnStart(false);
+      navigation.navigate('CreateProject', { fromOnboarding: true });
+    }
+  }, [openCreateProjectOnStart, navigation, setOpenCreateProjectOnStart]);
 
   const handleSelect = (userProject: UserProject) => {
     setSelectedProject(userProject);
@@ -136,7 +146,7 @@ export const ProjectListScreen: React.FC<Props> = ({ navigation }) => {
       <View style={[styles.addBtnWrap, { paddingBottom: insets.bottom + 8 }]}>
         <AuroraPrimaryButton
           label={t('ButtonNewProject')}
-          onPress={() => navigation.navigate('CreateProject')}
+          onPress={() => navigation.navigate('CreateProject', {})}
           icon="plus"
         />
       </View>

--- a/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
@@ -138,7 +138,7 @@ const getCurrencySymbol = (code: string): string => {
 };
 
 export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
-  const { projectId } = route.params;
+  const { projectId, fromOnboarding } = route.params;
   const { t } = useTranslation();
   const { dark, ink, ink2, hair } = useAuroraSkin();
   const { colors, customColors } = useAppTheme();
@@ -159,10 +159,13 @@ export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
   const { data: defaultCategoriesData } = useDefaultCategories(projectId);
   const postSmartSetupMutation = usePostSmartSetup();
 
+  // Keep the tab bar visible when coming from the onboarding flow so the user
+  // can see the main navigation structure for the first time.
   useEffect(() => {
+    if (fromOnboarding) return undefined;
     setHideTabBar(true);
     return () => { setHideTabBar(false); };
-  }, [setHideTabBar]);
+  }, [fromOnboarding, setHideTabBar]);
 
   useEffect(() => {
     if (defaultCategoriesData && !initialized.current) {

--- a/econoflow-mobile/src/screens/projects/__tests__/CreateProjectScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/CreateProjectScreen.test.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { CreateProjectScreen } from '../CreateProjectScreen';
 
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+jest.mock('@react-navigation/native', () => ({
+  CommonActions: {
+    reset: jest.fn((payload) => ({ type: 'RESET', payload })),
+  },
+}));
+
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
 
 jest.mock('@expo/vector-icons', () => ({
@@ -166,6 +174,7 @@ const mockNavigation = {
   navigate: mockNavigate,
   goBack: mockGoBack,
   dispatch: jest.fn(),
+  getParent: jest.fn(),
 } as unknown as React.ComponentProps<typeof CreateProjectScreen>['navigation'];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -245,7 +254,7 @@ describe('CreateProjectScreen', () => {
         expect.objectContaining({ taxYearType: 'CalendarYear' }),
       );
       expect(mockSetSelectedProject).toHaveBeenCalledWith(MOCK_USER_PROJECT);
-      expect(mockNavigate).toHaveBeenCalledWith('SmartSetup', { projectId: 'proj-1' });
+      expect(mockNavigate).toHaveBeenCalledWith('SmartSetup', expect.objectContaining({ projectId: 'proj-1' }));
     });
   });
 
@@ -260,9 +269,49 @@ describe('CreateProjectScreen', () => {
     expect(await screen.findByTestId('error-banner', {}, { timeout: 3000 })).toBeTruthy();
   });
 
-  it('calls goBack when cancel is pressed', async () => {
+  it('calls goBack when cancel is pressed (non-onboarding context)', async () => {
     await render(<CreateProjectScreen navigation={mockNavigation} />);
     await fireEvent.press(screen.getByText('ButtonCancel'));
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a skip button when fromOnboarding param is true', async () => {
+    const mockRouteOnboarding = {
+      key: 'CreateProject-1',
+      name: 'CreateProject',
+      params: { fromOnboarding: true },
+    };
+
+    await render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <CreateProjectScreen navigation={mockNavigation} route={mockRouteOnboarding as any} />,
+    );
+
+    expect(screen.queryByText('OnboardingSkip')).toBeTruthy();
+  });
+
+  it('skip button dispatches CommonActions.reset to the root navigator in onboarding context', async () => {
+    const mockRootDispatch = jest.fn();
+    const mockRootNav = { dispatch: mockRootDispatch };
+    const mockTabNav = { getParent: jest.fn(() => mockRootNav) };
+    const mockNavigationOnboarding = {
+      ...mockNavigation,
+      getParent: jest.fn(() => mockTabNav),
+    } as unknown as React.ComponentProps<typeof CreateProjectScreen>['navigation'];
+
+    const mockRouteOnboarding = {
+      key: 'CreateProject-1',
+      name: 'CreateProject',
+      params: { fromOnboarding: true },
+    };
+
+    await render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <CreateProjectScreen navigation={mockNavigationOnboarding} route={mockRouteOnboarding as any} />,
+    );
+
+    await fireEvent.press(screen.getByText('OnboardingSkip'));
+
+    expect(mockRootDispatch).toHaveBeenCalled();
   });
 });

--- a/econoflow-mobile/src/screens/projects/__tests__/ProjectListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/ProjectListScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react-native';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { ProjectListScreen } from '../ProjectListScreen';
 
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
@@ -69,6 +69,11 @@ jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
 // ─── Store / hook mocks ───────────────────────────────────────────────────────
 
 const mockSetSelectedProject = jest.fn();
+const mockSetOpenCreateProjectOnStart = jest.fn();
+const mockAuthState = {
+  openCreateProjectOnStart: false,
+  setOpenCreateProjectOnStart: mockSetOpenCreateProjectOnStart,
+};
 
 jest.mock('../../../hooks/useProjects', () => ({
   useProjects: jest.fn(() => ({ data: [], isLoading: false, refetch: jest.fn() })),
@@ -79,6 +84,10 @@ jest.mock('../../../store/projectStore', () => ({
     selectedProject: null,
     setSelectedProject: mockSetSelectedProject,
   })),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn((selector: (s: typeof mockAuthState) => unknown) => selector(mockAuthState)),
 }));
 
 // ─── Navigation mock ──────────────────────────────────────────────────────────
@@ -113,6 +122,8 @@ describe('ProjectListScreen', () => {
   beforeEach(() => {
     mockNavigate.mockReset();
     mockSetSelectedProject.mockReset();
+    mockSetOpenCreateProjectOnStart.mockReset();
+    mockAuthState.openCreateProjectOnStart = false;
     mockGetParent.mockReturnValue({ navigate: jest.fn() });
   });
 
@@ -147,6 +158,18 @@ describe('ProjectListScreen', () => {
 
     fireEvent.press(screen.getByTestId('btn-ButtonNewProject'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('CreateProject');
+    expect(mockNavigate).toHaveBeenCalledWith('CreateProject', {});
+  });
+
+  it('navigates to CreateProject and clears flag on mount when openCreateProjectOnStart is true', async () => {
+    mockAuthState.openCreateProjectOnStart = true;
+    getUseProjectsMock().mockReturnValue({ data: [], isLoading: false, refetch: jest.fn() });
+
+    await render(<ProjectListScreen navigation={mockNavigation} />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('CreateProject', { fromOnboarding: true });
+      expect(mockSetOpenCreateProjectOnStart).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
@@ -580,4 +580,45 @@ describe('SmartSetupScreen', () => {
     expect(ids[1]).not.toBe('undefined');
     expect(ids[0]).not.toBe(ids[1]);
   });
+
+  // ─── fromOnboarding=true path ─────────────────────────────────────────────────
+
+  const mockRouteOnboarding = {
+    params: { projectId: 'proj-1', fromOnboarding: true },
+  } as unknown as React.ComponentProps<typeof SmartSetupScreen>['route'];
+
+  it('does not hide the tab bar when fromOnboarding is true', async () => {
+    await render(
+      <SmartSetupScreen navigation={mockNavigation} route={mockRouteOnboarding} />,
+    );
+    expect(useUIStore.getState().hideTabBar).toBe(false);
+  });
+
+  it('Skip resets the project stack and navigates to Overview when fromOnboarding is true', async () => {
+    await render(
+      <SmartSetupScreen navigation={mockNavigation} route={mockRouteOnboarding} />,
+    );
+
+    await fireEvent.press(screen.getByText('SmartSetupSkip'));
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'RESET' }),
+    );
+    expect(mockParentNavigate).toHaveBeenCalledWith('Overview');
+  });
+
+  it('Finish navigates to Overview when fromOnboarding is true', async () => {
+    mockMutateAsync.mockResolvedValue(undefined);
+
+    await render(
+      <SmartSetupScreen navigation={mockNavigation} route={mockRouteOnboarding} />,
+    );
+
+    await goToStep3();
+    await fireEvent.press(screen.getByTestId('SmartSetupFinish'));
+
+    await waitFor(() => {
+      expect(mockParentNavigate).toHaveBeenCalledWith('Overview');
+    });
+  });
 });

--- a/econoflow-mobile/src/store/__tests__/authStore.test.ts
+++ b/econoflow-mobile/src/store/__tests__/authStore.test.ts
@@ -43,6 +43,37 @@ const getRehydrationCallback = (): ((state: AuthState | undefined) => void) => {
   return options.onRehydrateStorage();
 };
 
+describe('authStore – needsOnboarding derived value', () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      accessToken: null,
+      refreshToken: null,
+      user: null,
+      isAuthenticated: false,
+    });
+  });
+
+  it('is false when user is null', () => {
+    expect(useAuthStore.getState().needsOnboarding).toBe(false);
+  });
+
+  it('is true when user has no firstName', () => {
+    useAuthStore.getState().setUser({ ...mockUser, firstName: '' });
+    expect(useAuthStore.getState().needsOnboarding).toBe(true);
+  });
+
+  it('is false when user has a firstName', () => {
+    useAuthStore.getState().setUser({ ...mockUser, firstName: 'Alice' });
+    expect(useAuthStore.getState().needsOnboarding).toBe(false);
+  });
+
+  it('becomes false after clearAuth', () => {
+    useAuthStore.getState().setUser({ ...mockUser, firstName: '' });
+    useAuthStore.getState().clearAuth();
+    expect(useAuthStore.getState().needsOnboarding).toBe(false);
+  });
+});
+
 describe('authStore – Sentry user context integration', () => {
   beforeEach(() => {
     useAuthStore.setState({
@@ -123,5 +154,44 @@ describe('authStore – Sentry user context integration', () => {
       rehydrate({ ...useAuthStore.getState(), user: null });
       expect(setUserContext).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('authStore – partialize (persistence shape)', () => {
+  it('does not persist needsOnboarding (recomputed from user on rehydration)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { partialize } = (useAuthStore as any).persist.getOptions() as {
+      partialize: (s: AuthState) => Record<string, unknown>;
+    };
+    const partial = partialize({ ...useAuthStore.getState(), needsOnboarding: true, openCreateProjectOnStart: true });
+    expect(partial).not.toHaveProperty('needsOnboarding');
+    expect(partial).not.toHaveProperty('openCreateProjectOnStart');
+  });
+});
+
+describe('authStore – openCreateProjectOnStart flag', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ openCreateProjectOnStart: false });
+  });
+
+  it('defaults to false', () => {
+    expect(useAuthStore.getState().openCreateProjectOnStart).toBe(false);
+  });
+
+  it('setOpenCreateProjectOnStart(true) sets it to true', () => {
+    useAuthStore.getState().setOpenCreateProjectOnStart(true);
+    expect(useAuthStore.getState().openCreateProjectOnStart).toBe(true);
+  });
+
+  it('setOpenCreateProjectOnStart(false) resets it', () => {
+    useAuthStore.getState().setOpenCreateProjectOnStart(true);
+    useAuthStore.getState().setOpenCreateProjectOnStart(false);
+    expect(useAuthStore.getState().openCreateProjectOnStart).toBe(false);
+  });
+
+  it('clearAuth resets openCreateProjectOnStart to false', () => {
+    useAuthStore.getState().setOpenCreateProjectOnStart(true);
+    useAuthStore.getState().clearAuth();
+    expect(useAuthStore.getState().openCreateProjectOnStart).toBe(false);
   });
 });

--- a/econoflow-mobile/src/store/authStore.ts
+++ b/econoflow-mobile/src/store/authStore.ts
@@ -21,9 +21,13 @@ export interface AuthState {
   refreshToken: string | null;
   user: User | null;
   isAuthenticated: boolean;
+  needsOnboarding: boolean;
+  /** Volatile flag (not persisted): navigate to CreateProject when MainNavigator first mounts after onboarding */
+  openCreateProjectOnStart: boolean;
   setTokens: (accessToken: string, refreshToken: string) => void;
   setUser: (user: User) => void;
   clearAuth: () => void;
+  setOpenCreateProjectOnStart: (v: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -33,26 +37,41 @@ export const useAuthStore = create<AuthState>()(
       refreshToken: null,
       user: null,
       isAuthenticated: false,
+      needsOnboarding: false,
+      openCreateProjectOnStart: false,
       setTokens: (accessToken, refreshToken) =>
         set({ accessToken, refreshToken, isAuthenticated: true }),
       setUser: (user) => {
         setUserContext(user.id);
-        set({ user });
+        set({ user, needsOnboarding: !!user && !user.firstName });
       },
       clearAuth: () => {
         clearUserContext();
-        set({ accessToken: null, refreshToken: null, user: null, isAuthenticated: false });
+        set({ accessToken: null, refreshToken: null, user: null, isAuthenticated: false, needsOnboarding: false, openCreateProjectOnStart: false });
       },
+      setOpenCreateProjectOnStart: (v) => set({ openCreateProjectOnStart: v }),
     }),
     {
       name: 'econoflow-auth',
       storage: createJSONStorage(() => secureStorage),
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+        // needsOnboarding and openCreateProjectOnStart are intentionally excluded:
+        // needsOnboarding is recomputed from user.firstName in onRehydrateStorage;
+        // openCreateProjectOnStart resets to false on app restart.
+      }),
       // Restore the Sentry user context after the store is rehydrated from
       // SecureStore on app launch (the setUser action is not replayed on
       // rehydration, so we need to sync Sentry here explicitly).
       onRehydrateStorage: () => (state) => {
         if (state?.user?.id) {
           setUserContext(state.user.id);
+        }
+        if (state) {
+          state.needsOnboarding = !!state.user && !state.user.firstName;
         }
       },
     }


### PR DESCRIPTION
## Summary

- **New `ProfileSetupScreen`**: after registration (when `user.firstName` is empty), the user is redirected to a dedicated screen to enter first name, last name, and preferred language before they can use the app. Validated with React Hook Form; uses the existing `PATCH /api/users` endpoint.
- **`OnboardingNavigator`**: a new slim stack containing only `ProfileSetupScreen`. `AppNavigator` routes to it whenever `needsOnboarding` is true (derived from `user.firstName === ''`).
- **Direct CreateProject routing**: after profile setup succeeds the user lands on the `CreateProject` screen **with the bottom navigation bar visible**, not isolated inside the onboarding stack. A volatile `openCreateProjectOnStart` flag in `authStore` coordinates the redirect without coupling `ProfileSetupScreen` to the main nav structure.
- **Race-condition fix**: `setOpenCreateProjectOnStart(true)` is now set *before* `await mutateAsync(...)` so the flag is already `true` when `MainNavigator` first renders (triggered by `needsOnboarding` flipping to `false` inside `onSuccess`).
- **`MainNavigator`**: reads `openCreateProjectOnStart` and sets `initialRouteName="Projects"` when true, ensuring the `Projects` tab (and `ProjectListScreen`) mounts immediately so its `useEffect` can push `CreateProject` onto the stack.
- **`authStore`**: removed `needsOnboarding` from `partialize` — it is recomputed from `user.firstName` in `onRehydrateStorage` on every cold start, so persisting it created a potential divergence window on force-kill.
- **`CreateProjectScreen` type safety**: replaced `'Main' as never` dispatch cast with a proper `getParent().getParent<NativeStackNavigationProp<RootParamList>>()` chain. `RootParamList` is now exported from `AppNavigator`.
- **`RegisterScreen`**: auto-login after registration so the onboarding screen starts immediately without a manual re-login step.

## Test plan

- [ ] Register a new account → `ProfileSetupScreen` appears
- [ ] Submit without first name → validation error shown
- [ ] Submit with first name + last name → redirected to `CreateProject` with bottom nav visible
- [ ] Press Skip on `CreateProject` → lands on `Overview` (root reset to `Main`)
- [ ] Create a project + finish SmartSetup → lands on `Overview`
- [ ] Force-kill app after profile setup, relaunch → `needsOnboarding` correctly recomputed from persisted `user.firstName`; no stuck onboarding loop
- [ ] Existing user login (already has firstName) → no onboarding screen, goes straight to `Overview`
- [ ] `npm test` → 377 tests pass
- [ ] `npm run typecheck` → clean
- [ ] `npm run lint` → 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)