### PR TITLE
feat(mobile): make Profile page fully functional (#754)

### DIFF
--- a/econoflow-mobile/src/api/__tests__/user.api.test.ts
+++ b/econoflow-mobile/src/api/__tests__/user.api.test.ts
@@ -1,0 +1,100 @@
+import {
+  getUser,
+  patchUser,
+  manageInfo,
+  getTwoFactorSetup,
+  enableTwoFactor,
+  disableTwoFactor,
+} from '../user.api';
+import { apiClient } from '../client';
+import type { ManageInfoRequest, EnableTwoFactorRequest, DisableTwoFactorRequest } from '../types';
+
+jest.mock('../client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    patch: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+describe('user.api — existing functions', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('getUser GETs /api/AccessControl', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: {} });
+    await getUser();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/AccessControl');
+  });
+
+  it('patchUser PATCHes /api/AccessControl with ops', async () => {
+    (apiClient.patch as jest.Mock).mockResolvedValue({ data: {} });
+    const ops = [{ op: 'replace' as const, path: '/firstName', value: 'Alice' }];
+    await patchUser(ops);
+    expect(apiClient.patch).toHaveBeenCalledWith('/api/AccessControl', ops);
+  });
+});
+
+describe('user.api — manageInfo', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('POSTs to /api/AccessControl/manage/info for password change', async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({ data: {} });
+    const req: ManageInfoRequest = { oldPassword: 'old', newPassword: 'new' };
+    await manageInfo(req);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/AccessControl/manage/info', req);
+  });
+
+  it('POSTs to /api/AccessControl/manage/info for email change', async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({ data: {} });
+    const req: ManageInfoRequest = { newEmail: 'new@example.com' };
+    await manageInfo(req);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/AccessControl/manage/info', req);
+  });
+});
+
+describe('user.api — getTwoFactorSetup', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('GETs /api/AccessControl/2fa/setup', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: { isTwoFactorEnabled: false, sharedKey: 'key', otpAuthUri: 'otpauth://...' },
+    });
+    await getTwoFactorSetup();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/AccessControl/2fa/setup');
+  });
+});
+
+describe('user.api — enableTwoFactor', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('POSTs to /api/AccessControl/2fa/enable with code', async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({
+      data: { twoFactorEnabled: true, recoveryCodes: ['code1', 'code2'] },
+    });
+    const req: EnableTwoFactorRequest = { code: '123456' };
+    await enableTwoFactor(req);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/AccessControl/2fa/enable', req);
+  });
+});
+
+describe('user.api — disableTwoFactor', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('POSTs to /api/AccessControl/2fa/disable with password and twoFactorCode', async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({
+      data: { twoFactorEnabled: false },
+    });
+    const req: DisableTwoFactorRequest = { password: 'mypassword', twoFactorCode: '654321' };
+    await disableTwoFactor(req);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/AccessControl/2fa/disable', req);
+  });
+
+  it('POSTs to /api/AccessControl/2fa/disable with recoveryCode', async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({
+      data: { twoFactorEnabled: false },
+    });
+    const req: DisableTwoFactorRequest = { password: 'mypassword', twoFactorRecoveryCode: 'recovery-code-1' };
+    await disableTwoFactor(req);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/AccessControl/2fa/disable', req);
+  });
+});

--- a/econoflow-mobile/src/api/types.ts
+++ b/econoflow-mobile/src/api/types.ts
@@ -186,3 +186,30 @@ export interface SmartSetupRequest {
   defaultCategories: DefaultCategory[];
   emergencyReserveTarget: number;
 }
+
+export interface ManageInfoRequest {
+  oldPassword?: string;
+  newPassword?: string;
+  newEmail?: string;
+}
+
+export interface TwoFactorSetupInfo {
+  isTwoFactorEnabled: boolean;
+  sharedKey: string;
+  otpAuthUri: string;
+}
+
+export interface EnableTwoFactorRequest {
+  code: string;
+}
+
+export interface EnableTwoFactorResponse {
+  twoFactorEnabled: boolean;
+  recoveryCodes: string[];
+}
+
+export interface DisableTwoFactorRequest {
+  password: string;
+  twoFactorCode?: string;
+  twoFactorRecoveryCode?: string;
+}

--- a/econoflow-mobile/src/api/user.api.ts
+++ b/econoflow-mobile/src/api/user.api.ts
@@ -1,8 +1,28 @@
 import { apiClient } from './client';
-import type { User, PatchOperation } from './types';
+import type {
+  User,
+  PatchOperation,
+  ManageInfoRequest,
+  TwoFactorSetupInfo,
+  EnableTwoFactorRequest,
+  EnableTwoFactorResponse,
+  DisableTwoFactorRequest,
+} from './types';
 
 export const getUser = () =>
   apiClient.get<User>('/api/AccessControl');
 
 export const patchUser = (ops: PatchOperation[]) =>
   apiClient.patch<User>('/api/AccessControl', ops);
+
+export const manageInfo = (req: ManageInfoRequest) =>
+  apiClient.post('/api/AccessControl/manage/info', req);
+
+export const getTwoFactorSetup = () =>
+  apiClient.get<TwoFactorSetupInfo>('/api/AccessControl/2fa/setup');
+
+export const enableTwoFactor = (req: EnableTwoFactorRequest) =>
+  apiClient.post<EnableTwoFactorResponse>('/api/AccessControl/2fa/enable', req);
+
+export const disableTwoFactor = (req: DisableTwoFactorRequest) =>
+  apiClient.post('/api/AccessControl/2fa/disable', req);

--- a/econoflow-mobile/src/hooks/__tests__/useProfile.test.ts
+++ b/econoflow-mobile/src/hooks/__tests__/useProfile.test.ts
@@ -1,0 +1,215 @@
+import * as UserApi from '../../api/user.api';
+import {
+  useChangePassword,
+  useChangeEmail,
+  useTwoFactorSetup,
+  useEnableTwoFactor,
+  useDisableTwoFactor,
+} from '../useProfile';
+import { useAuthStore } from '../../store/authStore';
+import type { User, ManageInfoRequest, EnableTwoFactorRequest, EnableTwoFactorResponse, DisableTwoFactorRequest, TwoFactorSetupInfo } from '../../api/types';
+
+jest.mock('../../api/user.api');
+jest.mock('../../store/authStore');
+
+const mockSetUser = jest.fn();
+const mockInvalidateQueries = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: jest.fn((opts) => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+    _opts: opts,
+  })),
+  useQuery: jest.fn((opts) => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    _opts: opts,
+  })),
+  useQueryClient: jest.fn(() => ({ invalidateQueries: mockInvalidateQueries })),
+}));
+
+(useAuthStore as unknown as jest.Mock).mockReturnValue({ setUser: mockSetUser });
+
+const mockUser: User = {
+  id: 'user-1',
+  email: 'test@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  fullName: 'John Doe',
+  enabled: true,
+  isFirstLogin: false,
+  emailConfirmed: true,
+  twoFactorEnabled: false,
+  defaultProjectId: null,
+  notificationChannels: [],
+  languageCode: 'en',
+  isBetaTester: false,
+};
+
+beforeEach(() => {
+  mockSetUser.mockReset();
+  mockInvalidateQueries.mockReset();
+});
+
+// ─── useChangePassword ────────────────────────────────────────────────────────
+
+describe('useChangePassword', () => {
+  it('mutationFn calls manageInfo with oldPassword and newPassword', async () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedMutationFn!: (req: ManageInfoRequest) => Promise<unknown>;
+    useMutation.mockImplementationOnce((opts: { mutationFn: typeof capturedMutationFn }) => {
+      capturedMutationFn = opts.mutationFn;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    (UserApi.manageInfo as jest.Mock).mockResolvedValue({ data: {} });
+
+    useChangePassword();
+
+    const req: ManageInfoRequest = { oldPassword: 'old', newPassword: 'newpass' };
+    await capturedMutationFn(req);
+
+    expect(UserApi.manageInfo).toHaveBeenCalledWith(req);
+  });
+});
+
+// ─── useChangeEmail ───────────────────────────────────────────────────────────
+
+describe('useChangeEmail', () => {
+  it('mutationFn calls manageInfo with newEmail', async () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedMutationFn!: (req: ManageInfoRequest) => Promise<unknown>;
+    useMutation.mockImplementationOnce((opts: { mutationFn: typeof capturedMutationFn }) => {
+      capturedMutationFn = opts.mutationFn;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    (UserApi.manageInfo as jest.Mock).mockResolvedValue({ data: {} });
+
+    useChangeEmail();
+
+    const req: ManageInfoRequest = { newEmail: 'new@example.com' };
+    await capturedMutationFn(req);
+
+    expect(UserApi.manageInfo).toHaveBeenCalledWith(req);
+  });
+});
+
+// ─── useTwoFactorSetup ────────────────────────────────────────────────────────
+
+describe('useTwoFactorSetup', () => {
+  it('queryFn calls getTwoFactorSetup', async () => {
+    const { useQuery } = jest.requireMock('@tanstack/react-query') as { useQuery: jest.Mock };
+    let capturedQueryFn!: () => Promise<TwoFactorSetupInfo>;
+    useQuery.mockImplementationOnce((opts: { queryFn: typeof capturedQueryFn }) => {
+      capturedQueryFn = opts.queryFn;
+      return { data: undefined, isLoading: false, isError: false };
+    });
+
+    const mockSetup: TwoFactorSetupInfo = {
+      isTwoFactorEnabled: false,
+      sharedKey: 'abc123',
+      otpAuthUri: 'otpauth://totp/...',
+    };
+    (UserApi.getTwoFactorSetup as jest.Mock).mockResolvedValue({ data: mockSetup });
+
+    useTwoFactorSetup();
+
+    const result = await capturedQueryFn();
+    expect(UserApi.getTwoFactorSetup).toHaveBeenCalled();
+    expect(result).toEqual(mockSetup);
+  });
+});
+
+// ─── useEnableTwoFactor ───────────────────────────────────────────────────────
+
+describe('useEnableTwoFactor', () => {
+  it('mutationFn calls enableTwoFactor with code', async () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedMutationFn!: (req: EnableTwoFactorRequest) => Promise<EnableTwoFactorResponse>;
+    useMutation.mockImplementationOnce((opts: { mutationFn: typeof capturedMutationFn }) => {
+      capturedMutationFn = opts.mutationFn;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    const mockResponse: EnableTwoFactorResponse = {
+      twoFactorEnabled: true,
+      recoveryCodes: ['code1'],
+    };
+    (UserApi.enableTwoFactor as jest.Mock).mockResolvedValue({ data: mockResponse });
+
+    useEnableTwoFactor();
+
+    const req: EnableTwoFactorRequest = { code: '123456' };
+    const result = await capturedMutationFn(req);
+
+    expect(UserApi.enableTwoFactor).toHaveBeenCalledWith(req);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('onSuccess calls setUser with updated twoFactorEnabled=true', () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedOnSuccess!: (data: EnableTwoFactorResponse) => void;
+    useMutation.mockImplementationOnce((opts: { onSuccess: typeof capturedOnSuccess }) => {
+      capturedOnSuccess = opts.onSuccess;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    (useAuthStore as unknown as jest.Mock).mockReturnValue({ setUser: mockSetUser, user: mockUser });
+
+    useEnableTwoFactor();
+
+    const data: EnableTwoFactorResponse = { twoFactorEnabled: true, recoveryCodes: [] };
+    capturedOnSuccess(data);
+
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({ twoFactorEnabled: true }),
+    );
+  });
+});
+
+// ─── useDisableTwoFactor ──────────────────────────────────────────────────────
+
+describe('useDisableTwoFactor', () => {
+  it('mutationFn calls disableTwoFactor with request', async () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedMutationFn!: (req: DisableTwoFactorRequest) => Promise<unknown>;
+    useMutation.mockImplementationOnce((opts: { mutationFn: typeof capturedMutationFn }) => {
+      capturedMutationFn = opts.mutationFn;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    (UserApi.disableTwoFactor as jest.Mock).mockResolvedValue({ data: { twoFactorEnabled: false } });
+
+    useDisableTwoFactor();
+
+    const req: DisableTwoFactorRequest = { password: 'pw', twoFactorCode: '111111' };
+    await capturedMutationFn(req);
+
+    expect(UserApi.disableTwoFactor).toHaveBeenCalledWith(req);
+  });
+
+  it('onSuccess calls setUser with updated twoFactorEnabled=false', () => {
+    const { useMutation } = jest.requireMock('@tanstack/react-query') as { useMutation: jest.Mock };
+    let capturedOnSuccess!: () => void;
+    useMutation.mockImplementationOnce((opts: { onSuccess: typeof capturedOnSuccess }) => {
+      capturedOnSuccess = opts.onSuccess;
+      return { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false };
+    });
+
+    (useAuthStore as unknown as jest.Mock).mockReturnValue({
+      setUser: mockSetUser,
+      user: { ...mockUser, twoFactorEnabled: true },
+    });
+
+    useDisableTwoFactor();
+    capturedOnSuccess();
+
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({ twoFactorEnabled: false }),
+    );
+  });
+});

--- a/econoflow-mobile/src/hooks/useProfile.ts
+++ b/econoflow-mobile/src/hooks/useProfile.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  manageInfo,
+  getTwoFactorSetup,
+  enableTwoFactor,
+  disableTwoFactor,
+} from '../api/user.api';
+import { useAuthStore } from '../store/authStore';
+import type {
+  ManageInfoRequest,
+  EnableTwoFactorRequest,
+  EnableTwoFactorResponse,
+  DisableTwoFactorRequest,
+} from '../api/types';
+
+export const useChangePassword = () =>
+  useMutation({
+    mutationFn: (req: ManageInfoRequest) => manageInfo(req),
+  });
+
+export const useChangeEmail = () =>
+  useMutation({
+    mutationFn: (req: ManageInfoRequest) => manageInfo(req),
+  });
+
+export const useTwoFactorSetup = () =>
+  useQuery({
+    queryKey: ['twoFactorSetup'],
+    queryFn: () => getTwoFactorSetup().then((r) => r.data),
+    staleTime: 60_000,
+  });
+
+export const useEnableTwoFactor = () => {
+  const queryClient = useQueryClient();
+  const { setUser, user } = useAuthStore();
+
+  return useMutation<EnableTwoFactorResponse, Error, EnableTwoFactorRequest>({
+    mutationFn: (req) => enableTwoFactor(req).then((r) => r.data),
+    onSuccess: (data) => {
+      if (user) {
+        setUser({ ...user, twoFactorEnabled: data.twoFactorEnabled });
+      }
+      queryClient.invalidateQueries({ queryKey: ['twoFactorSetup'] });
+    },
+  });
+};
+
+export const useDisableTwoFactor = () => {
+  const queryClient = useQueryClient();
+  const { setUser, user } = useAuthStore();
+
+  return useMutation<unknown, Error, DisableTwoFactorRequest>({
+    mutationFn: (req) => disableTwoFactor(req).then((r) => r.data),
+    onSuccess: () => {
+      if (user) {
+        setUser({ ...user, twoFactorEnabled: false });
+      }
+      queryClient.invalidateQueries({ queryKey: ['twoFactorSetup'] });
+    },
+  });
+};

--- a/econoflow-mobile/src/i18n/__tests__/locales.test.ts
+++ b/econoflow-mobile/src/i18n/__tests__/locales.test.ts
@@ -155,4 +155,44 @@ describe('i18n locale completeness', () => {
   it('pt.json contains OnboardingSkip', () => {
     expect((pt as LocaleMap)['OnboardingSkip']).toBeTruthy();
   });
+
+  it('en.json contains EditName', () => {
+    expect((en as LocaleMap)['EditName']).toBeTruthy();
+  });
+
+  it('pt.json contains EditName', () => {
+    expect((pt as LocaleMap)['EditName']).toBeTruthy();
+  });
+
+  it('en.json contains VerificationEmailSent', () => {
+    expect((en as LocaleMap)['VerificationEmailSent']).toBeTruthy();
+  });
+
+  it('pt.json contains VerificationEmailSent', () => {
+    expect((pt as LocaleMap)['VerificationEmailSent']).toBeTruthy();
+  });
+
+  it('en.json contains ErrorChangePasswordFailed', () => {
+    expect((en as LocaleMap)['ErrorChangePasswordFailed']).toBeTruthy();
+  });
+
+  it('pt.json contains ErrorChangePasswordFailed', () => {
+    expect((pt as LocaleMap)['ErrorChangePasswordFailed']).toBeTruthy();
+  });
+
+  it('en.json contains ErrorChangeEmailFailed', () => {
+    expect((en as LocaleMap)['ErrorChangeEmailFailed']).toBeTruthy();
+  });
+
+  it('pt.json contains ErrorChangeEmailFailed', () => {
+    expect((pt as LocaleMap)['ErrorChangeEmailFailed']).toBeTruthy();
+  });
+
+  it('en.json contains ErrorNewPasswordSameAsCurrent', () => {
+    expect((en as LocaleMap)['ErrorNewPasswordSameAsCurrent']).toBeTruthy();
+  });
+
+  it('pt.json contains ErrorNewPasswordSameAsCurrent', () => {
+    expect((pt as LocaleMap)['ErrorNewPasswordSameAsCurrent']).toBeTruthy();
+  });
 });

--- a/econoflow-mobile/src/i18n/locales/en.json
+++ b/econoflow-mobile/src/i18n/locales/en.json
@@ -591,5 +591,12 @@
   "ProfileSetupSubtitle": "Help us personalise your experience",
   "ErrorProfileUpdateFailed": "Failed to update your profile. Please try again.",
   "ErrorAutoLoginFailed": "Account created, but sign-in failed. Please sign in manually.",
-  "OnboardingSkip": "Skip"
+  "OnboardingSkip": "Skip",
+
+  "EditName": "Edit Name",
+  "VerificationEmailSent": "A verification email has been sent. Please check your inbox.",
+  "ErrorChangePasswordFailed": "Failed to change password. Please try again.",
+  "ErrorChangeEmailFailed": "Failed to change email. Please try again.",
+  "ErrorNewPasswordSameAsCurrent": "New password must differ from the current password.",
+  "PlaceholderConfirmNewPassword": "Confirm new password"
 }

--- a/econoflow-mobile/src/i18n/locales/pt.json
+++ b/econoflow-mobile/src/i18n/locales/pt.json
@@ -590,6 +590,13 @@
   "ProfileSetupSubtitle": "Ajude-nos a personalizar sua experiência",
   "ErrorProfileUpdateFailed": "Falha ao actualizar o seu perfil. Por favor, tente novamente.",
   "ErrorAutoLoginFailed": "Conta criada, mas o login automático falhou. Por favor, entre manualmente.",
-  "OnboardingSkip": "Pular"
+  "OnboardingSkip": "Pular",
+
+  "EditName": "Editar Nome",
+  "VerificationEmailSent": "Um e-mail de verificação foi enviado. Por favor, verifique sua caixa de entrada.",
+  "ErrorChangePasswordFailed": "Falha ao alterar a senha. Por favor, tente novamente.",
+  "ErrorChangeEmailFailed": "Falha ao alterar o e-mail. Por favor, tente novamente.",
+  "ErrorNewPasswordSameAsCurrent": "A nova senha deve ser diferente da senha atual.",
+  "PlaceholderConfirmNewPassword": "Confirmar nova senha"
 }
 

--- a/econoflow-mobile/src/navigation/MainNavigator.tsx
+++ b/econoflow-mobile/src/navigation/MainNavigator.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { ProjectStackNavigator } from './ProjectStackNavigator';
 import { OverviewStackNavigator } from './OverviewStackNavigator';
 import { PlansStackNavigator } from './PlansStackNavigator';
-import { ProfileScreen } from '../screens/profile/ProfileScreen';
+import { ProfileStackNavigator } from './ProfileStackNavigator';
 import { QuickAddModal } from '../screens/quick-add/QuickAddModal';
 import { useQuickAddStore } from '../store/quickAddStore';
 import { useUIStore } from '../store/uiStore';
@@ -124,7 +124,7 @@ export const MainNavigator: React.FC = () => {
 
       <Tab.Screen
         name="Profile"
-        component={ProfileScreen}
+        component={ProfileStackNavigator}
         options={{ headerShown: false, tabBarLabel: t('TabProfile') }}
       />
     </Tab.Navigator>

--- a/econoflow-mobile/src/navigation/ProfileStackNavigator.tsx
+++ b/econoflow-mobile/src/navigation/ProfileStackNavigator.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ProfileScreen } from '../screens/profile/ProfileScreen';
+import { EditNameScreen } from '../screens/profile/EditNameScreen';
+import { ChangePasswordScreen } from '../screens/profile/ChangePasswordScreen';
+import { ChangeEmailScreen } from '../screens/profile/ChangeEmailScreen';
+import { LanguagePickerScreen } from '../screens/profile/LanguagePickerScreen';
+import { TwoFactorScreen } from '../screens/profile/TwoFactorScreen';
+
+export type ProfileStackParamList = {
+  Profile: undefined;
+  EditName: undefined;
+  ChangePassword: undefined;
+  ChangeEmail: undefined;
+  LanguagePicker: undefined;
+  TwoFactorSetup: undefined;
+};
+
+const Stack = createNativeStackNavigator<ProfileStackParamList>();
+
+export const ProfileStackNavigator: React.FC = () => (
+  <Stack.Navigator>
+    <Stack.Screen name="Profile" component={ProfileScreen} options={{ headerShown: false }} />
+    <Stack.Screen name="EditName" component={EditNameScreen} options={{ headerShown: false }} />
+    <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ headerShown: false }} />
+    <Stack.Screen name="ChangeEmail" component={ChangeEmailScreen} options={{ headerShown: false }} />
+    <Stack.Screen name="LanguagePicker" component={LanguagePickerScreen} options={{ headerShown: false }} />
+    <Stack.Screen name="TwoFactorSetup" component={TwoFactorScreen} options={{ headerShown: false }} />
+  </Stack.Navigator>
+);

--- a/econoflow-mobile/src/navigation/__tests__/MainNavigator.test.tsx
+++ b/econoflow-mobile/src/navigation/__tests__/MainNavigator.test.tsx
@@ -51,6 +51,10 @@ jest.mock('../PlansStackNavigator', () => ({
   PlansStackNavigator: () => null,
 }));
 
+jest.mock('../ProfileStackNavigator', () => ({
+  ProfileStackNavigator: () => null,
+}));
+
 jest.mock('../../screens/profile/ProfileScreen', () => ({
   ProfileScreen: () => null,
 }));

--- a/econoflow-mobile/src/screens/profile/ChangeEmailScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ChangeEmailScreen.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ProfileStackParamList } from '../../navigation/ProfileStackNavigator';
+import { useAuthStore } from '../../store/authStore';
+import { useChangeEmail } from '../../hooks/useProfile';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { AuroraField } from '../../components/auth/AuroraField';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+
+type Props = NativeStackScreenProps<ProfileStackParamList, 'ChangeEmail'>;
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const ChangeEmailScreen: React.FC<Props> = ({ navigation: _navigation }) => {
+  const { t } = useTranslation();
+  const { dark, ink, ink2 } = useAuroraSkin();
+  const insets = useSafeAreaInsets();
+  const { user } = useAuthStore();
+  const { mutateAsync, isPending } = useChangeEmail();
+
+  const [email, setEmail] = useState(user?.email ?? '');
+  const [emailError, setEmailError] = useState('');
+  const [apiError, setApiError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  const validate = () => {
+    if (!email.trim()) {
+      setEmailError(t('RequiredField') ?? 'This field is required.');
+      return false;
+    }
+    if (!EMAIL_REGEX.test(email.trim())) {
+      setEmailError(t('InvalidEmailFormat') ?? 'Invalid email format.');
+      return false;
+    }
+    setEmailError('');
+    return true;
+  };
+
+  const handleSave = async () => {
+    if (!validate()) return;
+    setApiError('');
+    try {
+      await mutateAsync({ newEmail: email.trim() });
+      setSuccess(true);
+    } catch {
+      setApiError(t('ErrorChangeEmailFailed') ?? 'Failed to change email. Please try again.');
+    }
+  };
+
+  return (
+    <GlassScreen dark={dark}>
+      <ErrorBanner
+        visible={!!apiError}
+        message={apiError}
+        onDismiss={() => setApiError('')}
+      />
+      <ScrollView
+        style={styles.fill}
+        contentContainerStyle={[styles.scroll, { paddingTop: insets.top + 20, paddingBottom: insets.bottom + 32 }]}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={[styles.title, { color: ink }]}>{t('ChangeEmailAddress') ?? 'Change Email Address'}</Text>
+
+        {success ? (
+          <View style={styles.successBox}>
+            <Text style={[styles.successText, { color: ink2 }]}>
+              {t('VerificationEmailSent') ?? 'A verification email has been sent. Please check your inbox.'}
+            </Text>
+          </View>
+        ) : (
+          <>
+            <AuroraField
+              dark={dark}
+              icon="email-outline"
+              placeholder={t('PlaceholderEmailAddress') ?? 'Email address'}
+              testID="PlaceholderEmailAddress"
+              value={email}
+              onChangeText={setEmail}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              hasError={!!emailError}
+            />
+            {!!emailError && (
+              <Text style={styles.errorText}>{emailError}</Text>
+            )}
+
+            <AuroraPrimaryButton
+              label={t('ButtonSave') ?? 'Save'}
+              onPress={handleSave}
+              loading={isPending}
+              testID="ButtonSave"
+            />
+          </>
+        )}
+      </ScrollView>
+    </GlassScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  fill:        { flex: 1 },
+  scroll:      { paddingHorizontal: 24 },
+  title:       { fontSize: 24, fontWeight: '800', marginBottom: 8 },
+  errorText:   { color: '#e74c3c', fontSize: 12, marginTop: 4, marginLeft: 4 },
+  successBox:  { marginTop: 24, padding: 16, borderRadius: 16, backgroundColor: 'rgba(14,159,110,0.12)', borderWidth: 1, borderColor: 'rgba(14,159,110,0.28)' },
+  successText: { fontSize: 14, fontWeight: '600', textAlign: 'center' },
+});

--- a/econoflow-mobile/src/screens/profile/ChangePasswordScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ChangePasswordScreen.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ProfileStackParamList } from '../../navigation/ProfileStackNavigator';
+import { useChangePassword } from '../../hooks/useProfile';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { AuroraField } from '../../components/auth/AuroraField';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+
+type Props = NativeStackScreenProps<ProfileStackParamList, 'ChangePassword'>;
+
+export const ChangePasswordScreen: React.FC<Props> = ({ navigation }) => {
+  const { t } = useTranslation();
+  const { dark, ink } = useAuroraSkin();
+  const insets = useSafeAreaInsets();
+  const { mutateAsync, isPending } = useChangePassword();
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [currentPasswordError, setCurrentPasswordError] = useState('');
+  const [newPasswordError, setNewPasswordError] = useState('');
+  const [confirmPasswordError, setConfirmPasswordError] = useState('');
+  const [apiError, setApiError] = useState('');
+
+  const validate = () => {
+    let valid = true;
+
+    if (!currentPassword) {
+      setCurrentPasswordError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else {
+      setCurrentPasswordError('');
+    }
+
+    if (!newPassword) {
+      setNewPasswordError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else if (newPassword === currentPassword) {
+      setNewPasswordError(t('ErrorNewPasswordSameAsCurrent') ?? 'New password must differ from current password.');
+      valid = false;
+    } else {
+      setNewPasswordError('');
+    }
+
+    if (!confirmPassword) {
+      setConfirmPasswordError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else if (confirmPassword !== newPassword) {
+      setConfirmPasswordError(t('PasswordsMustMatch') ?? 'Passwords must match');
+      valid = false;
+    } else {
+      setConfirmPasswordError('');
+    }
+
+    return valid;
+  };
+
+  const handleSave = async () => {
+    if (!validate()) return;
+    setApiError('');
+    try {
+      await mutateAsync({ oldPassword: currentPassword, newPassword });
+      navigation.goBack();
+    } catch {
+      setApiError(t('ErrorChangePasswordFailed') ?? 'Failed to change password. Please try again.');
+    } finally {
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    }
+  };
+
+  return (
+    <GlassScreen dark={dark}>
+      <ErrorBanner
+        visible={!!apiError}
+        message={apiError}
+        onDismiss={() => setApiError('')}
+      />
+      <ScrollView
+        style={styles.fill}
+        contentContainerStyle={[styles.scroll, { paddingTop: insets.top + 20, paddingBottom: insets.bottom + 32 }]}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={[styles.title, { color: ink }]}>{t('ChangePassword') ?? 'Change Password'}</Text>
+
+        <AuroraField
+          dark={dark}
+          icon="lock-outline"
+          placeholder={t('PlaceholderCurrentPassword') ?? 'Current password'}
+          testID="PlaceholderCurrentPassword"
+          value={currentPassword}
+          onChangeText={setCurrentPassword}
+          secureTextEntry
+          hasError={!!currentPasswordError}
+        />
+        {!!currentPasswordError && (
+          <Text style={styles.errorText}>{currentPasswordError}</Text>
+        )}
+
+        <AuroraField
+          dark={dark}
+          icon="lock-reset"
+          placeholder={t('PlaceholderNewPassword') ?? 'New Password'}
+          testID="PlaceholderNewPassword"
+          value={newPassword}
+          onChangeText={setNewPassword}
+          secureTextEntry
+          hasError={!!newPasswordError}
+        />
+        {!!newPasswordError && (
+          <Text style={styles.errorText}>{newPasswordError}</Text>
+        )}
+
+        <AuroraField
+          dark={dark}
+          icon="lock-check-outline"
+          placeholder={t('PlaceholderConfirmNewPassword') ?? 'Confirm New Password'}
+          testID="PlaceholderConfirmNewPassword"
+          value={confirmPassword}
+          onChangeText={setConfirmPassword}
+          secureTextEntry
+          hasError={!!confirmPasswordError}
+        />
+        {!!confirmPasswordError && (
+          <Text style={styles.errorText}>{confirmPasswordError}</Text>
+        )}
+
+        <AuroraPrimaryButton
+          label={t('ButtonSave') ?? 'Save'}
+          onPress={handleSave}
+          loading={isPending}
+          testID="ButtonSave"
+        />
+      </ScrollView>
+    </GlassScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  fill:      { flex: 1 },
+  scroll:    { paddingHorizontal: 24 },
+  title:     { fontSize: 24, fontWeight: '800', marginBottom: 8 },
+  errorText: { color: '#e74c3c', fontSize: 12, marginTop: 4, marginLeft: 4 },
+});

--- a/econoflow-mobile/src/screens/profile/EditNameScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/EditNameScreen.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ProfileStackParamList } from '../../navigation/ProfileStackNavigator';
+import { useAuthStore } from '../../store/authStore';
+import { useUpdateProfile } from '../../hooks/useUpdateProfile';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { AuroraField } from '../../components/auth/AuroraField';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+
+type Props = NativeStackScreenProps<ProfileStackParamList, 'EditName'>;
+
+export const EditNameScreen: React.FC<Props> = ({ navigation }) => {
+  const { t } = useTranslation();
+  const { dark, ink, ink2 } = useAuroraSkin();
+  const insets = useSafeAreaInsets();
+  const { user } = useAuthStore();
+  const { mutateAsync, isPending } = useUpdateProfile();
+
+  const [firstName, setFirstName] = useState(user?.firstName ?? '');
+  const [lastName, setLastName] = useState(user?.lastName ?? '');
+  const [firstNameError, setFirstNameError] = useState('');
+  const [lastNameError, setLastNameError] = useState('');
+  const [apiError, setApiError] = useState('');
+
+  const validate = () => {
+    let valid = true;
+    if (!firstName.trim()) {
+      setFirstNameError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else {
+      setFirstNameError('');
+    }
+    if (!lastName.trim()) {
+      setLastNameError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else {
+      setLastNameError('');
+    }
+    return valid;
+  };
+
+  const handleSave = async () => {
+    if (!validate()) return;
+    setApiError('');
+    try {
+      await mutateAsync([
+        { op: 'replace', path: '/firstName', value: firstName.trim() },
+        { op: 'replace', path: '/lastName', value: lastName.trim() },
+      ]);
+      navigation.goBack();
+    } catch {
+      setApiError(t('ErrorProfileUpdateFailed') ?? 'Failed to update your profile. Please try again.');
+    }
+  };
+
+  return (
+    <GlassScreen dark={dark}>
+      <ErrorBanner
+        visible={!!apiError}
+        message={apiError}
+        onDismiss={() => setApiError('')}
+      />
+      <ScrollView
+        style={styles.fill}
+        contentContainerStyle={[styles.scroll, { paddingTop: insets.top + 20, paddingBottom: insets.bottom + 32 }]}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={[styles.title, { color: ink }]}>{t('EditName') ?? 'Edit Name'}</Text>
+
+        <AuroraField
+          dark={dark}
+          icon="account-outline"
+          placeholder={t('PlaceholderFirstName') ?? 'First name'}
+          testID="PlaceholderFirstName"
+          value={firstName}
+          onChangeText={setFirstName}
+          autoCapitalize="words"
+          hasError={!!firstNameError}
+        />
+        {!!firstNameError && (
+          <Text style={styles.errorText}>{firstNameError}</Text>
+        )}
+
+        <AuroraField
+          dark={dark}
+          icon="account-outline"
+          placeholder={t('PlaceholderLastName') ?? 'Last name'}
+          testID="PlaceholderLastName"
+          value={lastName}
+          onChangeText={setLastName}
+          autoCapitalize="words"
+          hasError={!!lastNameError}
+        />
+        {!!lastNameError && (
+          <Text style={styles.errorText}>{lastNameError}</Text>
+        )}
+
+        <View style={styles.buttonRow}>
+          <AuroraPrimaryButton
+            label={t('ButtonSave') ?? 'Save'}
+            onPress={handleSave}
+            loading={isPending}
+            testID="ButtonSave"
+          />
+        </View>
+
+        <View style={[styles.ink2Hint, { marginTop: 12 }]}>
+          <Text style={{ color: ink2, fontSize: 12 }}>
+            {t('FieldFirstName') ?? 'First Name'} &amp; {t('FieldLastName') ?? 'Last Name'}
+          </Text>
+        </View>
+      </ScrollView>
+    </GlassScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  fill:       { flex: 1 },
+  scroll:     { paddingHorizontal: 24 },
+  title:      { fontSize: 24, fontWeight: '800', marginBottom: 8 },
+  errorText:  { color: '#e74c3c', fontSize: 12, marginTop: 4, marginLeft: 4 },
+  buttonRow:  { marginTop: 8 },
+  ink2Hint:   {},
+});

--- a/econoflow-mobile/src/screens/profile/LanguagePickerScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/LanguagePickerScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -10,6 +10,7 @@ import { useAuthStore } from '../../store/authStore';
 import { useUpdateProfile } from '../../hooks/useUpdateProfile';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import i18n from '../../i18n';
 
@@ -27,15 +28,22 @@ export const LanguagePickerScreen: React.FC<Props> = ({ navigation: _navigation 
   const { user } = useAuthStore();
   const { mutateAsync } = useUpdateProfile();
 
+  const [apiError, setApiError] = useState('');
   const currentLang = user?.languageCode ?? 'en-US';
 
   const handleSelect = async (code: string) => {
-    i18n.changeLanguage(code);
-    await mutateAsync([{ op: 'replace', path: '/languageCode', value: code }]);
+    setApiError('');
+    try {
+      await mutateAsync([{ op: 'replace', path: '/languageCode', value: code }]);
+      i18n.changeLanguage(code);
+    } catch {
+      setApiError(t('ErrorGeneric') ?? 'Something went wrong. Please try again.');
+    }
   };
 
   return (
     <GlassScreen dark={dark}>
+      <ErrorBanner visible={!!apiError} message={apiError} onDismiss={() => setApiError('')} />
       <ScrollView
         style={styles.fill}
         contentContainerStyle={[styles.scroll, { paddingTop: insets.top + 20, paddingBottom: insets.bottom + 32 }]}

--- a/econoflow-mobile/src/screens/profile/LanguagePickerScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/LanguagePickerScreen.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ProfileStackParamList } from '../../navigation/ProfileStackNavigator';
+import { useAuthStore } from '../../store/authStore';
+import { useUpdateProfile } from '../../hooks/useUpdateProfile';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { GlassCard } from '../../components/common/GlassCard';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import i18n from '../../i18n';
+
+type Props = NativeStackScreenProps<ProfileStackParamList, 'LanguagePicker'>;
+
+const SUPPORTED_LANGUAGES: { code: string; label: string }[] = [
+  { code: 'en-US', label: 'English (US)' },
+  { code: 'pt-BR', label: 'Português (Brasil)' },
+];
+
+export const LanguagePickerScreen: React.FC<Props> = ({ navigation: _navigation }) => {
+  const { t } = useTranslation();
+  const { dark, ink, ink2, hair } = useAuroraSkin();
+  const insets = useSafeAreaInsets();
+  const { user } = useAuthStore();
+  const { mutateAsync } = useUpdateProfile();
+
+  const currentLang = user?.languageCode ?? 'en-US';
+
+  const handleSelect = async (code: string) => {
+    i18n.changeLanguage(code);
+    await mutateAsync([{ op: 'replace', path: '/languageCode', value: code }]);
+  };
+
+  return (
+    <GlassScreen dark={dark}>
+      <ScrollView
+        style={styles.fill}
+        contentContainerStyle={[styles.scroll, { paddingTop: insets.top + 20, paddingBottom: insets.bottom + 32 }]}
+      >
+        <Text style={[styles.title, { color: ink }]}>{t('LabelLanguage') ?? 'Language'}</Text>
+
+        <GlassCard dark={dark} radius={20} style={styles.card}>
+          {SUPPORTED_LANGUAGES.map((lang, idx) => {
+            const isSelected = currentLang === lang.code;
+            const isLast = idx === SUPPORTED_LANGUAGES.length - 1;
+            return (
+              <TouchableOpacity
+                key={lang.code}
+                onPress={() => handleSelect(lang.code)}
+                activeOpacity={0.7}
+                testID={`lang-${lang.code}`}
+                style={[
+                  styles.langRow,
+                  { borderBottomColor: isLast ? 'transparent' : hair },
+                ]}
+              >
+                <Text style={[styles.langLabel, { color: ink }]}>{lang.label}</Text>
+                {isSelected && (
+                  <View testID={`lang-${lang.code}-selected`}>
+                    <MaterialCommunityIcons name="check" size={20} color="#0f76a8" />
+                  </View>
+                )}
+              </TouchableOpacity>
+            );
+          })}
+        </GlassCard>
+
+        <Text style={[styles.hint, { color: ink2 }]}>
+          {t('PlaceholderLanguage') ?? 'Select your language'}
+        </Text>
+      </ScrollView>
+    </GlassScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  fill:    { flex: 1 },
+  scroll:  { paddingHorizontal: 24 },
+  title:   { fontSize: 24, fontWeight: '800', marginBottom: 16 },
+  card:    { marginBottom: 12 },
+  langRow: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 16, paddingVertical: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  langLabel: { fontSize: 15, fontWeight: '600' },
+  hint:      { fontSize: 12, textAlign: 'center', marginTop: 8 },
+});

--- a/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
@@ -8,17 +8,15 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import type { MainTabParamList } from '../../navigation/MainNavigator';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ProfileStackParamList } from '../../navigation/ProfileStackNavigator';
 import { useAuthStore } from '../../store/authStore';
 import { useProjectStore } from '../../store/projectStore';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { GlassCard } from '../../components/common/GlassCard';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 
-type Props = {
-  navigation: BottomTabNavigationProp<MainTabParamList, 'Profile'>;
-};
+type Props = NativeStackScreenProps<ProfileStackParamList, 'Profile'>;
 
 interface SettingRowProps {
   icon: string;
@@ -30,24 +28,38 @@ interface SettingRowProps {
   ink2: string;
   hair: string;
   isLast?: boolean;
+  onPress?: () => void;
+  testID?: string;
 }
 
 const SettingRow: React.FC<SettingRowProps> = ({
-  icon, label, value, valueColor, dark, ink, ink2, hair, isLast,
-}) => (
-  <View style={[styles.settingRow, { borderBottomColor: isLast ? 'transparent' : hair }]}>
-    <View style={[styles.settingIconWrap, { backgroundColor: '#0f76a8' + (dark ? '28' : '18') }]}>
-      <MaterialCommunityIcons name={icon as never} size={18} color="#0f76a8" />
+  icon, label, value, valueColor, dark, ink, ink2, hair, isLast, onPress, testID,
+}) => {
+  const inner = (
+    <View style={[styles.settingRow, { borderBottomColor: isLast ? 'transparent' : hair }]}>
+      <View style={[styles.settingIconWrap, { backgroundColor: '#0f76a8' + (dark ? '28' : '18') }]}>
+        <MaterialCommunityIcons name={icon as never} size={18} color="#0f76a8" />
+      </View>
+      <View style={styles.settingInfo}>
+        <Text style={[styles.settingLabel, { color: ink2 }]}>{label}</Text>
+        <Text style={[styles.settingValue, { color: valueColor ?? ink }]}>{value}</Text>
+      </View>
+      <MaterialCommunityIcons name="chevron-right" size={18} color={ink2} />
     </View>
-    <View style={styles.settingInfo}>
-      <Text style={[styles.settingLabel, { color: ink2 }]}>{label}</Text>
-      <Text style={[styles.settingValue, { color: valueColor ?? ink }]}>{value}</Text>
-    </View>
-    <MaterialCommunityIcons name="chevron-right" size={18} color={ink2} />
-  </View>
-);
+  );
 
-export const ProfileScreen: React.FC<Props> = () => {
+  if (onPress) {
+    return (
+      <TouchableOpacity onPress={onPress} activeOpacity={0.7} testID={testID}>
+        {inner}
+      </TouchableOpacity>
+    );
+  }
+
+  return <View testID={testID}>{inner}</View>;
+};
+
+export const ProfileScreen: React.FC<Props> = ({ navigation }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2, hair } = useAuroraSkin();
   const insets = useSafeAreaInsets();
@@ -76,7 +88,12 @@ export const ProfileScreen: React.FC<Props> = () => {
       >
         {/* Avatar + name */}
         <View style={styles.heroSection}>
-          <View style={styles.avatarWrap}>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('EditName')}
+            activeOpacity={0.7}
+            testID="row-EditName"
+            style={styles.avatarWrap}
+          >
             <LinearGradient
               colors={['#0f76a8', '#14c08a']}
               start={{ x: 0, y: 0 }}
@@ -85,8 +102,10 @@ export const ProfileScreen: React.FC<Props> = () => {
             >
               <Text style={styles.avatarText}>{initial}</Text>
             </LinearGradient>
-          </View>
-          <Text style={[styles.displayName, { color: ink }]}>{displayName}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => navigation.navigate('EditName')} testID="row-EditName-name">
+            <Text style={[styles.displayName, { color: ink }]}>{displayName}</Text>
+          </TouchableOpacity>
           <Text style={[styles.email, { color: ink2 }]}>{user?.email}</Text>
           {selectedProject && (
             <View style={styles.projectPill}>
@@ -107,17 +126,29 @@ export const ProfileScreen: React.FC<Props> = () => {
             label={t('LabelTwoFactorAuthentication') ?? '2FA'}
             value={user?.twoFactorEnabled ? (t('LabelEnabled') ?? 'Enabled') : (t('LabelDisabled') ?? 'Disabled')}
             valueColor={user?.twoFactorEnabled ? '#0e9f6e' : undefined}
+            onPress={() => navigation.navigate('TwoFactorSetup')}
+            testID="row-TwoFactorSetup"
           />
           <SettingRow
             dark={dark} ink={ink} ink2={ink2} hair={hair}
             icon="translate"
             label={t('LabelLanguage') ?? 'Language'}
             value={user?.languageCode ?? 'en-US'}
+            onPress={() => navigation.navigate('LanguagePicker')}
+            testID="row-LanguagePicker"
+          />
+          <SettingRow
+            dark={dark} ink={ink} ink2={ink2} hair={hair}
+            icon="email-outline"
+            label={t('ChangeEmailAddress') ?? 'Email'}
+            value={user?.email ?? ''}
+            onPress={() => navigation.navigate('ChangeEmail')}
+            testID="row-ChangeEmail"
           />
           <SettingRow
             dark={dark} ink={ink} ink2={ink2} hair={hair}
             icon="email-check-outline"
-            label={t('EmailVerification') ?? 'Email'}
+            label={t('EmailVerification') ?? 'Email Verification'}
             value={user?.emailConfirmed ? (t('EmailVerified') ?? 'Verified') : (t('EmailNotVerified') ?? 'Not verified')}
             valueColor={user?.emailConfirmed ? '#0e9f6e' : '#e74c3c'}
             isLast
@@ -134,6 +165,8 @@ export const ProfileScreen: React.FC<Props> = () => {
             icon="lock-reset"
             label={t('ChangePassword') ?? 'Change Password'}
             value=""
+            onPress={() => navigation.navigate('ChangePassword')}
+            testID="row-ChangePassword"
           />
           <SettingRow
             dark={dark} ink={ink} ink2={ink2} hair={hair}
@@ -141,6 +174,7 @@ export const ProfileScreen: React.FC<Props> = () => {
             label={t('AuthenticatorAppTitle') ?? 'Authenticator App'}
             value={user?.twoFactorEnabled ? t('LabelEnabled') ?? 'On' : t('LabelDisabled') ?? 'Off'}
             valueColor={user?.twoFactorEnabled ? '#0e9f6e' : undefined}
+            onPress={() => navigation.navigate('TwoFactorSetup')}
             isLast
           />
         </GlassCard>

--- a/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
@@ -175,6 +175,7 @@ export const ProfileScreen: React.FC<Props> = ({ navigation }) => {
             value={user?.twoFactorEnabled ? t('LabelEnabled') ?? 'On' : t('LabelDisabled') ?? 'Off'}
             valueColor={user?.twoFactorEnabled ? '#0e9f6e' : undefined}
             onPress={() => navigation.navigate('TwoFactorSetup')}
+            testID="row-AuthenticatorApp"
             isLast
           />
         </GlassCard>

--- a/econoflow-mobile/src/screens/profile/TwoFactorScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/TwoFactorScreen.tsx
@@ -1,0 +1,243 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ProfileStackParamList } from '../../navigation/ProfileStackNavigator';
+import { useAuthStore } from '../../store/authStore';
+import {
+  useTwoFactorSetup,
+  useEnableTwoFactor,
+  useDisableTwoFactor,
+} from '../../hooks/useProfile';
+import { GlassScreen } from '../../components/common/GlassScreen';
+import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { AuroraField } from '../../components/auth/AuroraField';
+import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
+import { useAuroraSkin } from '../../theme/useAuroraSkin';
+
+type Props = NativeStackScreenProps<ProfileStackParamList, 'TwoFactorSetup'>;
+
+export const TwoFactorScreen: React.FC<Props> = ({ navigation }) => {
+  const { t } = useTranslation();
+  const { dark, ink, ink2, hair } = useAuroraSkin();
+  const insets = useSafeAreaInsets();
+  const { user } = useAuthStore();
+
+  const { data: setupData, isLoading } = useTwoFactorSetup();
+  const enableMutation = useEnableTwoFactor();
+  const disableMutation = useDisableTwoFactor();
+
+  const twoFactorEnabled = setupData?.isTwoFactorEnabled ?? user?.twoFactorEnabled ?? false;
+
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [codeError, setCodeError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [apiError, setApiError] = useState('');
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+
+  const handleEnable = async () => {
+    let valid = true;
+
+    if (!code.trim()) {
+      setCodeError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else {
+      setCodeError('');
+    }
+
+    if (!valid) return;
+    setApiError('');
+
+    try {
+      const result = await enableMutation.mutateAsync({ code: code.trim() });
+      setRecoveryCodes(result.recoveryCodes ?? []);
+      setCode('');
+    } catch {
+      setApiError(t('ErrorGeneric') ?? 'Something went wrong. Please try again.');
+    }
+  };
+
+  const handleDisable = async () => {
+    let valid = true;
+
+    if (!password) {
+      setPasswordError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else {
+      setPasswordError('');
+    }
+
+    if (!code.trim()) {
+      setCodeError(t('RequiredField') ?? 'This field is required.');
+      valid = false;
+    } else {
+      setCodeError('');
+    }
+
+    if (!valid) return;
+    setApiError('');
+
+    try {
+      await disableMutation.mutateAsync({ password, twoFactorCode: code.trim() });
+      navigation.goBack();
+    } catch {
+      setApiError(t('ErrorGeneric') ?? 'Something went wrong. Please try again.');
+    } finally {
+      setPassword('');
+      setCode('');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <GlassScreen dark={dark}>
+        <View style={styles.center}>
+          <Text style={{ color: ink2 }}>{t('LoadingTwoFactorSetup') ?? 'Preparing authenticator setup...'}</Text>
+        </View>
+      </GlassScreen>
+    );
+  }
+
+  return (
+    <GlassScreen dark={dark}>
+      <ErrorBanner
+        visible={!!apiError}
+        message={apiError}
+        onDismiss={() => setApiError('')}
+      />
+      <ScrollView
+        style={styles.fill}
+        contentContainerStyle={[styles.scroll, { paddingTop: insets.top + 20, paddingBottom: insets.bottom + 32 }]}
+        keyboardShouldPersistTaps="handled"
+      >
+        {twoFactorEnabled ? (
+          // ── Disable flow ──────────────────────────────────────────────────
+          <>
+            <Text style={[styles.title, { color: ink }]}>{t('DisableTwoFactorTitle') ?? 'Disable two-factor authentication'}</Text>
+
+            <AuroraField
+              dark={dark}
+              icon="lock-outline"
+              placeholder={t('PlaceholderCurrentPassword') ?? 'Current password'}
+              testID="PlaceholderCurrentPassword"
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              hasError={!!passwordError}
+            />
+            {!!passwordError && (
+              <Text style={styles.errorText}>{passwordError}</Text>
+            )}
+
+            <AuroraField
+              dark={dark}
+              icon="cellphone-key"
+              placeholder={t('PlaceholderAuthenticatorCode') ?? '6-digit code'}
+              testID="PlaceholderAuthenticatorCode"
+              value={code}
+              onChangeText={setCode}
+              keyboardType="number-pad"
+              maxLength={6}
+              hasError={!!codeError}
+            />
+            {!!codeError && (
+              <Text style={styles.errorText}>{codeError}</Text>
+            )}
+
+            <AuroraPrimaryButton
+              label={t('ButtonDisableTwoFactor') ?? 'Disable two-factor authentication'}
+              onPress={handleDisable}
+              loading={disableMutation.isPending}
+              testID="ButtonDisableTwoFactor"
+            />
+          </>
+        ) : recoveryCodes.length > 0 ? (
+          // ── Recovery codes display ────────────────────────────────────────
+          <>
+            <Text style={[styles.title, { color: ink }]}>{t('RecoveryCodesTitle') ?? 'Recovery codes'}</Text>
+            <Text style={[styles.description, { color: ink2 }]}>
+              {t('RecoveryCodesDescription') ?? 'Save these one-time recovery codes in a safe place. Each code can be used once.'}
+            </Text>
+            <View style={styles.codesBox}>
+              {recoveryCodes.map((rc) => (
+                <Text key={rc} style={[styles.recoveryCode, { color: ink, borderColor: hair }]}>{rc}</Text>
+              ))}
+            </View>
+            <AuroraPrimaryButton
+              label={t('ButtonICopiedCodes') ?? 'I saved these codes'}
+              onPress={() => navigation.goBack()}
+              testID="ButtonICopiedCodes"
+            />
+          </>
+        ) : (
+          // ── Setup (enable) flow ───────────────────────────────────────────
+          <>
+            <Text style={[styles.title, { color: ink }]}>{t('TwoFactorSetupInstructionsTitle') ?? 'Set up your authenticator app'}</Text>
+            <Text style={[styles.description, { color: ink2 }]}>
+              {t('TwoFactorSetupInstructionsDescription') ?? 'Scan this QR code in your authenticator app, then confirm with the first 6-digit code.'}
+            </Text>
+
+            <View style={[styles.keyBox, { borderColor: hair }]}>
+              <Text style={[styles.keyLabel, { color: ink2 }]}>{t('ManualSetupKeyLabel') ?? 'Manual setup key'}</Text>
+              <Text style={[styles.keyValue, { color: ink }]} selectable>
+                {setupData?.sharedKey ?? ''}
+              </Text>
+            </View>
+
+            <View style={[styles.separator, { backgroundColor: hair }]} />
+
+            <AuroraField
+              dark={dark}
+              icon="cellphone-key"
+              placeholder={t('PlaceholderAuthenticatorCode') ?? '6-digit code'}
+              testID="PlaceholderAuthenticatorCode"
+              value={code}
+              onChangeText={setCode}
+              keyboardType="number-pad"
+              maxLength={6}
+              hasError={!!codeError}
+            />
+            {!!codeError && (
+              <Text style={styles.errorText}>{codeError}</Text>
+            )}
+
+            <AuroraPrimaryButton
+              label={t('ButtonEnableTwoFactor') ?? 'Enable two-factor authentication'}
+              onPress={handleEnable}
+              loading={enableMutation.isPending}
+              testID="ButtonEnableTwoFactor"
+            />
+
+            <View style={styles.iconHint}>
+              <MaterialCommunityIcons name="information-outline" size={14} color={ink2} />
+              <Text style={[styles.iconHintText, { color: ink2 }]}>
+                {t('AuthenticatorAppDescription') ?? 'Use Google Authenticator, Authy, or Microsoft Authenticator for two-factor security.'}
+              </Text>
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </GlassScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  fill:          { flex: 1 },
+  scroll:        { paddingHorizontal: 24 },
+  center:        { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title:         { fontSize: 22, fontWeight: '800', marginBottom: 8 },
+  description:   { fontSize: 13.5, fontWeight: '500', marginBottom: 20, lineHeight: 20 },
+  keyBox:        { borderWidth: 1, borderRadius: 16, padding: 16, marginBottom: 20 },
+  keyLabel:      { fontSize: 11, fontWeight: '700', letterSpacing: 0.6, marginBottom: 6 },
+  keyValue:      { fontSize: 15, fontWeight: '700', letterSpacing: 1, fontVariant: ['tabular-nums'] },
+  separator:     { height: StyleSheet.hairlineWidth, marginBottom: 8 },
+  errorText:     { color: '#e74c3c', fontSize: 12, marginTop: 4, marginLeft: 4 },
+  codesBox:      { marginVertical: 16, gap: 8 },
+  recoveryCode:  { fontFamily: 'monospace', fontSize: 14, fontWeight: '700', padding: 10, borderRadius: 10, borderWidth: 1, letterSpacing: 1 },
+  iconHint:      { flexDirection: 'row', alignItems: 'flex-start', gap: 6, marginTop: 16 },
+  iconHintText:  { fontSize: 12, flex: 1, lineHeight: 18 },
+});

--- a/econoflow-mobile/src/screens/profile/__tests__/ChangeEmailScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/ChangeEmailScreen.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { ChangeEmailScreen } from '../ChangeEmailScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
+  };
+});
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({ testID, placeholder, value, onChangeText }: {
+      testID?: string;
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? placeholder,
+        value,
+        onChangeText,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading, testID,
+    }: { label: string; onPress: () => void; loading?: boolean; testID?: string }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: testID ?? label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+const mockMutateAsync = jest.fn();
+
+jest.mock('../../../hooks/useProfile', () => ({
+  useChangeEmail: jest.fn(() => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({
+    user: {
+      id: 'u1',
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      fullName: 'Alice Smith',
+      enabled: true,
+      isFirstLogin: false,
+      emailConfirmed: true,
+      twoFactorEnabled: false,
+      defaultProjectId: null,
+      notificationChannels: [],
+      languageCode: 'en',
+      isBetaTester: false,
+    },
+  })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof ChangeEmailScreen>['navigation'];
+
+const mockRoute = {} as unknown as React.ComponentProps<typeof ChangeEmailScreen>['route'];
+
+// ─── Helpers — capture element refs BEFORE entering act() ────────────────────
+
+async function changeText(testID: string, value: string) {
+  const el = screen.getByTestId(testID);
+  await act(async () => { el.props.onChangeText(value); });
+}
+
+async function pressButton(testID: string) {
+  fireEvent.press(screen.getByTestId(testID));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ChangeEmailScreen', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    // Default: never resolve — prevents accidental success state
+    mockMutateAsync.mockImplementation(() => new Promise(() => {}));
+    mockGoBack.mockReset();
+  });
+
+  it('pre-fills the email field with the current user email', async () => {
+    await render(<ChangeEmailScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByTestId('PlaceholderEmailAddress').props.value).toBe('alice@example.com');
+  });
+
+  it('shows required field error when email is cleared on submit', async () => {
+    await render(<ChangeEmailScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderEmailAddress', '');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.getByText('RequiredField')).toBeTruthy(); });
+  });
+
+  it('shows invalid email format error for malformed email', async () => {
+    await render(<ChangeEmailScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderEmailAddress', 'not-an-email');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.getByText('InvalidEmailFormat')).toBeTruthy(); });
+  });
+
+  it('calls useChangeEmail.mutateAsync with the new email', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<ChangeEmailScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderEmailAddress', 'new@example.com');
+    await pressButton('ButtonSave');
+    expect(mockMutateAsync).toHaveBeenCalledWith({ newEmail: 'new@example.com' });
+  });
+
+  it('shows verification email sent message on success', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<ChangeEmailScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderEmailAddress', 'new@example.com');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.queryByText('VerificationEmailSent')).toBeTruthy(); });
+  });
+
+  it('shows error banner when API fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+    await render(<ChangeEmailScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderEmailAddress', 'new@example.com');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+});

--- a/econoflow-mobile/src/screens/profile/__tests__/ChangePasswordScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/ChangePasswordScreen.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { ChangePasswordScreen } from '../ChangePasswordScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
+  };
+});
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({ testID, placeholder, value, onChangeText, secureTextEntry }: {
+      testID?: string;
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+      secureTextEntry?: boolean;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? placeholder,
+        value,
+        onChangeText,
+        secureTextEntry,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading, testID,
+    }: { label: string; onPress: () => void; loading?: boolean; testID?: string }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: testID ?? label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+// ─── Hook mocks ───────────────────────────────────────────────────────────────
+
+const mockMutateAsync = jest.fn();
+
+jest.mock('../../../hooks/useProfile', () => ({
+  useChangePassword: jest.fn(() => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof ChangePasswordScreen>['navigation'];
+
+const mockRoute = {} as unknown as React.ComponentProps<typeof ChangePasswordScreen>['route'];
+
+// ─── Helpers — capture element refs BEFORE entering act() ────────────────────
+
+async function changeText(testID: string, value: string) {
+  const el = screen.getByTestId(testID);
+  await act(async () => { el.props.onChangeText(value); });
+}
+
+async function pressButton(testID: string) {
+  fireEvent.press(screen.getByTestId(testID));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ChangePasswordScreen', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    // Default: never resolve — prevents accidental navigation
+    mockMutateAsync.mockImplementation(() => new Promise(() => {}));
+    mockGoBack.mockReset();
+  });
+
+  it('renders current password, new password, and confirm password fields', async () => {
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByTestId('PlaceholderCurrentPassword')).toBeTruthy();
+    expect(screen.getByTestId('PlaceholderNewPassword')).toBeTruthy();
+    expect(screen.getByTestId('PlaceholderConfirmNewPassword')).toBeTruthy();
+  });
+
+  it('shows required field error when current password is empty on submit', async () => {
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.getAllByText('RequiredField').length).toBeGreaterThan(0); });
+  });
+
+  it('shows error when new password and confirm password do not match', async () => {
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'oldpass');
+    await changeText('PlaceholderNewPassword', 'newpass1');
+    await changeText('PlaceholderConfirmNewPassword', 'newpass2');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.getByText('PasswordsMustMatch')).toBeTruthy(); });
+  });
+
+  it('shows error when new password is same as current password', async () => {
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'samepass');
+    await changeText('PlaceholderNewPassword', 'samepass');
+    await changeText('PlaceholderConfirmNewPassword', 'samepass');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.getByText('ErrorNewPasswordSameAsCurrent')).toBeTruthy(); });
+  });
+
+  it('calls useChangePassword.mutateAsync with oldPassword and newPassword on valid submit', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'oldpass');
+    await changeText('PlaceholderNewPassword', 'newpass');
+    await changeText('PlaceholderConfirmNewPassword', 'newpass');
+    await pressButton('ButtonSave');
+    expect(mockMutateAsync).toHaveBeenCalledWith({ oldPassword: 'oldpass', newPassword: 'newpass' });
+  });
+
+  it('navigates back on successful save', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'oldpass');
+    await changeText('PlaceholderNewPassword', 'newpass');
+    await changeText('PlaceholderConfirmNewPassword', 'newpass');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(mockGoBack).toHaveBeenCalledTimes(1); });
+  });
+
+  it('shows error banner when API fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'oldpass');
+    await changeText('PlaceholderNewPassword', 'newpass');
+    await changeText('PlaceholderConfirmNewPassword', 'newpass');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+});

--- a/econoflow-mobile/src/screens/profile/__tests__/EditNameScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/EditNameScreen.test.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { EditNameScreen } from '../EditNameScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
+  };
+});
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({ testID, placeholder, value, onChangeText }: {
+      testID?: string;
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? placeholder,
+        value,
+        onChangeText,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading, testID,
+    }: { label: string; onPress: () => void; loading?: boolean; testID?: string }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: testID ?? label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+const mockMutateAsync = jest.fn();
+
+jest.mock('../../../hooks/useUpdateProfile', () => ({
+  useUpdateProfile: jest.fn(() => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({
+    user: {
+      id: 'u1',
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      fullName: 'Alice Smith',
+      enabled: true,
+      isFirstLogin: false,
+      emailConfirmed: true,
+      twoFactorEnabled: false,
+      defaultProjectId: null,
+      notificationChannels: [],
+      languageCode: 'en',
+      isBetaTester: false,
+    },
+  })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof EditNameScreen>['navigation'];
+
+const mockRoute = {} as unknown as React.ComponentProps<typeof EditNameScreen>['route'];
+
+// ─── Helpers — capture element refs BEFORE entering act() ────────────────────
+
+async function changeText(testID: string, value: string) {
+  const el = screen.getByTestId(testID);
+  await act(async () => { el.props.onChangeText(value); });
+}
+
+async function pressButton(testID: string) {
+  fireEvent.press(screen.getByTestId(testID));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('EditNameScreen', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    // Default: never resolve — prevents accidental navigation
+    mockMutateAsync.mockImplementation(() => new Promise(() => {}));
+    mockGoBack.mockReset();
+  });
+
+  it('pre-fills first name and last name from user store', async () => {
+    await render(<EditNameScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByTestId('PlaceholderFirstName').props.value).toBe('Alice');
+    expect(screen.getByTestId('PlaceholderLastName').props.value).toBe('Smith');
+  });
+
+  it('shows required field error when first name is cleared on submit', async () => {
+    await render(<EditNameScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderFirstName', '');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.getAllByText('RequiredField').length).toBeGreaterThan(0); });
+  });
+
+  it('shows required field error when last name is cleared on submit', async () => {
+    await render(<EditNameScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderLastName', '');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.getAllByText('RequiredField').length).toBeGreaterThan(0); });
+  });
+
+  it('calls patchUser with firstName and lastName patch ops on save', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<EditNameScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderFirstName', 'Bob');
+    await changeText('PlaceholderLastName', 'Jones');
+    await pressButton('ButtonSave');
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ op: 'replace', path: '/firstName', value: 'Bob' }),
+        expect.objectContaining({ op: 'replace', path: '/lastName', value: 'Jones' }),
+      ]),
+    );
+  });
+
+  it('navigates back on successful save', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<EditNameScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderFirstName', 'Bob');
+    await changeText('PlaceholderLastName', 'Jones');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(mockGoBack).toHaveBeenCalledTimes(1); });
+  });
+
+  it('shows error banner when API fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+    await render(<EditNameScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderFirstName', 'Bob');
+    await changeText('PlaceholderLastName', 'Jones');
+    await pressButton('ButtonSave');
+    await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+});

--- a/econoflow-mobile/src/screens/profile/__tests__/LanguagePickerScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/LanguagePickerScreen.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { LanguagePickerScreen } from '../LanguagePickerScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+// ─── i18n mock — use jest.fn() inline to avoid hoisting TDZ issues ───────────
+
+jest.mock('../../../i18n', () => ({
+  __esModule: true,
+  default: { language: 'en-US', changeLanguage: jest.fn() },
+}));
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+const mockMutateAsync = jest.fn();
+
+jest.mock('../../../hooks/useUpdateProfile', () => ({
+  useUpdateProfile: jest.fn(() => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({
+    user: {
+      id: 'u1',
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      fullName: 'Alice Smith',
+      enabled: true,
+      isFirstLogin: false,
+      emailConfirmed: true,
+      twoFactorEnabled: false,
+      defaultProjectId: null,
+      notificationChannels: [],
+      languageCode: 'en-US',
+      isBetaTester: false,
+    },
+  })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigation = {} as unknown as React.ComponentProps<typeof LanguagePickerScreen>['navigation'];
+const mockRoute = {} as unknown as React.ComponentProps<typeof LanguagePickerScreen>['route'];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('LanguagePickerScreen', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    jest.requireMock('../../../i18n').default.changeLanguage.mockReset();
+  });
+
+  it('renders language options for en-US and pt-BR', async () => {
+    await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByTestId('lang-en-US')).toBeTruthy();
+    expect(screen.getByTestId('lang-pt-BR')).toBeTruthy();
+  });
+
+  it('shows a checkmark next to the currently selected language', async () => {
+    await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByTestId('lang-en-US-selected')).toBeTruthy();
+  });
+
+  it('calls patchUser with languageCode when a language is selected', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
+    const btn = screen.getByTestId('lang-pt-BR');
+    fireEvent.press(btn);
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ op: 'replace', path: '/languageCode', value: 'pt-BR' }),
+      ]),
+    );
+  });
+
+  it('calls i18n.changeLanguage when a language is selected', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
+    const btn = screen.getByTestId('lang-pt-BR');
+    fireEvent.press(btn);
+    expect(jest.requireMock('../../../i18n').default.changeLanguage).toHaveBeenCalledWith('pt-BR');
+  });
+});

--- a/econoflow-mobile/src/screens/profile/__tests__/LanguagePickerScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/LanguagePickerScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { LanguagePickerScreen } from '../LanguagePickerScreen';
 
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
@@ -44,6 +44,17 @@ jest.mock('../../../components/common/GlassCard', () => {
   return {
     GlassCard: ({ children }: { children: React.ReactNode }) =>
       React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
   };
 });
 
@@ -121,11 +132,28 @@ describe('LanguagePickerScreen', () => {
     );
   });
 
-  it('calls i18n.changeLanguage when a language is selected', async () => {
+  it('calls i18n.changeLanguage only after successful API call', async () => {
     mockMutateAsync.mockResolvedValue({});
     await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
     const btn = screen.getByTestId('lang-pt-BR');
     fireEvent.press(btn);
-    expect(jest.requireMock('../../../i18n').default.changeLanguage).toHaveBeenCalledWith('pt-BR');
+    await waitFor(() => {
+      expect(jest.requireMock('../../../i18n').default.changeLanguage).toHaveBeenCalledWith('pt-BR');
+    });
+  });
+
+  it('shows error banner when API fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+    await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('lang-pt-BR'));
+    await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+
+  it('does not call i18n.changeLanguage when API fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+    await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('lang-pt-BR'));
+    await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+    expect(jest.requireMock('../../../i18n').default.changeLanguage).not.toHaveBeenCalled();
   });
 });

--- a/econoflow-mobile/src/screens/profile/__tests__/ProfileScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/ProfileScreen.test.tsx
@@ -167,4 +167,10 @@ describe('ProfileScreen – row navigation', () => {
     fireEvent.press(screen.getByTestId('row-TwoFactorSetup'));
     expect(mockNavigate).toHaveBeenCalledWith('TwoFactorSetup');
   });
+
+  it('navigates to TwoFactorSetup when the Authenticator App row is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('row-AuthenticatorApp'));
+    expect(mockNavigate).toHaveBeenCalledWith('TwoFactorSetup');
+  });
 });

--- a/econoflow-mobile/src/screens/profile/__tests__/ProfileScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/ProfileScreen.test.tsx
@@ -96,7 +96,13 @@ jest.mock('@tanstack/react-query', () => ({
 
 // ─── Navigation mock ──────────────────────────────────────────────────────────
 
-const mockNavigation = {} as React.ComponentProps<typeof ProfileScreen>['navigation'];
+const mockNavigate = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+} as unknown as React.ComponentProps<typeof ProfileScreen>['navigation'];
+
+const mockRoute = {} as unknown as React.ComponentProps<typeof ProfileScreen>['route'];
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -105,23 +111,60 @@ describe('ProfileScreen – sign out', () => {
     mockClearAuth.mockReset();
     mockClearProject.mockReset();
     mockQueryClientClear.mockReset();
+    mockNavigate.mockReset();
   });
 
   it('calls clearAuth when the sign-out button is pressed', async () => {
-    await render(<ProfileScreen navigation={mockNavigation} />);
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
     fireEvent.press(screen.getByText('ButtonSignOut'));
     expect(mockClearAuth).toHaveBeenCalledTimes(1);
   });
 
   it('calls clearProject when the sign-out button is pressed', async () => {
-    await render(<ProfileScreen navigation={mockNavigation} />);
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
     fireEvent.press(screen.getByText('ButtonSignOut'));
     expect(mockClearProject).toHaveBeenCalledTimes(1);
   });
 
   it('clears the React Query cache when the sign-out button is pressed', async () => {
-    await render(<ProfileScreen navigation={mockNavigation} />);
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
     fireEvent.press(screen.getByText('ButtonSignOut'));
     expect(mockQueryClientClear).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ProfileScreen – row navigation', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('navigates to EditName when the edit-name row is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('row-EditName'));
+    expect(mockNavigate).toHaveBeenCalledWith('EditName');
+  });
+
+  it('navigates to ChangePassword when the change-password row is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('row-ChangePassword'));
+    expect(mockNavigate).toHaveBeenCalledWith('ChangePassword');
+  });
+
+  it('navigates to ChangeEmail when the change-email row is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('row-ChangeEmail'));
+    expect(mockNavigate).toHaveBeenCalledWith('ChangeEmail');
+  });
+
+  it('navigates to LanguagePicker when the language row is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('row-LanguagePicker'));
+    expect(mockNavigate).toHaveBeenCalledWith('LanguagePicker');
+  });
+
+  it('navigates to TwoFactorSetup when the 2FA row is pressed', async () => {
+    await render(<ProfileScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('row-TwoFactorSetup'));
+    expect(mockNavigate).toHaveBeenCalledWith('TwoFactorSetup');
   });
 });

--- a/econoflow-mobile/src/screens/profile/__tests__/TwoFactorScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/TwoFactorScreen.test.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { TwoFactorScreen } from '../TwoFactorScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ErrorBanner: ({ visible, message }: { visible: boolean; message?: string }) =>
+      visible
+        ? React.createElement(Text, { testID: 'error-banner' }, message ?? 'Error')
+        : null,
+  };
+});
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({ testID, placeholder, value, onChangeText, secureTextEntry }: {
+      testID?: string;
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+      secureTextEntry?: boolean;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? placeholder,
+        value,
+        onChangeText,
+        secureTextEntry,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading, testID,
+    }: { label: string; onPress: () => void; loading?: boolean; testID?: string }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: testID ?? label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+// ─── Hook / store mocks ───────────────────────────────────────────────────────
+
+const mockEnableMutateAsync = jest.fn();
+const mockDisableMutateAsync = jest.fn();
+
+jest.mock('../../../hooks/useProfile', () => ({
+  useTwoFactorSetup: jest.fn(),
+  useEnableTwoFactor: jest.fn(() => ({
+    mutateAsync: mockEnableMutateAsync,
+    isPending: false,
+  })),
+  useDisableTwoFactor: jest.fn(() => ({
+    mutateAsync: mockDisableMutateAsync,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof TwoFactorScreen>['navigation'];
+
+const mockRoute = {} as unknown as React.ComponentProps<typeof TwoFactorScreen>['route'];
+
+// ─── Shared user fixture ──────────────────────────────────────────────────────
+
+const baseUser = {
+  id: 'u1', email: 'alice@example.com', firstName: 'Alice', lastName: 'Smith',
+  fullName: 'Alice Smith', enabled: true, isFirstLogin: false, emailConfirmed: true,
+  defaultProjectId: null, notificationChannels: [], languageCode: 'en', isBetaTester: false,
+};
+
+// ─── Helpers — capture element refs BEFORE entering act() ────────────────────
+
+async function changeText(testID: string, value: string) {
+  const el = screen.getByTestId(testID);
+  await act(async () => { el.props.onChangeText(value); });
+}
+
+async function pressButton(testID: string) {
+  fireEvent.press(screen.getByTestId(testID));
+}
+
+// ─── Setup (2FA disabled) ─────────────────────────────────────────────────────
+
+describe('TwoFactorScreen – setup (2FA disabled)', () => {
+  beforeEach(() => {
+    mockEnableMutateAsync.mockReset();
+    mockEnableMutateAsync.mockImplementation(() => new Promise(() => {}));
+    mockGoBack.mockReset();
+
+    jest.requireMock('../../../hooks/useProfile').useTwoFactorSetup.mockReturnValue({
+      data: { isTwoFactorEnabled: false, sharedKey: 'abcd efgh', otpAuthUri: 'otpauth://...' },
+      isLoading: false,
+      isError: false,
+    });
+    jest.requireMock('../../../store/authStore').useAuthStore.mockReturnValue({
+      user: { ...baseUser, twoFactorEnabled: false },
+    });
+  });
+
+  it('shows the shared key', async () => {
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByText('abcd efgh')).toBeTruthy();
+  });
+
+  it('shows the setup title', async () => {
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByText('TwoFactorSetupInstructionsTitle')).toBeTruthy();
+  });
+
+  it('shows enable button', async () => {
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByTestId('ButtonEnableTwoFactor')).toBeTruthy();
+  });
+
+  it('shows required error when code is empty on enable', async () => {
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await pressButton('ButtonEnableTwoFactor');
+    await waitFor(() => { expect(screen.getAllByText('RequiredField').length).toBeGreaterThan(0); });
+  });
+
+  it('calls enableTwoFactor with the entered code', async () => {
+    mockEnableMutateAsync.mockResolvedValue({ twoFactorEnabled: true, recoveryCodes: ['r1', 'r2'] });
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderAuthenticatorCode', '123456');
+    await pressButton('ButtonEnableTwoFactor');
+    expect(mockEnableMutateAsync).toHaveBeenCalledWith({ code: '123456' });
+  });
+
+  it('shows recovery codes after successful enable', async () => {
+    mockEnableMutateAsync.mockResolvedValue({ twoFactorEnabled: true, recoveryCodes: ['rec-code-1', 'rec-code-2'] });
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderAuthenticatorCode', '123456');
+    await pressButton('ButtonEnableTwoFactor');
+    await waitFor(() => { expect(screen.queryByText('rec-code-1')).toBeTruthy(); });
+  });
+
+  it('shows error banner when enable API fails', async () => {
+    mockEnableMutateAsync.mockRejectedValue(new Error('Invalid code'));
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderAuthenticatorCode', '999999');
+    await pressButton('ButtonEnableTwoFactor');
+    await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+});
+
+// ─── Disable (2FA enabled) ────────────────────────────────────────────────────
+
+describe('TwoFactorScreen – disable (2FA enabled)', () => {
+  beforeEach(() => {
+    mockDisableMutateAsync.mockReset();
+    mockDisableMutateAsync.mockImplementation(() => new Promise(() => {}));
+    mockGoBack.mockReset();
+
+    jest.requireMock('../../../hooks/useProfile').useTwoFactorSetup.mockReturnValue({
+      data: { isTwoFactorEnabled: true, sharedKey: '', otpAuthUri: '' },
+      isLoading: false,
+      isError: false,
+    });
+    jest.requireMock('../../../store/authStore').useAuthStore.mockReturnValue({
+      user: { ...baseUser, twoFactorEnabled: true },
+    });
+  });
+
+  it('shows disable title when 2FA is enabled', async () => {
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByText('DisableTwoFactorTitle')).toBeTruthy();
+  });
+
+  it('shows disable button', async () => {
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    expect(screen.getByTestId('ButtonDisableTwoFactor')).toBeTruthy();
+  });
+
+  it('shows required error when password is empty on disable', async () => {
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await pressButton('ButtonDisableTwoFactor');
+    await waitFor(() => { expect(screen.getAllByText('RequiredField').length).toBeGreaterThan(0); });
+  });
+
+  it('calls disableTwoFactor with password and code', async () => {
+    mockDisableMutateAsync.mockResolvedValue({ twoFactorEnabled: false });
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'mypassword');
+    await changeText('PlaceholderAuthenticatorCode', '654321');
+    await pressButton('ButtonDisableTwoFactor');
+    expect(mockDisableMutateAsync).toHaveBeenCalledWith({ password: 'mypassword', twoFactorCode: '654321' });
+  });
+
+  it('navigates back after successful disable', async () => {
+    mockDisableMutateAsync.mockResolvedValue({ twoFactorEnabled: false });
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'mypassword');
+    await changeText('PlaceholderAuthenticatorCode', '654321');
+    await pressButton('ButtonDisableTwoFactor');
+    await waitFor(() => { expect(mockGoBack).toHaveBeenCalledTimes(1); });
+  });
+
+  it('shows error banner when disable API fails', async () => {
+    mockDisableMutateAsync.mockRejectedValue(new Error('Invalid password'));
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'wrongpassword');
+    await changeText('PlaceholderAuthenticatorCode', '111111');
+    await pressButton('ButtonDisableTwoFactor');
+    await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+});


### PR DESCRIPTION
Add navigation stack and screens for all profile management actions:
edit name, change password, change email, language picker, and 2FA
setup/disable. Wire profile API calls (PATCH, manageInfo, 2FA endpoints)
through new useProfile hooks and connect them to the updated ProfileScreen
navigation rows. Add full test coverage for all new screens and hooks.

https://claude.ai/code/session_01KHURon6VJvRppf8G5ZzXX4