### PR TITLE
feat(mobile): capture registration errors in Sentry

### DIFF
--- a/econoflow-mobile/src/screens/auth/ForgotPasswordScreen.tsx
+++ b/econoflow-mobile/src/screens/auth/ForgotPasswordScreen.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../../navigation/AuthNavigator';
 import { forgotPassword } from '../../api/auth.api';
+import { captureError } from '../../monitoring/sentry';
 import { AuthHero } from '../../components/auth/AuthHero';
 import { AuroraField } from '../../components/auth/AuroraField';
 import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
@@ -37,7 +38,10 @@ export const ForgotPasswordScreen: React.FC<Props> = ({ navigation }) => {
     // This prevents leaking whether an email address is registered (security best
     // practice) and fixes the silent no-op when the server returns an error.
     onSuccess: () => setSent(true),
-    onError:   () => setSent(true),
+    onError:   (error) => {
+      captureError(error, { screen: 'ForgotPasswordScreen', action: 'forgotPassword' });
+      setSent(true);
+    },
   });
 
   if (sent) {

--- a/econoflow-mobile/src/screens/auth/LoginScreen.tsx
+++ b/econoflow-mobile/src/screens/auth/LoginScreen.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../../navigation/AuthNavigator';
 import { mobileLogin, getCurrentUser } from '../../api/auth.api';
+import { captureError } from '../../monitoring/sentry';
 import { useAuthStore } from '../../store/authStore';
 import i18n from '../../i18n';
 import { AuthHero } from '../../components/auth/AuthHero';
@@ -64,13 +65,16 @@ export const LoginScreen: React.FC<Props> = ({ navigation }) => {
           const lang = userResponse.data.languageCode.startsWith('pt') ? 'pt' : 'en';
           i18n.changeLanguage(lang);
         }
-      } catch { /* proceed without user profile */ }
+      } catch (err) {
+        captureError(err, { screen: 'LoginScreen', action: 'fetchCurrentUser' });
+      }
     },
     onError: (err: { response?: { data?: { requiresTwoFactor?: boolean } } }, variables) => {
       if (err?.response?.data?.requiresTwoFactor) {
         navigation.navigate('TwoFactor', { email: variables.email, password: variables.password });
         return;
       }
+      captureError(err, { screen: 'LoginScreen', action: 'login' });
       setLoginError(t('ErrorInvalidCredentials'));
     },
   });

--- a/econoflow-mobile/src/screens/auth/RegisterScreen.tsx
+++ b/econoflow-mobile/src/screens/auth/RegisterScreen.tsx
@@ -17,6 +17,7 @@ import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import { GlassCard } from '../../components/common/GlassCard';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = {
   navigation: NativeStackNavigationProp<AuthStackParamList, 'Register'>;
@@ -76,10 +77,14 @@ export const RegisterScreen: React.FC<Props> = ({ navigation }) => {
           navigation.navigate('TwoFactor', { email: variables.email, password: variables.password });
           return;
         }
+        captureError(err, { screen: 'RegisterScreen', action: 'autoLogin' });
         setAutoLoginFailed(true);
       }
     },
-    onError: () => setServerError(t('ErrorRegistrationFailed')),
+    onError: (error) => {
+      captureError(error, { screen: 'RegisterScreen', action: 'register' });
+      setServerError(t('ErrorRegistrationFailed'));
+    },
   });
 
   if (autoLoginFailed) {

--- a/econoflow-mobile/src/screens/auth/TwoFactorScreen.tsx
+++ b/econoflow-mobile/src/screens/auth/TwoFactorScreen.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../../navigation/AuthNavigator';
 import { mobileLogin, getCurrentUser } from '../../api/auth.api';
+import { captureError } from '../../monitoring/sentry';
 import { useAuthStore } from '../../store/authStore';
 import i18n from '../../i18n';
 import { AuthHero } from '../../components/auth/AuthHero';
@@ -46,9 +47,14 @@ export const TwoFactorScreen: React.FC<Props> = ({ route }) => {
           const lang = userResponse.data.languageCode.startsWith('pt') ? 'pt' : 'en';
           i18n.changeLanguage(lang);
         }
-      } catch { /* proceed */ }
+      } catch (err) {
+        captureError(err, { screen: 'TwoFactorScreen', action: 'fetchCurrentUser' });
+      }
     },
-    onError: () => setAuthError(t('ErrorInvalidTwoFactorCode')),
+    onError: (error) => {
+      captureError(error, { screen: 'TwoFactorScreen', action: 'verifyTwoFactor' });
+      setAuthError(t('ErrorInvalidTwoFactorCode'));
+    },
   });
 
   return (

--- a/econoflow-mobile/src/screens/auth/__tests__/ForgotPasswordScreen.test.tsx
+++ b/econoflow-mobile/src/screens/auth/__tests__/ForgotPasswordScreen.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ForgotPasswordScreen } from '../ForgotPasswordScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/auth/AuthHero', () => ({
+  AuthHero: jest.fn(() => null),
+}));
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({
+      placeholder, value, onChangeText,
+    }: {
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+    }) =>
+      React.createElement(TextInput, {
+        testID: placeholder,
+        value,
+        onChangeText,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading,
+    }: { label: string; onPress: () => void; loading?: boolean }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+    Text: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+// ─── API mock ─────────────────────────────────────────────────────────────────
+
+const mockForgotPassword = jest.fn();
+
+jest.mock('../../../api/auth.api', () => ({
+  forgotPassword: (...args: unknown[]) => mockForgotPassword(...args),
+}));
+
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+} as unknown as React.ComponentProps<typeof ForgotPasswordScreen>['navigation'];
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+
+const renderScreen = (queryClient: QueryClient) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ForgotPasswordScreen navigation={mockNavigation} />
+    </QueryClientProvider>,
+  );
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ForgotPasswordScreen', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    mockForgotPassword.mockReset();
+    mockNavigate.mockReset();
+    mockCaptureError.mockReset();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const submitForm = async () => {
+    fireEvent.changeText(screen.getByTestId('FieldEmailAddress'), 'user@example.com');
+    fireEvent.press(screen.getByTestId('ButtonSendResetLink'));
+  };
+
+  it('shows success UI when mutation succeeds', async () => {
+    mockForgotPassword.mockResolvedValue({});
+
+    renderScreen(queryClient);
+    await submitForm();
+
+    await waitFor(() =>
+      expect(screen.queryByText('LabelCheckYourEmail')).toBeTruthy(),
+    );
+  });
+
+  it('shows success UI even when mutation fails (anti-enumeration)', async () => {
+    mockForgotPassword.mockRejectedValue(new Error('not found'));
+
+    renderScreen(queryClient);
+    await submitForm();
+
+    await waitFor(() =>
+      expect(screen.queryByText('LabelCheckYourEmail')).toBeTruthy(),
+    );
+  });
+
+  it('captures error to Sentry when mutation fails', async () => {
+    const error = new Error('server error');
+    mockForgotPassword.mockRejectedValue(error);
+
+    renderScreen(queryClient);
+    await submitForm();
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'ForgotPasswordScreen', action: 'forgotPassword' }),
+      ),
+    );
+  });
+
+  it('does NOT capture error to Sentry when mutation succeeds', async () => {
+    mockForgotPassword.mockResolvedValue({});
+
+    renderScreen(queryClient);
+    await submitForm();
+
+    await waitFor(() =>
+      expect(screen.queryByText('LabelCheckYourEmail')).toBeTruthy(),
+    );
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/auth/__tests__/LoginScreen.test.tsx
+++ b/econoflow-mobile/src/screens/auth/__tests__/LoginScreen.test.tsx
@@ -134,12 +134,13 @@ const createQueryClient = () =>
     },
   });
 
-const renderScreen = (queryClient: QueryClient) =>
-  render(
+const renderScreen = async (queryClient: QueryClient) => {
+  await render(
     <QueryClientProvider client={queryClient}>
       <LoginScreen navigation={mockNavigation} />
     </QueryClientProvider>,
   );
+};
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -156,14 +157,10 @@ describe('LoginScreen', () => {
     mockCaptureError.mockReset();
   });
 
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   const fillAndSubmit = async () => {
-    fireEvent.changeText(screen.getByTestId('FieldEmailAddress'), 'user@example.com');
-    fireEvent.changeText(screen.getByTestId('FieldPassword'), 'Passw0rd!');
-    fireEvent.press(screen.getByTestId('ButtonSignIn'));
+    await fireEvent.changeText(screen.getByTestId('FieldEmailAddress'), 'user@example.com');
+    await fireEvent.changeText(screen.getByTestId('FieldPassword'), 'Passw0rd!');
+    await fireEvent.press(screen.getByTestId('ButtonSignIn'));
   };
 
   it('saves tokens and user on successful login', async () => {
@@ -171,7 +168,7 @@ describe('LoginScreen', () => {
     mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
     mockGetCurrentUser.mockResolvedValue({ data: mockUser });
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() => {
@@ -183,7 +180,7 @@ describe('LoginScreen', () => {
   it('navigates to TwoFactor when requiresTwoFactor is true in response data', async () => {
     mockMobileLogin.mockResolvedValue({ data: { requiresTwoFactor: true } });
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() =>
@@ -199,7 +196,7 @@ describe('LoginScreen', () => {
       response: { data: { requiresTwoFactor: true } },
     });
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() =>
@@ -213,7 +210,7 @@ describe('LoginScreen', () => {
   it('shows error when login fails with non-2FA error', async () => {
     mockMobileLogin.mockRejectedValue(new Error('invalid credentials'));
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() =>
@@ -225,7 +222,7 @@ describe('LoginScreen', () => {
     const error = new Error('server error');
     mockMobileLogin.mockRejectedValue(error);
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() =>
@@ -241,7 +238,7 @@ describe('LoginScreen', () => {
       response: { data: { requiresTwoFactor: true } },
     });
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() =>
@@ -253,7 +250,7 @@ describe('LoginScreen', () => {
   it('does NOT capture error to Sentry when login redirects to TwoFactor via success response', async () => {
     mockMobileLogin.mockResolvedValue({ data: { requiresTwoFactor: true } });
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() =>
@@ -267,7 +264,7 @@ describe('LoginScreen', () => {
     mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
     mockGetCurrentUser.mockRejectedValue(fetchError);
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() =>
@@ -282,7 +279,7 @@ describe('LoginScreen', () => {
     mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
     mockGetCurrentUser.mockResolvedValue({ data: { id: 'u1', firstName: '', languageCode: 'en' } });
 
-    renderScreen(queryClient);
+    await renderScreen(queryClient);
     await fillAndSubmit();
 
     await waitFor(() => expect(mockSetTokens).toHaveBeenCalled());

--- a/econoflow-mobile/src/screens/auth/__tests__/LoginScreen.test.tsx
+++ b/econoflow-mobile/src/screens/auth/__tests__/LoginScreen.test.tsx
@@ -1,0 +1,291 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LoginScreen } from '../LoginScreen';
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../components/auth/AuthHero', () => ({
+  AuthHero: jest.fn(() => null),
+}));
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({
+      placeholder, value, onChangeText, secureTextEntry,
+    }: {
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+      secureTextEntry?: boolean;
+    }) =>
+      React.createElement(TextInput, {
+        testID: placeholder,
+        value,
+        onChangeText,
+        secureTextEntry,
+      }),
+  };
+});
+
+jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
+  const React = require('react');
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    AuroraPrimaryButton: ({
+      label, onPress, loading,
+    }: { label: string; onPress: () => void; loading?: boolean }) =>
+      loading
+        ? React.createElement(Text, { testID: 'loading-indicator' }, 'Loading')
+        : React.createElement(
+            TouchableOpacity,
+            { onPress, testID: label },
+            React.createElement(Text, null, label),
+          ),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+    Text: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+// ─── API / store mocks ────────────────────────────────────────────────────────
+
+const mockMobileLogin = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockSetTokens = jest.fn();
+const mockSetUser = jest.fn();
+
+jest.mock('../../../api/auth.api', () => ({
+  mobileLogin: (...args: unknown[]) => mockMobileLogin(...args),
+  getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({
+    setTokens: mockSetTokens,
+    setUser: mockSetUser,
+  })),
+}));
+
+jest.mock('../../../i18n', () => ({
+  __esModule: true,
+  default: { changeLanguage: jest.fn() },
+}));
+
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+} as unknown as React.ComponentProps<typeof LoginScreen>['navigation'];
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+
+const renderScreen = (queryClient: QueryClient) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <LoginScreen navigation={mockNavigation} />
+    </QueryClientProvider>,
+  );
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('LoginScreen', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    mockMobileLogin.mockReset();
+    mockGetCurrentUser.mockReset();
+    mockSetTokens.mockReset();
+    mockSetUser.mockReset();
+    mockNavigate.mockReset();
+    mockCaptureError.mockReset();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const fillAndSubmit = async () => {
+    fireEvent.changeText(screen.getByTestId('FieldEmailAddress'), 'user@example.com');
+    fireEvent.changeText(screen.getByTestId('FieldPassword'), 'Passw0rd!');
+    fireEvent.press(screen.getByTestId('ButtonSignIn'));
+  };
+
+  it('saves tokens and user on successful login', async () => {
+    const mockUser = { id: 'u1', firstName: 'Test', languageCode: 'en' };
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: mockUser });
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockSetTokens).toHaveBeenCalledWith('at', 'rt');
+      expect(mockSetUser).toHaveBeenCalledWith(mockUser);
+    });
+  });
+
+  it('navigates to TwoFactor when requiresTwoFactor is true in response data', async () => {
+    mockMobileLogin.mockResolvedValue({ data: { requiresTwoFactor: true } });
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('TwoFactor', {
+        email: 'user@example.com',
+        password: 'Passw0rd!',
+      }),
+    );
+  });
+
+  it('navigates to TwoFactor when requiresTwoFactor is true in error response', async () => {
+    mockMobileLogin.mockRejectedValue({
+      response: { data: { requiresTwoFactor: true } },
+    });
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('TwoFactor', {
+        email: 'user@example.com',
+        password: 'Passw0rd!',
+      }),
+    );
+  });
+
+  it('shows error when login fails with non-2FA error', async () => {
+    mockMobileLogin.mockRejectedValue(new Error('invalid credentials'));
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(screen.queryByText('ErrorInvalidCredentials')).toBeTruthy(),
+    );
+  });
+
+  it('captures error to Sentry when login mutation fails (non-2FA)', async () => {
+    const error = new Error('server error');
+    mockMobileLogin.mockRejectedValue(error);
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'LoginScreen', action: 'login' }),
+      ),
+    );
+  });
+
+  it('does NOT capture error to Sentry when login redirects to TwoFactor via error response', async () => {
+    mockMobileLogin.mockRejectedValue({
+      response: { data: { requiresTwoFactor: true } },
+    });
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('TwoFactor', expect.any(Object)),
+    );
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture error to Sentry when login redirects to TwoFactor via success response', async () => {
+    mockMobileLogin.mockResolvedValue({ data: { requiresTwoFactor: true } });
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('TwoFactor', expect.any(Object)),
+    );
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it('captures error to Sentry when getCurrentUser fails silently', async () => {
+    const fetchError = new Error('profile fetch failed');
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockRejectedValue(fetchError);
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        fetchError,
+        expect.objectContaining({ screen: 'LoginScreen', action: 'fetchCurrentUser' }),
+      ),
+    );
+  });
+
+  it('does NOT capture error to Sentry on successful login with profile', async () => {
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: { id: 'u1', firstName: '', languageCode: 'en' } });
+
+    renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() => expect(mockSetTokens).toHaveBeenCalled());
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx
+++ b/econoflow-mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx
@@ -106,6 +106,14 @@ jest.mock('../../../api/auth.api', () => ({
   getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
 }));
 
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 jest.mock('../../../store/authStore', () => ({
   useAuthStore: jest.fn(() => ({
     setTokens: mockSetTokens,
@@ -160,6 +168,7 @@ describe('RegisterScreen — auto-login after registration', () => {
     mockSetTokens.mockReset();
     mockSetUser.mockReset();
     mockNavigate.mockReset();
+    mockCaptureError.mockReset();
   });
 
   const fillAndSubmitForm = async () => {
@@ -245,5 +254,49 @@ describe('RegisterScreen — auto-login after registration', () => {
     await fillAndSubmitForm();
 
     await waitFor(() => expect(screen.queryByText('ErrorRegistrationFailed')).toBeTruthy());
+  });
+
+  it('captures error to Sentry when register API call fails', async () => {
+    const error = new Error('network error');
+    mockRegister.mockRejectedValue(error);
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'RegisterScreen', action: 'register' }),
+      ),
+    );
+  });
+
+  it('captures error to Sentry when auto-login fails after registration', async () => {
+    const error = new Error('login failed');
+    mockRegister.mockResolvedValue({ data: {} });
+    mockMobileLogin.mockRejectedValue(error);
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'RegisterScreen', action: 'autoLogin' }),
+      ),
+    );
+  });
+
+  it('does not capture error to Sentry when auto-login redirects to TwoFactor', async () => {
+    mockRegister.mockResolvedValue({ data: {} });
+    mockMobileLogin.mockResolvedValue({ data: { requiresTwoFactor: true } });
+
+    await renderScreen(queryClient);
+    await fillAndSubmitForm();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('TwoFactor', expect.any(Object)),
+    );
+    expect(mockCaptureError).not.toHaveBeenCalled();
   });
 });

--- a/econoflow-mobile/src/screens/auth/__tests__/TwoFactorScreen.test.tsx
+++ b/econoflow-mobile/src/screens/auth/__tests__/TwoFactorScreen.test.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ForgotPasswordScreen } from '../ForgotPasswordScreen';
+import { TwoFactorScreen } from '../TwoFactorScreen';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { AuthStackParamList } from '../../../navigation/AuthNavigator';
 
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
-
-jest.mock('@expo/vector-icons', () => ({
-  MaterialCommunityIcons: 'MaterialCommunityIcons',
-}));
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
@@ -86,12 +84,28 @@ jest.mock('react-native-paper', () => {
   };
 });
 
-// ─── API mock ─────────────────────────────────────────────────────────────────
+// ─── API / store mocks ────────────────────────────────────────────────────────
 
-const mockForgotPassword = jest.fn();
+const mockMobileLogin = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockSetTokens = jest.fn();
+const mockSetUser = jest.fn();
 
 jest.mock('../../../api/auth.api', () => ({
-  forgotPassword: (...args: unknown[]) => mockForgotPassword(...args),
+  mobileLogin: (...args: unknown[]) => mockMobileLogin(...args),
+  getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+}));
+
+jest.mock('../../../store/authStore', () => ({
+  useAuthStore: jest.fn(() => ({
+    setTokens: mockSetTokens,
+    setUser: mockSetUser,
+  })),
+}));
+
+jest.mock('../../../i18n', () => ({
+  __esModule: true,
+  default: { changeLanguage: jest.fn() },
 }));
 
 // ─── Sentry mock ─────────────────────────────────────────────────────────────
@@ -102,13 +116,17 @@ jest.mock('../../../monitoring/sentry', () => ({
   captureError: (...args: unknown[]) => mockCaptureError(...args),
 }));
 
-// ─── Navigation mock ──────────────────────────────────────────────────────────
+// ─── Route / navigation mock ─────────────────────────────────────────────────
 
-const mockNavigate = jest.fn();
+type TwoFactorProps = NativeStackScreenProps<AuthStackParamList, 'TwoFactor'>;
 
-const mockNavigation = {
-  navigate: mockNavigate,
-} as unknown as React.ComponentProps<typeof ForgotPasswordScreen>['navigation'];
+const mockRoute = {
+  params: { email: 'user@example.com', password: 'Passw0rd!' },
+  key: 'TwoFactor',
+  name: 'TwoFactor',
+} as TwoFactorProps['route'];
+
+const mockNavigation = {} as TwoFactorProps['navigation'];
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -123,74 +141,110 @@ const createQueryClient = () =>
 const renderScreen = async (queryClient: QueryClient) => {
   await render(
     <QueryClientProvider client={queryClient}>
-      <ForgotPasswordScreen navigation={mockNavigation} />
+      <TwoFactorScreen route={mockRoute} navigation={mockNavigation} />
     </QueryClientProvider>,
   );
 };
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('ForgotPasswordScreen', () => {
+describe('TwoFactorScreen', () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
     queryClient = createQueryClient();
-    mockForgotPassword.mockReset();
-    mockNavigate.mockReset();
+    mockMobileLogin.mockReset();
+    mockGetCurrentUser.mockReset();
+    mockSetTokens.mockReset();
+    mockSetUser.mockReset();
     mockCaptureError.mockReset();
   });
 
-  const submitForm = async () => {
-    await fireEvent.changeText(screen.getByTestId('FieldEmailAddress'), 'user@example.com');
-    await fireEvent.press(screen.getByTestId('ButtonSendResetLink'));
+  const fillAndSubmit = async () => {
+    await fireEvent.changeText(screen.getByTestId('FieldTwoFactorCode'), '123456');
+    await fireEvent.press(screen.getByTestId('ButtonVerify'));
   };
 
-  it('shows success UI when mutation succeeds', async () => {
-    mockForgotPassword.mockResolvedValue({});
+  it('saves tokens and user on successful 2FA verification', async () => {
+    const mockUser = { id: 'u1', firstName: 'Test', languageCode: 'en' };
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: mockUser });
 
     await renderScreen(queryClient);
-    await submitForm();
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockSetTokens).toHaveBeenCalledWith('at', 'rt');
+      expect(mockSetUser).toHaveBeenCalledWith(mockUser);
+    });
+  });
+
+  it('shows error when 2FA verification fails', async () => {
+    mockMobileLogin.mockRejectedValue(new Error('invalid code'));
+
+    await renderScreen(queryClient);
+    await fillAndSubmit();
 
     await waitFor(() =>
-      expect(screen.queryByText('LabelCheckYourEmail')).toBeTruthy(),
+      expect(screen.queryByText('ErrorInvalidTwoFactorCode')).toBeTruthy(),
     );
   });
 
-  it('shows success UI even when mutation fails (anti-enumeration)', async () => {
-    mockForgotPassword.mockRejectedValue(new Error('not found'));
+  it('calls mobileLogin with email, password, and 2FA code from route params', async () => {
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: { id: 'u1', firstName: '', languageCode: 'en' } });
 
     await renderScreen(queryClient);
-    await submitForm();
+    await fillAndSubmit();
 
     await waitFor(() =>
-      expect(screen.queryByText('LabelCheckYourEmail')).toBeTruthy(),
+      expect(mockMobileLogin).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'Passw0rd!',
+        twoFactorCode: '123456',
+      }),
     );
   });
 
-  it('captures error to Sentry when mutation fails', async () => {
-    const error = new Error('server error');
-    mockForgotPassword.mockRejectedValue(error);
+  it('captures error to Sentry when 2FA mutation fails', async () => {
+    const error = new Error('invalid 2FA code');
+    mockMobileLogin.mockRejectedValue(error);
 
     await renderScreen(queryClient);
-    await submitForm();
+    await fillAndSubmit();
 
     await waitFor(() =>
       expect(mockCaptureError).toHaveBeenCalledWith(
         error,
-        expect.objectContaining({ screen: 'ForgotPasswordScreen', action: 'forgotPassword' }),
+        expect.objectContaining({ screen: 'TwoFactorScreen', action: 'verifyTwoFactor' }),
       ),
     );
   });
 
-  it('does NOT capture error to Sentry when mutation succeeds', async () => {
-    mockForgotPassword.mockResolvedValue({});
+  it('captures error to Sentry when getCurrentUser fails silently', async () => {
+    const fetchError = new Error('profile fetch failed');
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockRejectedValue(fetchError);
 
     await renderScreen(queryClient);
-    await submitForm();
+    await fillAndSubmit();
 
     await waitFor(() =>
-      expect(screen.queryByText('LabelCheckYourEmail')).toBeTruthy(),
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        fetchError,
+        expect.objectContaining({ screen: 'TwoFactorScreen', action: 'fetchCurrentUser' }),
+      ),
     );
+  });
+
+  it('does NOT capture error to Sentry on successful 2FA with profile', async () => {
+    mockMobileLogin.mockResolvedValue({ data: { accessToken: 'at', refreshToken: 'rt' } });
+    mockGetCurrentUser.mockResolvedValue({ data: { id: 'u1', firstName: '', languageCode: 'en' } });
+
+    await renderScreen(queryClient);
+    await fillAndSubmit();
+
+    await waitFor(() => expect(mockSetTokens).toHaveBeenCalled());
     expect(mockCaptureError).not.toHaveBeenCalled();
   });
 });

--- a/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/CategoryListScreen.tsx
@@ -26,6 +26,7 @@ import {
   calculateRemainingBudget,
 } from '../../utils/budget';
 import { getCurrencySymbol } from '../../utils/currency';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'CategoryList'>;
 
@@ -48,10 +49,14 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
   }, [month, isFocused, setViewedMonth]);
   const projectId = selectedProject?.project.id ?? '';
 
-  const { data: categories, isLoading, isFetching, isError, refetch } =
+  const { data: categories, isLoading, isFetching, isError, error: categoriesError, refetch } =
     useCategoriesForMonth(projectId, month);
   const archiveCategory   = useArchiveCategory(projectId, month);
   const unarchiveCategory = useUnarchiveCategory(projectId, month);
+
+  useEffect(() => {
+    if (categoriesError) captureError(categoriesError, { screen: 'CategoryListScreen', action: 'fetchCategories' });
+  }, [categoriesError]);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -144,7 +149,9 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
             index={index}
             dark={dark}
             onSwipeAction={() => {
-              archiveCategory.mutate(item.id);
+              archiveCategory.mutate(item.id, {
+                onError: (err) => captureError(err, { screen: 'CategoryListScreen', action: 'archiveCategory' }),
+              });
               setUndoState({ visible: true, id: item.id });
             }}
             swipeActionColor={ink2}
@@ -172,7 +179,11 @@ export const CategoryListScreen: React.FC<Props> = ({ route, navigation }) => {
         visible={undoState.visible}
         message={t('LabelUndoArchive')}
         onUndo={() => {
-          if (undoState.id) unarchiveCategory.mutate(undoState.id);
+          if (undoState.id) {
+            unarchiveCategory.mutate(undoState.id, {
+              onError: (err) => captureError(err, { screen: 'CategoryListScreen', action: 'unarchiveCategory' }),
+            });
+          }
         }}
         onDismiss={() => setUndoState({ visible: false, id: null })}
       />

--- a/econoflow-mobile/src/screens/expenses/ExpenseFormScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseFormScreen.tsx
@@ -12,6 +12,7 @@ import { toDateOnly, fromDateOnly } from '../../utils/date';
 import { buildPatch } from '../../utils/patch';
 import { extractApiErrors } from '../../utils/apiErrors';
 import { ErrorBanner } from '../../components/common/ErrorBanner';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'ExpenseForm'>;
 
@@ -97,12 +98,18 @@ export const ExpenseFormScreen: React.FC<Props> = ({ route, navigation }) => {
     if (isEdit) {
       patchExpense.mutate(buildPatch(parsed as Record<string, unknown>), {
         onSuccess: () => navigation.goBack(),
-        onError: handleApiError,
+        onError: (error) => {
+          captureError(error, { screen: 'ExpenseFormScreen', action: 'updateExpense' });
+          handleApiError(error);
+        },
       });
     } else {
       createExpense.mutate(parsed, {
         onSuccess: () => navigation.goBack(),
-        onError: handleApiError,
+        onError: (error) => {
+          captureError(error, { screen: 'ExpenseFormScreen', action: 'createExpense' });
+          handleApiError(error);
+        },
       });
     }
   };

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -32,6 +32,7 @@ import { getCategoryIcon } from '../../utils/categoryIcon';
 import { getCurrencySymbol } from '../../utils/currency';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
+import { captureError } from '../../monitoring/sentry';
 import { useQuickAddStore } from '../../store/quickAddStore';
 import { formatAmount } from '../../utils/format';
 import type { TFunction } from 'i18next';
@@ -75,12 +76,16 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
     setViewedMonth(isFocused ? month : null);
   }, [month, isFocused, setViewedMonth]);
 
-  const { data: expenses, isLoading, isFetching, refetch } =
+  const { data: expenses, isLoading, isFetching, refetch, error: expensesError } =
     useExpensesForMonth(projectId, categoryId, month);
   const deleteExpense      = useDeleteExpense(projectId, categoryId, month);
   const deleteExpenseItem  = useDeleteExpenseItem(projectId, categoryId, month);
   const restoreExpense     = useRestoreExpense(projectId, categoryId, month);
   const restoreExpenseItem = useRestoreExpenseItem(projectId, categoryId, month);
+
+  useEffect(() => {
+    if (expensesError) captureError(expensesError, { screen: 'ExpenseListScreen', action: 'fetchExpenses' });
+  }, [expensesError]);
 
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [refreshing, setRefreshing] = useState(false);
@@ -203,7 +208,9 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                     actionIcon="trash-can-outline"
                     actionColor={customColors.expense}
                     onAction={() => {
-                      deleteExpense.mutate(expense.id);
+                      deleteExpense.mutate(expense.id, {
+                        onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'deleteExpense' }),
+                      });
                       setUndoState({ visible: true, expenseId: expense.id, itemId: null });
                     }}
                   >
@@ -307,7 +314,10 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                         defaultExpenseId: expense.id,
                       })}
                       onDeleteItem={(expenseItemId) => {
-                        deleteExpenseItem.mutate({ expenseId: expense.id, expenseItemId });
+                        deleteExpenseItem.mutate(
+                          { expenseId: expense.id, expenseItemId },
+                          { onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'deleteExpense' }) },
+                        );
                         setUndoState({ visible: true, expenseId: expense.id, itemId: expenseItemId });
                       }}
                       onEditItem={(item, itemIndex) => setQuickAdd({
@@ -339,9 +349,14 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
         message={t('LabelUndoDelete')}
         onUndo={() => {
           if (undoState.itemId && undoState.expenseId) {
-            restoreExpenseItem.mutate({ expenseId: undoState.expenseId, expenseItemId: undoState.itemId });
+            restoreExpenseItem.mutate(
+              { expenseId: undoState.expenseId, expenseItemId: undoState.itemId },
+              { onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'restoreExpense' }) },
+            );
           } else if (undoState.expenseId) {
-            restoreExpense.mutate(undoState.expenseId);
+            restoreExpense.mutate(undoState.expenseId, {
+              onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'restoreExpense' }),
+            });
           }
         }}
         onDismiss={() => setUndoState({ visible: false, expenseId: null, itemId: null })}

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -216,6 +216,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                   >
                   {/* ── Group header ──────────────────────────────────── */}
                   <TouchableOpacity
+                    testID={`expand-${expense.id}`}
                     onPress={() => setExpandedIds(prev => toggleSetItem(prev, expense.id))}
                     activeOpacity={0.75}
                     style={styles.groupHeader}
@@ -316,7 +317,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
                       onDeleteItem={(expenseItemId) => {
                         deleteExpenseItem.mutate(
                           { expenseId: expense.id, expenseItemId },
-                          { onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'deleteExpense' }) },
+                          { onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'deleteExpenseItem' }) },
                         );
                         setUndoState({ visible: true, expenseId: expense.id, itemId: expenseItemId });
                       }}

--- a/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
+++ b/econoflow-mobile/src/screens/expenses/ExpenseListScreen.tsx
@@ -352,7 +352,7 @@ export const ExpenseListScreen: React.FC<Props> = ({ route, navigation }) => {
           if (undoState.itemId && undoState.expenseId) {
             restoreExpenseItem.mutate(
               { expenseId: undoState.expenseId, expenseItemId: undoState.itemId },
-              { onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'restoreExpense' }) },
+              { onError: (err) => captureError(err, { screen: 'ExpenseListScreen', action: 'restoreExpenseItem' }) },
             );
           } else if (undoState.expenseId) {
             restoreExpense.mutate(undoState.expenseId, {

--- a/econoflow-mobile/src/screens/expenses/__tests__/CategoryListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/expenses/__tests__/CategoryListScreen.test.tsx
@@ -1,0 +1,310 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { CategoryListScreen } from '../CategoryListScreen';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── UI infrastructure mocks ──────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c' },
+    customColors: { income: '#2ecc71', expense: '#e74c3c' },
+  }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/LoadingIndicator', () => ({
+  LoadingIndicator: () => null,
+}));
+
+jest.mock('../../../components/common/ErrorBanner', () => ({
+  ErrorBanner: () => null,
+}));
+
+jest.mock('../../../components/common/MonthNavigator', () => ({
+  MonthNavigator: () => null,
+}));
+
+const MockCategoryCard = jest.fn(
+  (_props: { onSwipeAction?: () => void; [key: string]: unknown }) => null,
+);
+jest.mock('../../../components/budget/CategoryCard', () => ({
+  CategoryCard: (props: unknown) => MockCategoryCard(props as Record<string, unknown>),
+}));
+
+const MockUndoToast = jest.fn(
+  (_props: { visible?: boolean; onUndo?: () => void; onDismiss?: () => void; message?: string }) => null,
+);
+jest.mock('../../../components/common/UndoToast', () => ({
+  UndoToast: (props: unknown) => MockUndoToast(props as { visible?: boolean; onUndo?: () => void; onDismiss?: () => void; message?: string }),
+}));
+
+jest.mock('../../../utils/budget', () => ({
+  calculateTotalBudget: jest.fn(() => 0),
+  calculateTotalExpenses: jest.fn(() => 0),
+  calculateTotalOverspend: jest.fn(() => 0),
+  calculateRemainingBudget: jest.fn(() => 0),
+}));
+
+jest.mock('../../../utils/currency', () => ({
+  getCurrencySymbol: jest.fn(() => '€'),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(() => true),
+}));
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: { project: { id: 'proj-1' }, role: 'Manager' },
+    currency: 'EUR',
+  })),
+}));
+
+jest.mock('../../../store/quickAddStore', () => ({
+  useQuickAddStore: jest.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setViewedMonth: jest.fn() }),
+  ),
+}));
+
+const mockArchiveMutate = jest.fn();
+const mockUnarchiveMutate = jest.fn();
+
+jest.mock('../../../hooks/useCategories', () => ({
+  useCategoriesForMonth: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: jest.fn(),
+  })),
+  useArchiveCategory: jest.fn(() => ({ mutate: mockArchiveMutate })),
+  useUnarchiveCategory: jest.fn(() => ({ mutate: mockUnarchiveMutate })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  navigate: mockNavigate,
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof CategoryListScreen>['navigation'];
+
+const mockRoute = {
+  key: 'CategoryList',
+  name: 'CategoryList' as const,
+  params: { month: '2024-01' },
+} as unknown as React.ComponentProps<typeof CategoryListScreen>['route'];
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const MOCK_CATEGORY = {
+  id: 'cat-1',
+  name: 'Food',
+  isArchived: false,
+  budget: 500,
+  totalExpenses: 200,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('CategoryListScreen — captureError', () => {
+  beforeEach(() => {
+    MockCategoryCard.mockReset();
+    MockUndoToast.mockReset();
+    mockArchiveMutate.mockReset();
+    mockUnarchiveMutate.mockReset();
+    mockNavigate.mockReset();
+    mockGoBack.mockReset();
+    mockCaptureError.mockReset();
+
+    // reset to healthy state
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useCategoriesForMonth.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useArchiveCategory.mockReturnValue({
+      mutate: mockArchiveMutate,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useUnarchiveCategory.mockReturnValue({
+      mutate: mockUnarchiveMutate,
+    });
+  });
+
+  it('calls captureError with fetchCategories action when query returns an error', async () => {
+    const fetchError = new Error('network error');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useCategoriesForMonth.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: fetchError,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<CategoryListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        fetchError,
+        expect.objectContaining({ screen: 'CategoryListScreen', action: 'fetchCategories' }),
+      ),
+    );
+  });
+
+  it('calls captureError with archiveCategory action when archiveCategory mutation fails', async () => {
+    const archiveError = new Error('archive failed');
+    mockArchiveMutate.mockImplementation(
+      (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(archiveError);
+      },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useCategoriesForMonth.mockReturnValue({
+      data: [MOCK_CATEGORY],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<CategoryListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Find the CategoryCard's onSwipeAction and trigger it
+    const cardCall = MockCategoryCard.mock.calls.find(
+      (call) => typeof call[0]?.onSwipeAction === 'function',
+    );
+    expect(cardCall).toBeTruthy();
+    const onSwipeAction: () => void = cardCall![0].onSwipeAction!;
+
+    await act(async () => { onSwipeAction(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        archiveError,
+        expect.objectContaining({ screen: 'CategoryListScreen', action: 'archiveCategory' }),
+      ),
+    );
+  });
+
+  it('calls captureError with unarchiveCategory action when unarchiveCategory mutation fails', async () => {
+    const unarchiveError = new Error('unarchive failed');
+    mockUnarchiveMutate.mockImplementation(
+      (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(unarchiveError);
+      },
+    );
+
+    // Render with a category so we can trigger archive → then undo (unarchive)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useCategoriesForMonth.mockReturnValue({
+      data: [MOCK_CATEGORY],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    mockArchiveMutate.mockImplementation(jest.fn()); // no-op archive
+
+    await act(async () => {
+      render(<CategoryListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Trigger archive to set undoState
+    const cardCall = MockCategoryCard.mock.calls.find(
+      (call) => typeof call[0]?.onSwipeAction === 'function',
+    );
+    expect(cardCall).toBeTruthy();
+    await act(async () => { cardCall![0].onSwipeAction!(); });
+
+    // Trigger undo (unarchive)
+    const latestUndoCall = MockUndoToast.mock.calls[MockUndoToast.mock.calls.length - 1];
+    expect(latestUndoCall).toBeTruthy();
+    const onUndo: () => void = latestUndoCall[0]?.onUndo!;
+    expect(onUndo).toBeDefined();
+
+    await act(async () => { onUndo(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        unarchiveError,
+        expect.objectContaining({ screen: 'CategoryListScreen', action: 'unarchiveCategory' }),
+      ),
+    );
+  });
+
+  it('does not call captureError when query succeeds', async () => {
+    await act(async () => {
+      render(<CategoryListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/expenses/__tests__/ExpenseFormScreen.test.tsx
+++ b/econoflow-mobile/src/screens/expenses/__tests__/ExpenseFormScreen.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { ExpenseFormScreen } from '../ExpenseFormScreen';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── UI infrastructure mocks ──────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text, TextInput, TouchableOpacity, View } = require('react-native');
+  return {
+    Button: ({
+      children,
+      onPress,
+      loading: _loading,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      loading?: boolean;
+      testID?: string;
+    }) =>
+      React.createElement(
+        TouchableOpacity,
+        { onPress, testID: testID ?? String(children) },
+        React.createElement(Text, null, children),
+      ),
+    Checkbox: ({
+      status,
+      onPress,
+    }: {
+      status: string;
+      onPress: () => void;
+    }) =>
+      React.createElement(TouchableOpacity, { onPress, testID: 'checkbox' },
+        React.createElement(Text, null, status),
+      ),
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+    Text: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+    TextInput: ({
+      label,
+      value,
+      onChangeText,
+      testID,
+    }: {
+      label?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+      testID?: string;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? label,
+        value,
+        onChangeText,
+      }),
+    View: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+jest.mock('../../../components/common/ErrorBanner', () => ({
+  ErrorBanner: () => null,
+}));
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: { project: { id: 'proj-1' }, role: 'Manager' },
+    currency: 'EUR',
+  })),
+}));
+
+const mockCreateMutate = jest.fn();
+const mockPatchMutate = jest.fn();
+
+jest.mock('../../../hooks/useExpenses', () => ({
+  useCreateExpense: jest.fn(() => ({
+    mutate: mockCreateMutate,
+    isPending: false,
+  })),
+  usePatchExpense: jest.fn(() => ({
+    mutate: mockPatchMutate,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../utils/date', () => ({
+  toDateOnly: jest.fn(() => '2024-01-01'),
+  fromDateOnly: jest.fn(() => new Date('2024-01-01')),
+}));
+
+jest.mock('../../../utils/patch', () => ({
+  buildPatch: jest.fn((obj: Record<string, unknown>) => obj),
+}));
+
+jest.mock('../../../utils/apiErrors', () => ({
+  extractApiErrors: jest.fn(() => ({})),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof ExpenseFormScreen>['navigation'];
+
+const makeRoute = (overrides = {}) =>
+  ({
+    key: 'ExpenseForm',
+    name: 'ExpenseForm' as const,
+    params: {
+      categoryId: 'cat-1',
+      month: '2024-01',
+      ...overrides,
+    },
+  } as unknown as React.ComponentProps<typeof ExpenseFormScreen>['route']);
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ExpenseFormScreen — captureError', () => {
+  beforeEach(() => {
+    mockCreateMutate.mockReset();
+    mockPatchMutate.mockReset();
+    mockGoBack.mockReset();
+    mockCaptureError.mockReset();
+  });
+
+  it('calls captureError with createExpense action when createExpense mutation fails', async () => {
+    const error = new Error('create failed');
+    mockCreateMutate.mockImplementation((_data: unknown, opts?: { onError?: (e: unknown) => void }) => {
+      opts?.onError?.(error);
+    });
+
+    await act(async () => {
+      render(<ExpenseFormScreen navigation={mockNavigation} route={makeRoute()} />);
+    });
+
+    // Fill required name field so react-hook-form validation passes
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('FieldName'), 'Lunch');
+    });
+
+    // submit the form - wrap in act so all state updates are flushed
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('ButtonAdd'));
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'ExpenseFormScreen', action: 'createExpense' }),
+      ),
+    );
+  });
+
+  it('calls captureError with updateExpense action when patchExpense mutation fails', async () => {
+    const error = new Error('patch failed');
+    mockPatchMutate.mockImplementation((_data: unknown, opts?: { onError?: (e: unknown) => void }) => {
+      opts?.onError?.(error);
+    });
+
+    await act(async () => {
+      render(
+        <ExpenseFormScreen
+          navigation={mockNavigation}
+          route={makeRoute({
+            expenseId: 'exp-1',
+            initialValues: { name: 'Test', amount: 10, budget: 0, isDeductible: false, date: '2024-01-01' },
+          })}
+        />,
+      );
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('ButtonSave'));
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'ExpenseFormScreen', action: 'updateExpense' }),
+      ),
+    );
+  });
+
+  it('does not call captureError when createExpense succeeds', async () => {
+    mockCreateMutate.mockImplementation((_data: unknown, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+
+    await act(async () => {
+      render(<ExpenseFormScreen navigation={mockNavigation} route={makeRoute()} />);
+    });
+
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('FieldName'), 'Lunch');
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('ButtonAdd'));
+    });
+
+    await waitFor(() => expect(mockGoBack).toHaveBeenCalled());
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/expenses/__tests__/ExpenseListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/expenses/__tests__/ExpenseListScreen.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { act, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { ExpenseListScreen } from '../ExpenseListScreen';
-import type { Expense } from '../../../api/types';
+import type { Expense, ExpenseItem } from '../../../api/types';
 
 // ─── Sentry mock ──────────────────────────────────────────────────────────────
 
@@ -69,11 +69,21 @@ jest.mock('../../../components/common/LoadingIndicator', () => ({
 }));
 
 const MockSwipeableRow = jest.fn(
-  (_props: { onAction?: () => void; disabled?: boolean; [key: string]: unknown }) => null,
+  (_props: { onAction?: () => void; disabled?: boolean; children?: unknown }) => null,
 );
-jest.mock('../../../components/common/SwipeableRow', () => ({
-  SwipeableRow: (props: unknown) => MockSwipeableRow(props as Record<string, unknown>),
-}));
+jest.mock('../../../components/common/SwipeableRow', () => {
+  const React = require('react');
+  return {
+    SwipeableRow: (props: unknown) => {
+      MockSwipeableRow(props as Record<string, unknown>);
+      return React.createElement(
+        React.Fragment,
+        null,
+        (props as Record<string, unknown>).children,
+      );
+    },
+  };
+});
 
 const MockUndoToast = jest.fn(
   (_props: { visible?: boolean; onUndo?: () => void; onDismiss?: () => void; message?: string }) => null,
@@ -193,6 +203,21 @@ const MOCK_EXPENSE: Expense = {
   isDeductible: false,
   items: [],
   attachments: [],
+};
+
+const MOCK_ITEM: ExpenseItem = {
+  id: 'item-1',
+  name: 'Coffee',
+  amount: 5,
+  date: '2024-01-15',
+  isDeductible: false,
+  attachments: [],
+};
+
+const MOCK_EXPENSE_WITH_ITEMS: Expense = {
+  ...MOCK_EXPENSE,
+  amount: 5,
+  items: [MOCK_ITEM],
 };
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -345,6 +370,51 @@ describe('ExpenseListScreen — captureError', () => {
       expect(mockCaptureError).toHaveBeenCalledWith(
         restoreError,
         expect.objectContaining({ screen: 'ExpenseListScreen', action: 'restoreExpense' }),
+      ),
+    );
+  });
+
+  it('calls captureError with deleteExpenseItem action when deleteExpenseItem mutation fails', async () => {
+    const deleteItemError = new Error('delete item failed');
+    mockDeleteExpenseItemMutate.mockImplementation(
+      (_data: unknown, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(deleteItemError);
+      },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useExpensesForMonth.mockReturnValue({
+      data: [MOCK_EXPENSE_WITH_ITEMS],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Expand the expense group to reveal its items
+    MockSwipeableRow.mockClear();
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('expand-exp-1'));
+    });
+
+    // The item-level SwipeableRow is the last call after expansion
+    const allCalls = MockSwipeableRow.mock.calls.filter(
+      (call) => typeof call[0]?.onAction === 'function',
+    );
+    const itemCall = allCalls.at(-1);
+    expect(itemCall).toBeTruthy();
+
+    await act(async () => { itemCall![0].onAction!(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        deleteItemError,
+        expect.objectContaining({ screen: 'ExpenseListScreen', action: 'deleteExpenseItem' }),
       ),
     );
   });

--- a/econoflow-mobile/src/screens/expenses/__tests__/ExpenseListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/expenses/__tests__/ExpenseListScreen.test.tsx
@@ -419,6 +419,59 @@ describe('ExpenseListScreen — captureError', () => {
     );
   });
 
+  it('calls captureError with restoreExpenseItem action when restoreExpenseItem mutation fails', async () => {
+    const restoreItemError = new Error('restore item failed');
+    mockRestoreExpenseItemMutate.mockImplementation(
+      (_data: unknown, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(restoreItemError);
+      },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useExpensesForMonth.mockReturnValue({
+      data: [MOCK_EXPENSE_WITH_ITEMS],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    mockDeleteExpenseItemMutate.mockImplementation(jest.fn()); // no-op delete item
+
+    await act(async () => {
+      render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Expand the expense group to reveal items
+    MockSwipeableRow.mockClear();
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('expand-exp-1'));
+    });
+
+    // Trigger item delete to populate undoState with both expenseId and itemId
+    const allCalls = MockSwipeableRow.mock.calls.filter(
+      (call) => typeof call[0]?.onAction === 'function',
+    );
+    const itemCall = allCalls.at(-1);
+    expect(itemCall).toBeTruthy();
+    await act(async () => { itemCall![0].onAction!(); });
+
+    // Trigger undo — because undoState has itemId, restoreExpenseItem.mutate is called
+    const latestUndoCall = MockUndoToast.mock.calls[MockUndoToast.mock.calls.length - 1];
+    expect(latestUndoCall).toBeTruthy();
+    const onUndo: () => void = latestUndoCall[0]?.onUndo!;
+    expect(onUndo).toBeDefined();
+
+    await act(async () => { onUndo(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        restoreItemError,
+        expect.objectContaining({ screen: 'ExpenseListScreen', action: 'restoreExpenseItem' }),
+      ),
+    );
+  });
+
   it('does not call captureError when query succeeds', async () => {
     await act(async () => {
       render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);

--- a/econoflow-mobile/src/screens/expenses/__tests__/ExpenseListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/expenses/__tests__/ExpenseListScreen.test.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { ExpenseListScreen } from '../ExpenseListScreen';
+import type { Expense } from '../../../api/types';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── UI infrastructure mocks ──────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('i18next', () => ({ language: 'en' }));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c' },
+    customColors: { income: '#2ecc71', expense: '#e74c3c' },
+  }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/LoadingIndicator', () => ({
+  LoadingIndicator: () => null,
+}));
+
+const MockSwipeableRow = jest.fn(
+  (_props: { onAction?: () => void; disabled?: boolean; [key: string]: unknown }) => null,
+);
+jest.mock('../../../components/common/SwipeableRow', () => ({
+  SwipeableRow: (props: unknown) => MockSwipeableRow(props as Record<string, unknown>),
+}));
+
+const MockUndoToast = jest.fn(
+  (_props: { visible?: boolean; onUndo?: () => void; onDismiss?: () => void; message?: string }) => null,
+);
+jest.mock('../../../components/common/UndoToast', () => ({
+  UndoToast: (props: unknown) => MockUndoToast(props as { visible?: boolean; onUndo?: () => void; onDismiss?: () => void; message?: string }),
+}));
+
+jest.mock('../../../components/common/DonutRing', () => ({
+  DonutRing: () => null,
+}));
+
+jest.mock('../../../components/common/MonthNavigator', () => ({
+  MonthNavigator: () => null,
+}));
+
+jest.mock('../../quick-add/QuickAddModal', () => ({
+  QuickAddModal: () => null,
+}));
+
+jest.mock('../../../utils/date', () => ({
+  fromDateOnly: jest.fn(() => new Date('2024-01-15')),
+  formatMonthLabel: jest.fn(() => 'January 2024'),
+}));
+
+jest.mock('../../../utils/budget', () => ({
+  toggleSetItem: jest.fn((set: Set<string>, id: string) => {
+    const next = new Set(set);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  }),
+  calculateExpensesOverspend: jest.fn(() => 0),
+}));
+
+jest.mock('../../../utils/categoryTheme', () => ({
+  getCategoryColor: jest.fn(() => '#e74c3c'),
+}));
+
+jest.mock('../../../utils/categoryIcon', () => ({
+  getCategoryIcon: jest.fn(() => 'food'),
+}));
+
+jest.mock('../../../utils/currency', () => ({
+  getCurrencySymbol: jest.fn(() => '€'),
+}));
+
+jest.mock('../../../utils/format', () => ({
+  formatAmount: jest.fn((n: number) => String(n)),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+  useIsFocused: jest.fn(() => true),
+}));
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: { project: { id: 'proj-1' }, role: 'Manager' },
+    currency: 'EUR',
+  })),
+}));
+
+jest.mock('../../../store/quickAddStore', () => ({
+  useQuickAddStore: jest.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setCategoryId: jest.fn(), setViewedMonth: jest.fn() }),
+  ),
+}));
+
+const mockDeleteExpenseMutate = jest.fn();
+const mockDeleteExpenseItemMutate = jest.fn();
+const mockRestoreExpenseMutate = jest.fn();
+const mockRestoreExpenseItemMutate = jest.fn();
+
+jest.mock('../../../hooks/useExpenses', () => ({
+  useExpensesForMonth: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: jest.fn(),
+  })),
+  useDeleteExpense: jest.fn(() => ({ mutate: mockDeleteExpenseMutate })),
+  useDeleteExpenseItem: jest.fn(() => ({ mutate: mockDeleteExpenseItemMutate })),
+  useRestoreExpense: jest.fn(() => ({ mutate: mockRestoreExpenseMutate })),
+  useRestoreExpenseItem: jest.fn(() => ({ mutate: mockRestoreExpenseItemMutate })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof ExpenseListScreen>['navigation'];
+
+const mockRoute = {
+  key: 'ExpenseList',
+  name: 'ExpenseList' as const,
+  params: {
+    categoryId: 'cat-1',
+    categoryName: 'Food',
+    month: '2024-01',
+    categoryIndex: 0,
+  },
+} as unknown as React.ComponentProps<typeof ExpenseListScreen>['route'];
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const MOCK_EXPENSE: Expense = {
+  id: 'exp-1',
+  name: 'Lunch',
+  amount: 15,
+  budget: 20,
+  date: '2024-01-15',
+  isDeductible: false,
+  items: [],
+  attachments: [],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ExpenseListScreen — captureError', () => {
+  beforeEach(() => {
+    MockSwipeableRow.mockReset();
+    MockUndoToast.mockReset();
+    mockDeleteExpenseMutate.mockReset();
+    mockDeleteExpenseItemMutate.mockReset();
+    mockRestoreExpenseMutate.mockReset();
+    mockRestoreExpenseItemMutate.mockReset();
+    mockGoBack.mockReset();
+    mockCaptureError.mockReset();
+
+    // reset to healthy state
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useExpensesForMonth.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useDeleteExpense.mockReturnValue({
+      mutate: mockDeleteExpenseMutate,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useRestoreExpense.mockReturnValue({
+      mutate: mockRestoreExpenseMutate,
+    });
+  });
+
+  it('calls captureError with fetchExpenses action when query returns an error', async () => {
+    const fetchError = new Error('network error');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useExpensesForMonth.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: fetchError,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        fetchError,
+        expect.objectContaining({ screen: 'ExpenseListScreen', action: 'fetchExpenses' }),
+      ),
+    );
+  });
+
+  it('calls captureError with deleteExpense action when deleteExpense mutation fails', async () => {
+    const deleteError = new Error('delete failed');
+    mockDeleteExpenseMutate.mockImplementation(
+      (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(deleteError);
+      },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useExpensesForMonth.mockReturnValue({
+      data: [MOCK_EXPENSE],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Trigger the swipeable row's onAction (delete)
+    const swipeableCall = MockSwipeableRow.mock.calls.find(
+      (call) => typeof call[0]?.onAction === 'function',
+    );
+    expect(swipeableCall).toBeTruthy();
+    const onAction = swipeableCall![0].onAction!;
+
+    await act(async () => { onAction(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        deleteError,
+        expect.objectContaining({ screen: 'ExpenseListScreen', action: 'deleteExpense' }),
+      ),
+    );
+  });
+
+  it('calls captureError with restoreExpense action when restoreExpense mutation fails', async () => {
+    const restoreError = new Error('restore failed');
+    mockRestoreExpenseMutate.mockImplementation(
+      (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(restoreError);
+      },
+    );
+
+    await act(async () => {
+      render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Trigger the UndoToast onUndo callback (restoreExpense is called from there)
+    const undoCall = MockUndoToast.mock.calls[MockUndoToast.mock.calls.length - 1];
+    expect(undoCall).toBeTruthy();
+
+    // Set up undo state by triggering a delete first (to populate expenseId)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useExpensesForMonth.mockReturnValue({
+      data: [MOCK_EXPENSE],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    mockDeleteExpenseMutate.mockImplementation(jest.fn()); // no-op for delete
+
+    // Re-render with expense data
+    MockSwipeableRow.mockReset();
+    MockUndoToast.mockReset();
+
+    await act(async () => {
+      render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Trigger delete to set undoState
+    const swipeableCall = MockSwipeableRow.mock.calls.find(
+      (call) => typeof call[0]?.onAction === 'function',
+    );
+    expect(swipeableCall).toBeTruthy();
+    await act(async () => { swipeableCall![0].onAction!(); });
+
+    // Now trigger undo (restoreExpense)
+    const latestUndoCall = MockUndoToast.mock.calls[MockUndoToast.mock.calls.length - 1];
+    expect(latestUndoCall).toBeTruthy();
+    const latestOnUndo = latestUndoCall[0]?.onUndo!;
+
+    await act(async () => { latestOnUndo(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        restoreError,
+        expect.objectContaining({ screen: 'ExpenseListScreen', action: 'restoreExpense' }),
+      ),
+    );
+  });
+
+  it('does not call captureError when query succeeds', async () => {
+    await act(async () => {
+      render(<ExpenseListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/incomes/IncomeFormScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeFormScreen.tsx
@@ -10,6 +10,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useCreateIncome, usePatchIncome } from '../../hooks/useIncomes';
 import { toDateOnly, fromDateOnly, currentMonth } from '../../utils/date';
 import { buildPatch } from '../../utils/patch';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'IncomeForm'>;
 
@@ -50,10 +51,12 @@ export const IncomeFormScreen: React.FC<Props> = ({ route, navigation }) => {
     if (isEdit) {
       patchIncome.mutate(buildPatch(parsed as Record<string, unknown>), {
         onSuccess: () => navigation.goBack(),
+        onError: (error) => captureError(error, { screen: 'IncomeFormScreen', action: 'updateIncome' }),
       });
     } else {
       createIncome.mutate(parsed, {
         onSuccess: () => navigation.goBack(),
+        onError: (error) => captureError(error, { screen: 'IncomeFormScreen', action: 'createIncome' }),
       });
     }
   };

--- a/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
+++ b/econoflow-mobile/src/screens/incomes/IncomeListScreen.tsx
@@ -29,6 +29,7 @@ import { getCategoryIcon } from '../../utils/categoryIcon';
 import { fromDateOnly, formatMonthLabel } from '../../utils/date';
 import { formatAmount } from '../../utils/format';
 import { MonthNavigator } from '../../components/common/MonthNavigator';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<OverviewStackParamList, 'IncomeList'>;
 
@@ -68,9 +69,13 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
     setViewedMonth(isFocused ? month : null);
   }, [month, isFocused, setViewedMonth]);
 
-  const { data: incomes, isLoading, isFetching, isError, refetch } = useIncomesForMonth(projectId, month);
+  const { data: incomes, isLoading, isFetching, isError, error: incomesError, refetch } = useIncomesForMonth(projectId, month);
   const deleteIncome = useDeleteIncome(projectId, month);
   const restoreIncome = useRestoreIncome(projectId, month);
+
+  useEffect(() => {
+    if (incomesError) captureError(incomesError, { screen: 'IncomeListScreen', action: 'fetchIncomes' });
+  }, [incomesError]);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -172,7 +177,9 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
                     actionIcon="trash-can-outline"
                     actionColor={customColors.expense}
                     onAction={() => {
-                      deleteIncome.mutate(item.id);
+                      deleteIncome.mutate(item.id, {
+                        onError: (err) => captureError(err, { screen: 'IncomeListScreen', action: 'deleteIncome' }),
+                      });
                       setUndoState({ visible: true, id: item.id });
                     }}
                   >
@@ -217,7 +224,11 @@ export const IncomeListScreen: React.FC<Props> = ({ route, navigation }) => {
         visible={undoState.visible}
         message={t('LabelUndoDelete')}
         onUndo={() => {
-          if (undoState.id) restoreIncome.mutate(undoState.id);
+          if (undoState.id) {
+            restoreIncome.mutate(undoState.id, {
+              onError: (err) => captureError(err, { screen: 'IncomeListScreen', action: 'restoreIncome' }),
+            });
+          }
         }}
         onDismiss={() => setUndoState({ visible: false, id: null })}
       />

--- a/econoflow-mobile/src/screens/incomes/__tests__/IncomeFormScreen.test.tsx
+++ b/econoflow-mobile/src/screens/incomes/__tests__/IncomeFormScreen.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { IncomeFormScreen } from '../IncomeFormScreen';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── UI infrastructure mocks ──────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text, TextInput, TouchableOpacity } = require('react-native');
+  return {
+    Button: ({
+      children,
+      onPress,
+      loading: _loading,
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      loading?: boolean;
+    }) =>
+      React.createElement(
+        TouchableOpacity,
+        { onPress, testID: String(children) },
+        React.createElement(Text, null, children),
+      ),
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+    Text: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+    TextInput: ({
+      label,
+      value,
+      onChangeText,
+    }: {
+      label?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+    }) =>
+      React.createElement(TextInput, {
+        testID: label,
+        value,
+        onChangeText,
+      }),
+  };
+});
+
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: { project: { id: 'proj-1' }, role: 'Manager' },
+    currency: 'EUR',
+  })),
+}));
+
+const mockCreateMutate = jest.fn();
+const mockPatchMutate = jest.fn();
+
+jest.mock('../../../hooks/useIncomes', () => ({
+  useCreateIncome: jest.fn(() => ({
+    mutate: mockCreateMutate,
+    isPending: false,
+  })),
+  usePatchIncome: jest.fn(() => ({
+    mutate: mockPatchMutate,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../utils/date', () => ({
+  toDateOnly: jest.fn(() => '2024-01-01'),
+  fromDateOnly: jest.fn(() => new Date('2024-01-01')),
+  currentMonth: jest.fn(() => '2024-01'),
+}));
+
+jest.mock('../../../utils/patch', () => ({
+  buildPatch: jest.fn((obj: Record<string, unknown>) => obj),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof IncomeFormScreen>['navigation'];
+
+const makeRoute = (overrides = {}) =>
+  ({
+    key: 'IncomeForm',
+    name: 'IncomeForm' as const,
+    params: {
+      month: '2024-01',
+      ...overrides,
+    },
+  } as unknown as React.ComponentProps<typeof IncomeFormScreen>['route']);
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('IncomeFormScreen — captureError', () => {
+  beforeEach(() => {
+    mockCreateMutate.mockReset();
+    mockPatchMutate.mockReset();
+    mockGoBack.mockReset();
+    mockCaptureError.mockReset();
+  });
+
+  it('calls captureError with createIncome action when createIncome mutation fails', async () => {
+    const error = new Error('create failed');
+    mockCreateMutate.mockImplementation((_data: unknown, opts?: { onError?: (e: unknown) => void }) => {
+      opts?.onError?.(error);
+    });
+
+    await act(async () => {
+      render(<IncomeFormScreen navigation={mockNavigation} route={makeRoute()} />);
+    });
+
+    // Fill required name field so react-hook-form validation passes
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('FieldName'), 'Salary');
+    });
+
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('FieldAmount'), '1000');
+    });
+
+    // submit the form
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('ButtonAdd'));
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'IncomeFormScreen', action: 'createIncome' }),
+      ),
+    );
+  });
+
+  it('calls captureError with updateIncome action when patchIncome mutation fails', async () => {
+    const error = new Error('patch failed');
+    mockPatchMutate.mockImplementation((_data: unknown, opts?: { onError?: (e: unknown) => void }) => {
+      opts?.onError?.(error);
+    });
+
+    await act(async () => {
+      render(
+        <IncomeFormScreen
+          navigation={mockNavigation}
+          route={makeRoute({
+            incomeId: 'inc-1',
+            initialValues: { name: 'Salary', amount: 1000, date: '2024-01-01' },
+          })}
+        />,
+      );
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('ButtonSave'));
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ screen: 'IncomeFormScreen', action: 'updateIncome' }),
+      ),
+    );
+  });
+
+  it('does not call captureError when createIncome succeeds', async () => {
+    mockCreateMutate.mockImplementation((_data: unknown, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+
+    await act(async () => {
+      render(<IncomeFormScreen navigation={mockNavigation} route={makeRoute()} />);
+    });
+
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('FieldName'), 'Salary');
+    });
+
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('FieldAmount'), '1000');
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('ButtonAdd'));
+    });
+
+    await waitFor(() => expect(mockGoBack).toHaveBeenCalled());
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/incomes/__tests__/IncomeListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/incomes/__tests__/IncomeListScreen.test.tsx
@@ -1,0 +1,320 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { IncomeListScreen } from '../IncomeListScreen';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── UI infrastructure mocks ──────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('i18next', () => ({ language: 'en' }));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  useAuroraSkin: () => ({ dark: false, ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+jest.mock('../../../theme/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: { primary: '#0f76a8', error: '#e74c3c' },
+    customColors: { income: '#2ecc71', expense: '#e74c3c' },
+  }),
+}));
+
+jest.mock('../../../components/common/GlassScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassScreen: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/GlassCard', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    GlassCard: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('../../../components/common/LoadingIndicator', () => ({
+  LoadingIndicator: () => null,
+}));
+
+jest.mock('../../../components/common/ErrorBanner', () => ({
+  ErrorBanner: () => null,
+}));
+
+const MockSwipeableRow = jest.fn(
+  (_props: { onAction?: () => void; disabled?: boolean; [key: string]: unknown }) => null,
+);
+jest.mock('../../../components/common/SwipeableRow', () => ({
+  SwipeableRow: (props: unknown) => MockSwipeableRow(props as Record<string, unknown>),
+}));
+
+const MockUndoToast = jest.fn(
+  (_props: { visible?: boolean; onUndo?: () => void; onDismiss?: () => void; message?: string }) => null,
+);
+jest.mock('../../../components/common/UndoToast', () => ({
+  UndoToast: (props: unknown) => MockUndoToast(props as { visible?: boolean; onUndo?: () => void; onDismiss?: () => void; message?: string }),
+}));
+
+jest.mock('../../../components/common/MonthNavigator', () => ({
+  MonthNavigator: () => null,
+}));
+
+jest.mock('../../quick-add/QuickAddModal', () => ({
+  QuickAddModal: () => null,
+}));
+
+jest.mock('../../../utils/date', () => ({
+  fromDateOnly: jest.fn(() => new Date('2024-01-15')),
+  formatMonthLabel: jest.fn(() => 'January 2024'),
+}));
+
+jest.mock('../../../utils/currency', () => ({
+  getCurrencySymbol: jest.fn(() => '€'),
+}));
+
+jest.mock('../../../utils/categoryIcon', () => ({
+  getCategoryIcon: jest.fn(() => 'cash'),
+}));
+
+jest.mock('../../../utils/format', () => ({
+  formatAmount: jest.fn((n: number) => String(n)),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+  useIsFocused: jest.fn(() => true),
+}));
+
+// ─── Store / hook mocks ───────────────────────────────────────────────────────
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: { project: { id: 'proj-1' }, role: 'Manager' },
+    currency: 'EUR',
+  })),
+}));
+
+jest.mock('../../../store/quickAddStore', () => ({
+  useQuickAddStore: jest.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setDefaultType: jest.fn(), setViewedMonth: jest.fn() }),
+  ),
+}));
+
+const mockDeleteIncomeMutate = jest.fn();
+const mockRestoreIncomeMutate = jest.fn();
+
+jest.mock('../../../hooks/useIncomes', () => ({
+  useIncomesForMonth: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: jest.fn(),
+  })),
+  useDeleteIncome: jest.fn(() => ({ mutate: mockDeleteIncomeMutate })),
+  useRestoreIncome: jest.fn(() => ({ mutate: mockRestoreIncomeMutate })),
+}));
+
+// ─── Navigation mock ──────────────────────────────────────────────────────────
+
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+} as unknown as React.ComponentProps<typeof IncomeListScreen>['navigation'];
+
+const mockRoute = {
+  key: 'IncomeList',
+  name: 'IncomeList' as const,
+  params: { month: '2024-01' },
+} as unknown as React.ComponentProps<typeof IncomeListScreen>['route'];
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const MOCK_INCOME = {
+  id: 'inc-1',
+  name: 'Salary',
+  amount: 2000,
+  date: '2024-01-01',
+  attachments: [],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('IncomeListScreen — captureError', () => {
+  beforeEach(() => {
+    MockSwipeableRow.mockReset();
+    MockUndoToast.mockReset();
+    mockDeleteIncomeMutate.mockReset();
+    mockRestoreIncomeMutate.mockReset();
+    mockGoBack.mockReset();
+    mockCaptureError.mockReset();
+
+    // reset to healthy state
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useIncomes') as any).useIncomesForMonth.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useIncomes') as any).useDeleteIncome.mockReturnValue({
+      mutate: mockDeleteIncomeMutate,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useIncomes') as any).useRestoreIncome.mockReturnValue({
+      mutate: mockRestoreIncomeMutate,
+    });
+  });
+
+  it('calls captureError with fetchIncomes action when query returns an error', async () => {
+    const fetchError = new Error('network error');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useIncomes') as any).useIncomesForMonth.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: fetchError,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<IncomeListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        fetchError,
+        expect.objectContaining({ screen: 'IncomeListScreen', action: 'fetchIncomes' }),
+      ),
+    );
+  });
+
+  it('calls captureError with deleteIncome action when deleteIncome mutation fails', async () => {
+    const deleteError = new Error('delete failed');
+    mockDeleteIncomeMutate.mockImplementation(
+      (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(deleteError);
+      },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useIncomes') as any).useIncomesForMonth.mockReturnValue({
+      data: [MOCK_INCOME],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<IncomeListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Find and trigger the SwipeableRow's onAction (delete income)
+    const swipeableCall = MockSwipeableRow.mock.calls.find(
+      (call) => typeof call[0]?.onAction === 'function',
+    );
+    expect(swipeableCall).toBeTruthy();
+    const onAction: () => void = swipeableCall![0].onAction!;
+
+    await act(async () => { onAction(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        deleteError,
+        expect.objectContaining({ screen: 'IncomeListScreen', action: 'deleteIncome' }),
+      ),
+    );
+  });
+
+  it('calls captureError with restoreIncome action when restoreIncome mutation fails', async () => {
+    const restoreError = new Error('restore failed');
+    mockRestoreIncomeMutate.mockImplementation(
+      (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(restoreError);
+      },
+    );
+
+    // Render with an income item so undo state can be set
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useIncomes') as any).useIncomesForMonth.mockReturnValue({
+      data: [MOCK_INCOME],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    mockDeleteIncomeMutate.mockImplementation(jest.fn()); // no-op delete
+
+    await act(async () => {
+      render(<IncomeListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // Trigger delete to set undoState with the income id
+    const swipeableCall = MockSwipeableRow.mock.calls.find(
+      (call) => typeof call[0]?.onAction === 'function',
+    );
+    expect(swipeableCall).toBeTruthy();
+    await act(async () => { swipeableCall![0].onAction!(); });
+
+    // Trigger undo which calls restoreIncome.mutate
+    const latestUndoCall = MockUndoToast.mock.calls[MockUndoToast.mock.calls.length - 1];
+    expect(latestUndoCall).toBeTruthy();
+    const onUndo: () => void = latestUndoCall[0]?.onUndo!;
+    expect(onUndo).toBeDefined();
+
+    await act(async () => { onUndo(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        restoreError,
+        expect.objectContaining({ screen: 'IncomeListScreen', action: 'restoreIncome' }),
+      ),
+    );
+  });
+
+  it('does not call captureError when query succeeds', async () => {
+    await act(async () => {
+      render(<IncomeListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+});

--- a/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
+++ b/econoflow-mobile/src/screens/monthly/MonthlyOverviewScreen.tsx
@@ -16,6 +16,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useQuickAddStore } from '../../store/quickAddStore';
 import { useAuthStore } from '../../store/authStore';
 import { useProjects } from '../../hooks/useProjects';
+import { captureError } from '../../monitoring/sentry';
 import { useCategoriesForMonth, useArchiveCategory, useUnarchiveCategory } from '../../hooks/useCategories';
 import { UndoToast } from '../../components/common/UndoToast';
 import { useIncomesForMonth } from '../../hooks/useIncomes';
@@ -70,14 +71,14 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
 
   const {
     data: categories, isLoading: loadingCats, isFetching: fetchingCats,
-    isError: catsError, refetch: refetchCats,
+    isError: catsError, error: categoriesError, refetch: refetchCats,
   } = useCategoriesForMonth(projectId, month);
   const archiveCategory   = useArchiveCategory(projectId, month);
   const unarchiveCategory = useUnarchiveCategory(projectId, month);
   const canEdit = selectedProject?.role !== 'Viewer';
   const {
     data: incomes, isLoading: loadingInc, isFetching: fetchingIncs,
-    isError: incError, refetch: refetchIncs,
+    isError: incError, error: incomesError, refetch: refetchIncs,
   } = useIncomesForMonth(projectId, month);
   const { totalSaved, isLoading: loadingSaved } = useTotalSavedForMonth(projectId, month);
 
@@ -89,6 +90,14 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
         : null) ?? projects[0];
     if (pick) setSelectedProject(pick);
   }, [projects, selectedProject, user, setSelectedProject]);
+
+  useEffect(() => {
+    if (categoriesError) captureError(categoriesError, { screen: 'MonthlyOverviewScreen', action: 'fetchCategories' });
+  }, [categoriesError]);
+
+  useEffect(() => {
+    if (incomesError) captureError(incomesError, { screen: 'MonthlyOverviewScreen', action: 'fetchIncomes' });
+  }, [incomesError]);
 
   // Header is hidden in the navigator; clear the title so it never bleeds through
   useEffect(() => { navigation.setOptions({ title: '' }); }, [navigation]);
@@ -322,7 +331,9 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
                   index={idx}
                   dark={dark}
                   onSwipeAction={() => {
-                    archiveCategory.mutate(cat.id);
+                    archiveCategory.mutate(cat.id, {
+                      onError: (err) => captureError(err, { screen: 'MonthlyOverviewScreen', action: 'archiveCategory' }),
+                    });
                     setUndoState({ visible: true, id: cat.id });
                   }}
                   swipeActionColor={ink2}
@@ -349,7 +360,9 @@ export const MonthlyOverviewScreen: React.FC<Props> = ({ navigation }) => {
         visible={undoState.visible}
         message={t('LabelUndoArchive')}
         onUndo={() => {
-          if (undoState.id) unarchiveCategory.mutate(undoState.id);
+          if (undoState.id) unarchiveCategory.mutate(undoState.id, {
+            onError: (err) => captureError(err, { screen: 'MonthlyOverviewScreen', action: 'unarchiveCategory' }),
+          });
         }}
         onDismiss={() => setUndoState({ visible: false, id: null })}
       />

--- a/econoflow-mobile/src/screens/monthly/__tests__/MonthlyOverviewScreen.test.tsx
+++ b/econoflow-mobile/src/screens/monthly/__tests__/MonthlyOverviewScreen.test.tsx
@@ -4,7 +4,7 @@
  * correctly wired for each role.
  */
 import React from 'react';
-import { act, render, screen, fireEvent } from '@testing-library/react-native';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { MonthlyOverviewScreen } from '../MonthlyOverviewScreen';
 import type { Category } from '../../../api/types';
 
@@ -68,6 +68,13 @@ jest.mock('../../../components/common/UndoToast', () => ({
 
 jest.mock('../../../components/budget/CategoryCard', () => ({
   CategoryCard: jest.fn(() => null),
+}));
+
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
 }));
 
 // ─── Store / hook mocks ───────────────────────────────────────────────────────
@@ -156,6 +163,7 @@ describe('MonthlyOverviewScreen — archive-category capability', () => {
     getCategoryCardSpy().mockClear();
     getUndoToastSpy().mockClear();
     mockParentNavigate.mockReset();
+    mockCaptureError.mockReset();
   });
 
   it('passes onSwipeAction and swipeDisabled=false to CategoryCard for Manager role', async () => {
@@ -196,6 +204,128 @@ describe('MonthlyOverviewScreen — archive-category capability', () => {
     });
 
     expect(getUndoToastSpy()).toHaveBeenCalled();
+  });
+
+  it('calls captureError when useCategoriesForMonth query has an error', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockImplementation(() => makeProjectStore('Manager'));
+
+    const err = new Error('Cats fetch failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useCategoriesForMonth.mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: err,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<MonthlyOverviewScreen navigation={mockNavigation} />);
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'MonthlyOverviewScreen', action: 'fetchCategories' },
+      );
+    });
+  });
+
+  it('calls captureError when useIncomesForMonth query has an error', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockImplementation(() => makeProjectStore('Manager'));
+
+    const err = new Error('Incomes fetch failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useIncomes') as any).useIncomesForMonth.mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: err,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<MonthlyOverviewScreen navigation={mockNavigation} />);
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'MonthlyOverviewScreen', action: 'fetchIncomes' },
+      );
+    });
+  });
+
+  it('calls captureError with archiveCategory action when archive mutation errors', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockImplementation(() => makeProjectStore('Manager'));
+
+    const err = new Error('Archive failed');
+    const mockArchiveWithError = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useArchiveCategory.mockReturnValueOnce({
+      mutate: (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        mockArchiveWithError();
+        opts?.onError?.(err);
+      },
+    });
+
+    await act(async () => {
+      render(<MonthlyOverviewScreen navigation={mockNavigation} />);
+    });
+
+    const categoryCardProps = getCategoryCardSpy().mock.calls[0][0];
+    await act(async () => {
+      categoryCardProps.onSwipeAction();
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'MonthlyOverviewScreen', action: 'archiveCategory' },
+      );
+    });
+  });
+
+  it('calls captureError with unarchiveCategory action when unarchive mutation errors', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockImplementation(() => makeProjectStore('Manager'));
+
+    const err = new Error('Unarchive failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useCategories') as any).useUnarchiveCategory.mockReturnValue({
+      mutate: (_id: string, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.(err);
+      },
+    });
+
+    await act(async () => {
+      render(<MonthlyOverviewScreen navigation={mockNavigation} />);
+    });
+
+    // First trigger a swipe to populate undoState.id so the undo call is guarded
+    const categoryCardProps = getCategoryCardSpy().mock.calls[0][0];
+    await act(async () => {
+      categoryCardProps.onSwipeAction();
+    });
+
+    // UndoToast re-renders after swipe — use the latest call to get the updated onUndo closure
+    const undoToastCalls = getUndoToastSpy().mock.calls;
+    const latestUndoToastProps = undoToastCalls[undoToastCalls.length - 1][0];
+    await act(async () => {
+      latestUndoToastProps.onUndo();
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'MonthlyOverviewScreen', action: 'unarchiveCategory' },
+      );
+    });
   });
 
   it('pressing the saved panel navigates to the Plans tab', async () => {

--- a/econoflow-mobile/src/screens/onboarding/ProfileSetupScreen.tsx
+++ b/econoflow-mobile/src/screens/onboarding/ProfileSetupScreen.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { OnboardingParamList } from '../../navigation/OnboardingNavigator';
 import { useUpdateProfile } from '../../hooks/useUpdateProfile';
+import { captureError } from '../../monitoring/sentry';
 import { useAuthStore } from '../../store/authStore';
 import i18n from '../../i18n';
 import { AuthHero } from '../../components/auth/AuthHero';
@@ -77,7 +78,8 @@ export const ProfileSetupScreen: React.FC<Props> = () => {
       if (values.languageCode) {
         i18n.changeLanguage(values.languageCode.startsWith('pt') ? 'pt' : 'en');
       }
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'ProfileSetupScreen', action: 'setupProfile' });
       setOpenCreateProjectOnStart(false);
       setError(t('ErrorProfileUpdateFailed'));
     }

--- a/econoflow-mobile/src/screens/onboarding/__tests__/ProfileSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/onboarding/__tests__/ProfileSetupScreen.test.tsx
@@ -109,6 +109,13 @@ jest.mock('../../../i18n', () => ({
   default: { language: 'en', changeLanguage: jest.fn() },
 }));
 
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── Hook / store mocks ───────────────────────────────────────────────────────
 
 const mockMutateAsync = jest.fn();
@@ -145,6 +152,7 @@ describe('ProfileSetupScreen', () => {
     mockMutateAsync.mockReset();
     mockNavigate.mockReset();
     mockSetOpenCreateProjectOnStart.mockReset();
+    mockCaptureError.mockReset();
   });
 
   it('renders first name, last name, and language fields', async () => {
@@ -229,6 +237,24 @@ describe('ProfileSetupScreen', () => {
 
     await waitFor(() => {
       expect(mockSetOpenCreateProjectOnStart).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('calls captureError when patchUser API fails', async () => {
+    const err = new Error('Network error');
+    mockMutateAsync.mockRejectedValue(err);
+
+    await render(<ProfileSetupScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderFirstName'), 'John');
+    await fireEvent.changeText(screen.getByTestId('PlaceholderLastName'), 'Doe');
+    await fireEvent.press(screen.getByTestId('ButtonSaveAndContinue'));
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'ProfileSetupScreen', action: 'setupProfile' },
+      );
     });
   });
 

--- a/econoflow-mobile/src/screens/plans/PlanDetailScreen.tsx
+++ b/econoflow-mobile/src/screens/plans/PlanDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { FlatList, StyleSheet, TouchableOpacity, View, RefreshControl } from 'react-native';
 import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -18,6 +18,7 @@ import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
 import { getCurrencySymbol } from '../../utils/currency';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<PlansStackParamList, 'PlanDetail'>;
 
@@ -34,15 +35,24 @@ export const PlanDetailScreen: React.FC<Props> = ({ route, navigation }) => {
   const { planId, planName } = route.params;
   const sym = getCurrencySymbol(currency);
 
-  const { data: plans } = usePlans(projectId);
+  const { data: plans, error: plansError } = usePlans(projectId);
   const plan = (plans ?? []).find((p) => p.id === planId);
 
   const {
     data: entries,
     isLoading,
     isError,
+    error: entriesError,
     refetch,
   } = usePlanEntries(projectId, planId);
+
+  useEffect(() => {
+    if (plansError) captureError(plansError, { screen: 'PlanDetailScreen', action: 'fetchPlans' });
+  }, [plansError]);
+
+  useEffect(() => {
+    if (entriesError) captureError(entriesError, { screen: 'PlanDetailScreen', action: 'fetchPlanEntries' });
+  }, [entriesError]);
 
   const onRefresh = async () => {
     setRefreshing(true);

--- a/econoflow-mobile/src/screens/plans/PlanEntryFormScreen.tsx
+++ b/econoflow-mobile/src/screens/plans/PlanEntryFormScreen.tsx
@@ -18,6 +18,7 @@ import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
 import { extractApiErrors } from '../../utils/apiErrors';
 import { toDateOnly } from '../../utils/date';
+import { captureError } from '../../monitoring/sentry';
 
 type ActionType = 'deposit' | 'withdrawal';
 
@@ -48,6 +49,7 @@ export const PlanEntryFormScreen: React.FC<Props> = ({ route, navigation }) => {
   };
 
   const handleApiError = (error: unknown) => {
+    captureError(error, { screen: 'PlanEntryFormScreen', action: 'savePlanEntry' });
     const fieldErrors = extractApiErrors(error);
     const unmapped: string[] = [];
     clearErrors();

--- a/econoflow-mobile/src/screens/plans/PlanFormScreen.tsx
+++ b/econoflow-mobile/src/screens/plans/PlanFormScreen.tsx
@@ -17,6 +17,7 @@ import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { useAppTheme } from '../../theme/useAppTheme';
 import { extractApiErrors } from '../../utils/apiErrors';
 import { buildPatch } from '../../utils/patch';
+import { captureError } from '../../monitoring/sentry';
 
 type PlanType = 'Savings' | 'EmergencyReserve';
 
@@ -100,14 +101,26 @@ export const PlanFormScreen: React.FC<Props> = ({ route, navigation }) => {
       if (isEdit && planId) {
         const ops = buildPatch({ name: name.trim(), targetAmount: amount } as Record<string, unknown>);
         await new Promise<void>((resolve, reject) => {
-          patchPlan.mutate(ops, { onSuccess: () => resolve(), onError: (err) => reject(err) });
+          patchPlan.mutate(ops, {
+            onSuccess: () => resolve(),
+            onError: (err) => {
+              captureError(err, { screen: 'PlanFormScreen', action: 'updatePlan' });
+              reject(err);
+            },
+          });
         });
         navigation.goBack();
       } else {
         await new Promise<void>((resolve, reject) => {
           createPlan.mutate(
             { type: selectedType, name: name.trim(), targetAmount: amount },
-            { onSuccess: () => resolve(), onError: (err) => reject(err) },
+            {
+              onSuccess: () => resolve(),
+              onError: (err) => {
+                captureError(err, { screen: 'PlanFormScreen', action: 'createPlan' });
+                reject(err);
+              },
+            },
           );
         });
         navigation.goBack();

--- a/econoflow-mobile/src/screens/plans/PlanListScreen.tsx
+++ b/econoflow-mobile/src/screens/plans/PlanListScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { FlatList, StyleSheet, TouchableOpacity, View, RefreshControl } from 'react-native';
 import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -16,6 +16,7 @@ import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { GlassScreen } from '../../components/common/GlassScreen';
 import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<PlansStackParamList, 'PlanList'>;
 
@@ -29,8 +30,12 @@ export const PlanListScreen: React.FC<Props> = ({ navigation }) => {
   const canEdit = selectedProject?.role !== 'Viewer';
   const projectId = selectedProject?.project.id ?? '';
 
-  const { data: plans, isLoading, isFetching, isError, refetch } = usePlans(projectId);
+  const { data: plans, isLoading, isFetching, isError, error: plansError, refetch } = usePlans(projectId);
   const archivePlan = useArchivePlan(projectId);
+
+  useEffect(() => {
+    if (plansError) captureError(plansError, { screen: 'PlanListScreen', action: 'fetchPlans' });
+  }, [plansError]);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -82,7 +87,9 @@ export const PlanListScreen: React.FC<Props> = ({ navigation }) => {
             dark={dark}
             onPress={() => navigation.navigate('PlanDetail', { planId: item.id, planName: item.name })}
             onSwipeAction={canEdit ? () => {
-              archivePlan.mutate(item.id);
+              archivePlan.mutate(item.id, {
+                onError: (err) => captureError(err, { screen: 'PlanListScreen', action: 'archivePlan' }),
+              });
             } : undefined}
             swipeDisabled={!canEdit}
           />

--- a/econoflow-mobile/src/screens/plans/__tests__/PlanDetailScreen.test.tsx
+++ b/econoflow-mobile/src/screens/plans/__tests__/PlanDetailScreen.test.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { act, render, screen, fireEvent } from '@testing-library/react-native';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { PlanDetailScreen } from '../PlanDetailScreen';
 import type { Plan, PlanEntry } from '../../../api/types';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
 
 // ─── UI infrastructure mocks ──────────────────────────────────────────────────
 
@@ -144,6 +151,7 @@ const mockRoute = {
 describe('PlanDetailScreen', () => {
   beforeEach(() => {
     mockNavigate.mockReset();
+    mockCaptureError.mockReset();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockReturnValue({
       selectedProject: {
@@ -152,6 +160,17 @@ describe('PlanDetailScreen', () => {
         project: { id: 'proj-1', name: 'Test', preferredCurrency: 'EUR', isArchived: false },
       },
       currency: 'EUR',
+    });
+    // reset hooks to default non-error state
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlans.mockReturnValue({ data: [MOCK_PLAN], error: null });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlanEntries.mockReturnValue({
+      data: [MOCK_ENTRY],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
     });
   });
 
@@ -189,6 +208,7 @@ describe('PlanDetailScreen', () => {
       data: [],
       isLoading: false,
       isError: false,
+      error: null,
       refetch: jest.fn(),
     });
 
@@ -196,5 +216,48 @@ describe('PlanDetailScreen', () => {
       render(<PlanDetailScreen navigation={mockNavigation} route={mockRoute} />);
     });
     expect(screen.getByText('NoPlanEntriesYet')).toBeTruthy();
+  });
+
+  it('calls captureError when usePlans query returns an error', async () => {
+    const plansError = new Error('plans fetch failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlans.mockReturnValue({
+      data: undefined,
+      error: plansError,
+    });
+
+    await act(async () => {
+      render(<PlanDetailScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ screen: 'PlanDetailScreen', action: 'fetchPlans' }),
+      ),
+    );
+  });
+
+  it('calls captureError when usePlanEntries query returns an error', async () => {
+    const entriesError = new Error('entries fetch failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlanEntries.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: entriesError,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<PlanDetailScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ screen: 'PlanDetailScreen', action: 'fetchPlanEntries' }),
+      ),
+    );
   });
 });

--- a/econoflow-mobile/src/screens/plans/__tests__/PlanEntryFormScreen.test.tsx
+++ b/econoflow-mobile/src/screens/plans/__tests__/PlanEntryFormScreen.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { act, cleanup, render, screen, fireEvent } from '@testing-library/react-native';
+import { act, cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { PlanEntryFormScreen } from '../PlanEntryFormScreen';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
 
 // ─── UI infrastructure mocks ──────────────────────────────────────────────────
 
@@ -112,6 +119,7 @@ describe('PlanEntryFormScreen', () => {
   beforeEach(() => {
     cleanup();
     mockGoBack.mockReset();
+    mockCaptureError.mockReset();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (jest.requireMock('../../../hooks/usePlans') as any).useAddPlanEntry.mockReturnValue({
       mutate: jest.fn(),
@@ -256,5 +264,34 @@ describe('PlanEntryFormScreen', () => {
     });
 
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('calls captureError when addEntry mutation fails', async () => {
+    const entryError = new Error('save entry failed');
+    const mockMutate = jest.fn().mockImplementation((_data, callbacks) => callbacks.onError(entryError));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).useAddPlanEntry.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    });
+
+    await act(async () => {
+      render(<PlanEntryFormScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('field-0.00'), '100');
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('btn-ButtonSave'));
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ screen: 'PlanEntryFormScreen', action: 'savePlanEntry' }),
+      ),
+    );
   });
 });

--- a/econoflow-mobile/src/screens/plans/__tests__/PlanFormScreen.test.tsx
+++ b/econoflow-mobile/src/screens/plans/__tests__/PlanFormScreen.test.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { PlanFormScreen } from '../PlanFormScreen';
 import type { Plan } from '../../../api/types';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
 
 // ─── UI infrastructure mocks ──────────────────────────────────────────────────
 
@@ -144,6 +151,7 @@ describe('PlanFormScreen', () => {
   beforeEach(() => {
     mockNavigate.mockReset();
     mockGoBack.mockReset();
+    mockCaptureError.mockReset();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockReturnValue({
       selectedProject: {
@@ -153,6 +161,13 @@ describe('PlanFormScreen', () => {
       },
       currency: 'EUR',
     });
+    // reset hooks to defaults
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlans.mockReturnValue({ data: [] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).useCreatePlan.mockReturnValue({ mutate: jest.fn(), isPending: false });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePatchPlan.mockReturnValue({ mutate: jest.fn(), isPending: false });
   });
 
   it('shows CreatePlan title in create mode', async () => {
@@ -219,5 +234,60 @@ describe('PlanFormScreen', () => {
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('calls captureError when createPlan mutation fails', async () => {
+    const createError = new Error('create failed');
+    const mockMutate = jest.fn().mockImplementation((_data, { onError }) => onError(createError));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).useCreatePlan.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    });
+
+    await act(async () => {
+      render(<PlanFormScreen navigation={mockNavigation} route={makeCreateRoute()} />);
+    });
+
+    await act(async () => {
+      fireEvent.changeText(screen.getByTestId('field-PlanName'), 'Test Plan');
+      fireEvent.changeText(screen.getByTestId('field-0'), '500');
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('btn-ButtonSave'));
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ screen: 'PlanFormScreen', action: 'createPlan' }),
+      ),
+    );
+  });
+
+  it('calls captureError when patchPlan mutation fails', async () => {
+    const patchError = new Error('patch failed');
+    const mockMutate = jest.fn().mockImplementation((_ops, { onError }) => onError(patchError));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePatchPlan.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    });
+
+    await act(async () => {
+      render(<PlanFormScreen navigation={mockNavigation} route={makeEditRoute('plan-1')} />);
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('btn-ButtonSave'));
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ screen: 'PlanFormScreen', action: 'updatePlan' }),
+      ),
+    );
   });
 });

--- a/econoflow-mobile/src/screens/plans/__tests__/PlanListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/plans/__tests__/PlanListScreen.test.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { act, render, screen, fireEvent } from '@testing-library/react-native';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { PlanListScreen } from '../PlanListScreen';
 import type { Plan } from '../../../api/types';
+
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
 
 // ─── UI infrastructure mocks ──────────────────────────────────────────────────
 
@@ -147,8 +154,19 @@ describe('PlanListScreen', () => {
     mockNavigate.mockReset();
     mockArchiveMutate.mockReset();
     mockParentNavigate.mockReset();
+    mockCaptureError.mockReset();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (jest.requireMock('../../../store/projectStore') as any).useProjectStore.mockReturnValue(makeProjectStore());
+    // reset usePlans to a default non-error state
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlans.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
   });
 
   it('shows empty state when there are no plans', async () => {
@@ -235,5 +253,65 @@ describe('PlanListScreen', () => {
       render(<PlanListScreen navigation={mockNavigation} route={mockRoute} />);
     });
     expect(screen.getByTestId('header-title-spacer')).toBeTruthy();
+  });
+
+  it('calls captureError when usePlans query returns an error', async () => {
+    const fetchError = new Error('network error');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlans.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: fetchError,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      render(<PlanListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ screen: 'PlanListScreen', action: 'fetchPlans' }),
+      ),
+    );
+  });
+
+  it('calls captureError when archivePlan mutation fails', async () => {
+    const archiveError = new Error('archive failed');
+    const mockMutateWithError = jest.fn().mockImplementation((_id, opts) => {
+      opts?.onError?.(archiveError);
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).usePlans.mockReturnValue({
+      data: [MOCK_PLAN],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).useArchivePlan.mockReturnValue({
+      mutate: mockMutateWithError,
+    });
+
+    await act(async () => {
+      render(<PlanListScreen navigation={mockNavigation} route={mockRoute} />);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const PlanCard = (jest.requireMock('../../../components/plans/PlanCard') as any).PlanCard;
+    const swipeAction: () => void = PlanCard.mock.calls[0][0].onSwipeAction;
+    await act(async () => { swipeAction(); });
+
+    await waitFor(() =>
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ screen: 'PlanListScreen', action: 'archivePlan' }),
+      ),
+    );
   });
 });

--- a/econoflow-mobile/src/screens/plans/__tests__/PlanListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/plans/__tests__/PlanListScreen.test.tsx
@@ -167,6 +167,9 @@ describe('PlanListScreen', () => {
       error: null,
       refetch: jest.fn(),
     });
+    // reset useArchivePlan to use the shared mockArchiveMutate
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/usePlans') as any).useArchivePlan.mockReturnValue({ mutate: mockArchiveMutate });
   });
 
   it('shows empty state when there are no plans', async () => {
@@ -193,7 +196,7 @@ describe('PlanListScreen', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const PlanCard = (jest.requireMock('../../../components/plans/PlanCard') as any).PlanCard;
     expect(PlanCard.mock.calls.length).toBeGreaterThan(0);
-    expect(PlanCard.mock.calls[0][0].plan.id).toBe('plan-1');
+    expect(PlanCard.mock.calls[PlanCard.mock.calls.length - 1][0].plan.id).toBe('plan-1');
   });
 
   it('navigates to PlanForm when create button is pressed', async () => {
@@ -220,10 +223,10 @@ describe('PlanListScreen', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const PlanCard = (jest.requireMock('../../../components/plans/PlanCard') as any).PlanCard;
-    const swipeAction: () => void = PlanCard.mock.calls[0][0].onSwipeAction;
+    const swipeAction: () => void = PlanCard.mock.calls[PlanCard.mock.calls.length - 1][0].onSwipeAction;
     await act(async () => { swipeAction(); });
 
-    expect(mockArchiveMutate).toHaveBeenCalledWith('plan-1');
+    expect(mockArchiveMutate).toHaveBeenCalledWith('plan-1', expect.objectContaining({ onError: expect.any(Function) }));
   });
 
   it('does not render header top-right create button', async () => {
@@ -304,7 +307,8 @@ describe('PlanListScreen', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const PlanCard = (jest.requireMock('../../../components/plans/PlanCard') as any).PlanCard;
-    const swipeAction: () => void = PlanCard.mock.calls[0][0].onSwipeAction;
+    const lastCall = PlanCard.mock.calls[PlanCard.mock.calls.length - 1];
+    const swipeAction: () => void = lastCall[0].onSwipeAction;
     await act(async () => { swipeAction(); });
 
     await waitFor(() =>

--- a/econoflow-mobile/src/screens/profile/ChangeEmailScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ChangeEmailScreen.tsx
@@ -12,6 +12,7 @@ import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { AuroraField } from '../../components/auth/AuroraField';
 import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<ProfileStackParamList, 'ChangeEmail'>;
 
@@ -48,7 +49,8 @@ export const ChangeEmailScreen: React.FC<Props> = ({ navigation: _navigation }) 
     try {
       await mutateAsync({ newEmail: email.trim() });
       setSuccess(true);
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'ChangeEmailScreen', action: 'changeEmail' });
       setApiError(t('ErrorChangeEmailFailed') ?? 'Failed to change email. Please try again.');
     }
   };

--- a/econoflow-mobile/src/screens/profile/ChangePasswordScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ChangePasswordScreen.tsx
@@ -11,6 +11,7 @@ import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { AuroraField } from '../../components/auth/AuroraField';
 import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<ProfileStackParamList, 'ChangePassword'>;
 
@@ -67,7 +68,8 @@ export const ChangePasswordScreen: React.FC<Props> = ({ navigation }) => {
     try {
       await mutateAsync({ oldPassword: currentPassword, newPassword });
       navigation.goBack();
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'ChangePasswordScreen', action: 'changePassword' });
       setApiError(t('ErrorChangePasswordFailed') ?? 'Failed to change password. Please try again.');
     } finally {
       setCurrentPassword('');

--- a/econoflow-mobile/src/screens/profile/EditNameScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/EditNameScreen.tsx
@@ -12,6 +12,7 @@ import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { AuroraField } from '../../components/auth/AuroraField';
 import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<ProfileStackParamList, 'EditName'>;
 
@@ -54,7 +55,8 @@ export const EditNameScreen: React.FC<Props> = ({ navigation }) => {
         { op: 'replace', path: '/lastName', value: lastName.trim() },
       ]);
       navigation.goBack();
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'EditNameScreen', action: 'updateProfile' });
       setApiError(t('ErrorProfileUpdateFailed') ?? 'Failed to update your profile. Please try again.');
     }
   };

--- a/econoflow-mobile/src/screens/profile/LanguagePickerScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/LanguagePickerScreen.tsx
@@ -13,6 +13,7 @@ import { GlassCard } from '../../components/common/GlassCard';
 import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import i18n from '../../i18n';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<ProfileStackParamList, 'LanguagePicker'>;
 
@@ -36,7 +37,8 @@ export const LanguagePickerScreen: React.FC<Props> = ({ navigation: _navigation 
     try {
       await mutateAsync([{ op: 'replace', path: '/languageCode', value: code }]);
       i18n.changeLanguage(code);
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'LanguagePickerScreen', action: 'updateLanguage' });
       setApiError(t('ErrorGeneric') ?? 'Something went wrong. Please try again.');
     }
   };

--- a/econoflow-mobile/src/screens/profile/TwoFactorScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/TwoFactorScreen.tsx
@@ -17,6 +17,7 @@ import { ErrorBanner } from '../../components/common/ErrorBanner';
 import { AuroraField } from '../../components/auth/AuroraField';
 import { AuroraPrimaryButton } from '../../components/auth/AuroraPrimaryButton';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
+import { captureError } from '../../monitoring/sentry';
 
 type Props = NativeStackScreenProps<ProfileStackParamList, 'TwoFactorSetup'>;
 
@@ -56,7 +57,8 @@ export const TwoFactorScreen: React.FC<Props> = ({ navigation }) => {
       const result = await enableMutation.mutateAsync({ code: code.trim() });
       setRecoveryCodes(result.recoveryCodes ?? []);
       setCode('');
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'ProfileTwoFactorScreen', action: 'enableTwoFactor' });
       setApiError(t('ErrorGeneric') ?? 'Something went wrong. Please try again.');
     }
   };
@@ -84,7 +86,8 @@ export const TwoFactorScreen: React.FC<Props> = ({ navigation }) => {
     try {
       await disableMutation.mutateAsync({ password, twoFactorCode: code.trim() });
       navigation.goBack();
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'ProfileTwoFactorScreen', action: 'disableTwoFactor' });
       setApiError(t('ErrorGeneric') ?? 'Something went wrong. Please try again.');
     } finally {
       setPassword('');

--- a/econoflow-mobile/src/screens/profile/__tests__/ChangeEmailScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/ChangeEmailScreen.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { ChangeEmailScreen } from '../ChangeEmailScreen';
 
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
 
 jest.mock('@expo/vector-icons', () => ({
@@ -145,6 +152,7 @@ describe('ChangeEmailScreen', () => {
     // Default: never resolve — prevents accidental success state
     mockMutateAsync.mockImplementation(() => new Promise(() => {}));
     mockGoBack.mockReset();
+    mockCaptureError.mockReset();
   });
 
   it('pre-fills the email field with the current user email', async () => {
@@ -188,5 +196,16 @@ describe('ChangeEmailScreen', () => {
     await changeText('PlaceholderEmailAddress', 'new@example.com');
     await pressButton('ButtonSave');
     await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+
+  it('calls captureError when API fails', async () => {
+    const err = new Error('Network error');
+    mockMutateAsync.mockRejectedValue(err);
+    await render(<ChangeEmailScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderEmailAddress', 'new@example.com');
+    await pressButton('ButtonSave');
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(err, { screen: 'ChangeEmailScreen', action: 'changeEmail' });
+    });
   });
 });

--- a/econoflow-mobile/src/screens/profile/__tests__/ChangePasswordScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/ChangePasswordScreen.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { ChangePasswordScreen } from '../ChangePasswordScreen';
 
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
 
 jest.mock('@expo/vector-icons', () => ({
@@ -127,6 +134,7 @@ describe('ChangePasswordScreen', () => {
     // Default: never resolve — prevents accidental navigation
     mockMutateAsync.mockImplementation(() => new Promise(() => {}));
     mockGoBack.mockReset();
+    mockCaptureError.mockReset();
   });
 
   it('renders current password, new password, and confirm password fields', async () => {
@@ -188,5 +196,18 @@ describe('ChangePasswordScreen', () => {
     await changeText('PlaceholderConfirmNewPassword', 'newpass');
     await pressButton('ButtonSave');
     await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+
+  it('calls captureError when API fails', async () => {
+    const err = new Error('Network error');
+    mockMutateAsync.mockRejectedValue(err);
+    await render(<ChangePasswordScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'oldpass');
+    await changeText('PlaceholderNewPassword', 'newpass');
+    await changeText('PlaceholderConfirmNewPassword', 'newpass');
+    await pressButton('ButtonSave');
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(err, { screen: 'ChangePasswordScreen', action: 'changePassword' });
+    });
   });
 });

--- a/econoflow-mobile/src/screens/profile/__tests__/EditNameScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/EditNameScreen.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { EditNameScreen } from '../EditNameScreen';
 
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
 
 jest.mock('@expo/vector-icons', () => ({
@@ -145,6 +152,7 @@ describe('EditNameScreen', () => {
     // Default: never resolve — prevents accidental navigation
     mockMutateAsync.mockImplementation(() => new Promise(() => {}));
     mockGoBack.mockReset();
+    mockCaptureError.mockReset();
   });
 
   it('pre-fills first name and last name from user store', async () => {
@@ -197,5 +205,17 @@ describe('EditNameScreen', () => {
     await changeText('PlaceholderLastName', 'Jones');
     await pressButton('ButtonSave');
     await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+
+  it('calls captureError when API fails', async () => {
+    const err = new Error('Network error');
+    mockMutateAsync.mockRejectedValue(err);
+    await render(<EditNameScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderFirstName', 'Bob');
+    await changeText('PlaceholderLastName', 'Jones');
+    await pressButton('ButtonSave');
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(err, { screen: 'EditNameScreen', action: 'updateProfile' });
+    });
   });
 });

--- a/econoflow-mobile/src/screens/profile/__tests__/LanguagePickerScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/LanguagePickerScreen.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { LanguagePickerScreen } from '../LanguagePickerScreen';
 
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
 
 jest.mock('@expo/vector-icons', () => ({
@@ -107,6 +114,7 @@ describe('LanguagePickerScreen', () => {
   beforeEach(() => {
     mockMutateAsync.mockReset();
     jest.requireMock('../../../i18n').default.changeLanguage.mockReset();
+    mockCaptureError.mockReset();
   });
 
   it('renders language options for en-US and pt-BR', async () => {
@@ -155,5 +163,15 @@ describe('LanguagePickerScreen', () => {
     fireEvent.press(screen.getByTestId('lang-pt-BR'));
     await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
     expect(jest.requireMock('../../../i18n').default.changeLanguage).not.toHaveBeenCalled();
+  });
+
+  it('calls captureError when API fails', async () => {
+    const err = new Error('Network error');
+    mockMutateAsync.mockRejectedValue(err);
+    await render(<LanguagePickerScreen navigation={mockNavigation} route={mockRoute} />);
+    fireEvent.press(screen.getByTestId('lang-pt-BR'));
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(err, { screen: 'LanguagePickerScreen', action: 'updateLanguage' });
+    });
   });
 });

--- a/econoflow-mobile/src/screens/profile/__tests__/TwoFactorScreen.test.tsx
+++ b/econoflow-mobile/src/screens/profile/__tests__/TwoFactorScreen.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { TwoFactorScreen } from '../TwoFactorScreen';
 
+// ─── Sentry mock ──────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── UI infrastructure mocks ─────────────────────────────────────────────────
 
 jest.mock('@expo/vector-icons', () => ({
@@ -144,6 +151,7 @@ describe('TwoFactorScreen – setup (2FA disabled)', () => {
     mockEnableMutateAsync.mockReset();
     mockEnableMutateAsync.mockImplementation(() => new Promise(() => {}));
     mockGoBack.mockReset();
+    mockCaptureError.mockReset();
 
     jest.requireMock('../../../hooks/useProfile').useTwoFactorSetup.mockReturnValue({
       data: { isTwoFactorEnabled: false, sharedKey: 'abcd efgh', otpAuthUri: 'otpauth://...' },
@@ -199,6 +207,17 @@ describe('TwoFactorScreen – setup (2FA disabled)', () => {
     await pressButton('ButtonEnableTwoFactor');
     await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
   });
+
+  it('calls captureError when enable API fails', async () => {
+    const err = new Error('Invalid code');
+    mockEnableMutateAsync.mockRejectedValue(err);
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderAuthenticatorCode', '999999');
+    await pressButton('ButtonEnableTwoFactor');
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(err, { screen: 'ProfileTwoFactorScreen', action: 'enableTwoFactor' });
+    });
+  });
 });
 
 // ─── Disable (2FA enabled) ────────────────────────────────────────────────────
@@ -208,6 +227,7 @@ describe('TwoFactorScreen – disable (2FA enabled)', () => {
     mockDisableMutateAsync.mockReset();
     mockDisableMutateAsync.mockImplementation(() => new Promise(() => {}));
     mockGoBack.mockReset();
+    mockCaptureError.mockReset();
 
     jest.requireMock('../../../hooks/useProfile').useTwoFactorSetup.mockReturnValue({
       data: { isTwoFactorEnabled: true, sharedKey: '', otpAuthUri: '' },
@@ -260,5 +280,17 @@ describe('TwoFactorScreen – disable (2FA enabled)', () => {
     await changeText('PlaceholderAuthenticatorCode', '111111');
     await pressButton('ButtonDisableTwoFactor');
     await waitFor(() => { expect(screen.queryByTestId('error-banner')).toBeTruthy(); });
+  });
+
+  it('calls captureError when disable API fails', async () => {
+    const err = new Error('Invalid password');
+    mockDisableMutateAsync.mockRejectedValue(err);
+    await render(<TwoFactorScreen navigation={mockNavigation} route={mockRoute} />);
+    await changeText('PlaceholderCurrentPassword', 'wrongpassword');
+    await changeText('PlaceholderAuthenticatorCode', '111111');
+    await pressButton('ButtonDisableTwoFactor');
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(err, { screen: 'ProfileTwoFactorScreen', action: 'disableTwoFactor' });
+    });
   });
 });

--- a/econoflow-mobile/src/screens/projects/CreateProjectScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/CreateProjectScreen.tsx
@@ -21,6 +21,7 @@ import type { ProjectStackParamList } from '../../navigation/ProjectStackNavigat
 import type { RootParamList } from '../../navigation/AppNavigator';
 import { useCreateProject } from '../../hooks/useProjects';
 import { putTaxYearSettings } from '../../api/projects.api';
+import { captureError } from '../../monitoring/sentry';
 import { useProjectStore } from '../../store/projectStore';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
 import { GlassScreen } from '../../components/common/GlassScreen';
@@ -93,7 +94,8 @@ export const CreateProjectScreen: React.FC<Props> = ({ navigation, route }) => {
 
       setSelectedProject(userProject);
       navigation.navigate('SmartSetup', { projectId: userProject.project.id, fromOnboarding });
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'CreateProjectScreen', action: 'createProject' });
       setError(t('ErrorGeneric'));
     } finally {
       setIsSubmitting(false);

--- a/econoflow-mobile/src/screens/projects/ProjectListScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/ProjectListScreen.tsx
@@ -11,6 +11,7 @@ import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { ProjectStackParamList } from '../../navigation/ProjectStackNavigator';
 import type { MainTabParamList } from '../../navigation/MainNavigator';
 import { useProjects } from '../../hooks/useProjects';
+import { captureError } from '../../monitoring/sentry';
 import { useProjectStore } from '../../store/projectStore';
 import { useAuthStore } from '../../store/authStore';
 import { LoadingIndicator } from '../../components/common/LoadingIndicator';
@@ -38,7 +39,7 @@ export const ProjectListScreen: React.FC<Props> = ({ navigation }) => {
   const { t } = useTranslation();
   const { dark, ink, ink2 } = useAuroraSkin();
   const insets = useSafeAreaInsets();
-  const { data: projects, isLoading, refetch } = useProjects();
+  const { data: projects, isLoading, error: projectsError, refetch } = useProjects();
   const { selectedProject, setSelectedProject } = useProjectStore();
   const openCreateProjectOnStart = useAuthStore((s) => s.openCreateProjectOnStart);
   const setOpenCreateProjectOnStart = useAuthStore((s) => s.setOpenCreateProjectOnStart);
@@ -50,6 +51,10 @@ export const ProjectListScreen: React.FC<Props> = ({ navigation }) => {
       navigation.navigate('CreateProject', { fromOnboarding: true });
     }
   }, [openCreateProjectOnStart, navigation, setOpenCreateProjectOnStart]);
+
+  useEffect(() => {
+    if (projectsError) captureError(projectsError, { screen: 'ProjectListScreen', action: 'fetchProjects' });
+  }, [projectsError]);
 
   const handleSelect = (userProject: UserProject) => {
     setSelectedProject(userProject);

--- a/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
+++ b/econoflow-mobile/src/screens/projects/SmartSetupScreen.tsx
@@ -21,6 +21,7 @@ import dayjs from 'dayjs';
 import type { ProjectStackParamList } from '../../navigation/ProjectStackNavigator';
 import type { MainTabParamList } from '../../navigation/MainNavigator';
 import { useDefaultCategories, usePostSmartSetup } from '../../hooks/useSmartSetup';
+import { captureError } from '../../monitoring/sentry';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { useAuroraSkin } from '../../theme/useAuroraSkin';
@@ -229,7 +230,8 @@ export const SmartSetupScreen: React.FC<Props> = ({ navigation, route }) => {
         },
       });
       navigateToOverview();
-    } catch {
+    } catch (err) {
+      captureError(err, { screen: 'SmartSetupScreen', action: 'smartSetup' });
       setError(t('ErrorGeneric'));
     }
   };

--- a/econoflow-mobile/src/screens/projects/__tests__/CreateProjectScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/CreateProjectScreen.test.tsx
@@ -137,6 +137,13 @@ jest.mock('expo-linear-gradient', () => {
   };
 });
 
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── Store / hook mocks ───────────────────────────────────────────────────────
 
 const mockMutateAsync = jest.fn();
@@ -197,6 +204,7 @@ describe('CreateProjectScreen', () => {
     mockSetSelectedProject.mockReset();
     getPutTaxYearMock().mockReset();
     mockAuthHero.mockClear();
+    mockCaptureError.mockReset();
   });
 
   it('shows required field error when name is empty on submit', async () => {
@@ -262,6 +270,23 @@ describe('CreateProjectScreen', () => {
     await fireEvent.press(screen.getByTestId('ButtonCreate'));
 
     expect(await screen.findByTestId('error-banner', {}, { timeout: 3000 })).toBeTruthy();
+  });
+
+  it('calls captureError when createProject API call fails', async () => {
+    const err = new Error('Network error');
+    mockMutateAsync.mockRejectedValue(err);
+
+    await render(<CreateProjectScreen navigation={mockNavigation} />);
+
+    await fireEvent.changeText(screen.getByTestId('PlaceholderProjectName'), 'My Budget');
+    await fireEvent.press(screen.getByTestId('ButtonCreate'));
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'CreateProjectScreen', action: 'createProject' },
+      );
+    });
   });
 
   it('calls goBack when cancel is pressed (non-onboarding context)', async () => {

--- a/econoflow-mobile/src/screens/projects/__tests__/ProjectListScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/ProjectListScreen.test.tsx
@@ -66,6 +66,13 @@ jest.mock('../../../components/auth/AuroraPrimaryButton', () => {
   };
 });
 
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── Store / hook mocks ───────────────────────────────────────────────────────
 
 const mockSetSelectedProject = jest.fn();
@@ -125,6 +132,7 @@ describe('ProjectListScreen', () => {
     mockSetOpenCreateProjectOnStart.mockReset();
     mockAuthState.openCreateProjectOnStart = false;
     mockGetParent.mockReturnValue({ navigate: jest.fn() });
+    mockCaptureError.mockReset();
   });
 
   it('shows the new project button when the list is empty', async () => {
@@ -170,6 +178,25 @@ describe('ProjectListScreen', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('CreateProject', { fromOnboarding: true });
       expect(mockSetOpenCreateProjectOnStart).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('calls captureError when useProjects query has an error', async () => {
+    const err = new Error('Fetch failed');
+    getUseProjectsMock().mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: err,
+      refetch: jest.fn(),
+    });
+
+    await render(<ProjectListScreen navigation={mockNavigation} />);
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'ProjectListScreen', action: 'fetchProjects' },
+      );
     });
   });
 

--- a/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
+++ b/econoflow-mobile/src/screens/projects/__tests__/SmartSetupScreen.test.tsx
@@ -134,6 +134,13 @@ jest.mock('../../../store/projectStore', () => ({
   useProjectStore: jest.fn(() => ({ currency: 'EUR' })),
 }));
 
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
 // ─── Hook mocks ───────────────────────────────────────────────────────────────
 
 const MOCK_CATEGORIES: DefaultCategory[] = [
@@ -194,6 +201,7 @@ describe('SmartSetupScreen', () => {
     mockParentNavigate.mockReset();
     (CommonActions.reset as jest.Mock).mockClear();
     useUIStore.setState({ hideTabBar: false });
+    mockCaptureError.mockReset();
   });
 
   it('renders step 1 with annual income field by default', async () => {
@@ -350,6 +358,23 @@ describe('SmartSetupScreen', () => {
     await fireEvent.press(screen.getByTestId('SmartSetupFinish'));
 
     expect(await screen.findByTestId('error-banner', {}, { timeout: 3000 })).toBeTruthy();
+  });
+
+  it('calls captureError when Finish API call fails', async () => {
+    const err = new Error('Server error');
+    mockMutateAsync.mockRejectedValue(err);
+
+    await render(<SmartSetupScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await goToStep3();
+    await fireEvent.press(screen.getByTestId('SmartSetupFinish'));
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'SmartSetupScreen', action: 'smartSetup' },
+      );
+    });
   });
 
   it('Skip on step 2 navigates to Overview', async () => {

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -10,6 +10,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useForm, Controller } from 'react-hook-form';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useTranslation } from 'react-i18next';
+import { captureError } from '../../monitoring/sentry';
 import { useProjectStore } from '../../store/projectStore';
 import { useCategoriesForMonth } from '../../hooks/useCategories';
 import { useExpensesForMonth, useCreateExpense, useAddExpenseItem, usePatchExpense } from '../../hooks/useExpenses';
@@ -347,33 +348,69 @@ export const QuickAddModal: React.FC<Props> = ({
         const idx = editMode.itemIndex ?? 0;
         patchExpense.mutate(
           buildExpenseItemPatch(idx, { name, amount, date: dateStr, isDeductible: modal.isDeductible }),
-          { onSuccess: onClose, onError: handleApiError },
+          {
+            onSuccess: onClose,
+            onError: (err) => {
+              captureError(err, { screen: 'QuickAddModal', action: 'addExpenseItem' });
+              handleApiError(err);
+            },
+          },
         );
         return;
       }
       if (editMode.type === 'expense') {
         const fields: Record<string, unknown> = { name, date: dateStr, isDeductible: modal.isDeductible, budget };
         if (!editMode.hasItems) fields.amount = amount;
-        patchExpense.mutate(buildPatch(fields), { onSuccess: onClose, onError: handleApiError });
+        patchExpense.mutate(buildPatch(fields), {
+          onSuccess: onClose,
+          onError: (err) => {
+            captureError(err, { screen: 'QuickAddModal', action: 'updateExpense' });
+            handleApiError(err);
+          },
+        });
       } else {
         // income: only patch name, amount, date — no isDeductible or budget
-        patchIncome.mutate(buildPatch({ name, amount, date: dateStr } as Record<string, unknown>), { onSuccess: onClose, onError: handleApiError });
+        patchIncome.mutate(buildPatch({ name, amount, date: dateStr } as Record<string, unknown>), {
+          onSuccess: onClose,
+          onError: (err) => {
+            captureError(err, { screen: 'QuickAddModal', action: 'updateIncome' });
+            handleApiError(err);
+          },
+        });
       }
       return;
     }
 
     if (modal.entryType === 'income') {
-      createIncome.mutate({ name, amount, date: dateStr }, { onSuccess: onClose, onError: handleApiError });
+      createIncome.mutate({ name, amount, date: dateStr }, {
+        onSuccess: onClose,
+        onError: (err) => {
+          captureError(err, { screen: 'QuickAddModal', action: 'createIncome' });
+          handleApiError(err);
+        },
+      });
     } else if (modal.selectedExpenseId) {
       addExpenseItem.mutate(
         { expenseId: modal.selectedExpenseId, item: { name, amount, date: dateStr, isDeductible: modal.isDeductible } as never },
-        { onSuccess: onClose, onError: handleApiError },
+        {
+          onSuccess: onClose,
+          onError: (err) => {
+            captureError(err, { screen: 'QuickAddModal', action: 'addExpenseItem' });
+            handleApiError(err);
+          },
+        },
       );
     } else {
       if (!modal.selectedCategoryId) return;
       createExpense.mutate(
         { name, amount, budget, isDeductible: modal.isDeductible, date: dateStr },
-        { onSuccess: onClose, onError: handleApiError },
+        {
+          onSuccess: onClose,
+          onError: (err) => {
+            captureError(err, { screen: 'QuickAddModal', action: 'createExpense' });
+            handleApiError(err);
+          },
+        },
       );
     }
   };

--- a/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
+++ b/econoflow-mobile/src/screens/quick-add/QuickAddModal.tsx
@@ -351,7 +351,7 @@ export const QuickAddModal: React.FC<Props> = ({
           {
             onSuccess: onClose,
             onError: (err) => {
-              captureError(err, { screen: 'QuickAddModal', action: 'addExpenseItem' });
+              captureError(err, { screen: 'QuickAddModal', action: 'updateExpenseItem' });
               handleApiError(err);
             },
           },

--- a/econoflow-mobile/src/screens/quick-add/__tests__/QuickAddModal.test.tsx
+++ b/econoflow-mobile/src/screens/quick-add/__tests__/QuickAddModal.test.tsx
@@ -339,4 +339,34 @@ describe('QuickAddModal — Sentry captureError', () => {
       );
     });
   });
+
+  it('calls captureError with updateExpenseItem action when patchExpense errors on edit-expenseItem path', async () => {
+    const err = new Error('Patch expense item failed');
+    mockPatchExpenseMutate.mockImplementation(
+      (_data: unknown, opts?: { onSuccess?: () => void; onError?: (e: unknown) => void }) => {
+        opts?.onError?.(err);
+      },
+    );
+
+    const editMode = {
+      type: 'expenseItem' as const,
+      id: 'exp-1',
+      categoryId: 'cat-1',
+      itemIndex: 0,
+      initialValues: { name: 'Groceries', amount: 50, date: '2026-06-01', isDeductible: false },
+    };
+
+    await act(async () => { renderModal({ editMode }); });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('ButtonSave'));
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'QuickAddModal', action: 'updateExpenseItem' },
+      );
+    });
+  });
 });

--- a/econoflow-mobile/src/screens/quick-add/__tests__/QuickAddModal.test.tsx
+++ b/econoflow-mobile/src/screens/quick-add/__tests__/QuickAddModal.test.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { QuickAddModal } from '../QuickAddModal';
+
+// ─── Sentry mock ─────────────────────────────────────────────────────────────
+
+const mockCaptureError = jest.fn();
+jest.mock('../../../monitoring/sentry', () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+// ─── UI infrastructure mocks ─────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('expo-linear-gradient', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, null, children),
+  };
+});
+
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement(Text, props, children),
+    HelperText: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../../components/common/ErrorBanner', () => ({
+  ErrorBanner: () => null,
+}));
+
+jest.mock('../../../components/auth/AuroraField', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  return {
+    AuroraField: ({
+      placeholder, value, onChangeText, testID,
+    }: {
+      placeholder?: string;
+      value?: string;
+      onChangeText?: (t: string) => void;
+      testID?: string;
+    }) =>
+      React.createElement(TextInput, {
+        testID: testID ?? placeholder,
+        value,
+        onChangeText,
+      }),
+  };
+});
+
+jest.mock('../../../theme/useAuroraSkin', () => ({
+  auroraTokens: () => ({ ink: '#000', ink2: '#666', hair: '#ccc' }),
+}));
+
+// ─── Store / utility mocks ───────────────────────────────────────────────────
+
+jest.mock('../../../store/projectStore', () => ({
+  useProjectStore: jest.fn(() => ({
+    selectedProject: {
+      id: 'up-1',
+      userId: 'u1',
+      userName: 'Test',
+      userEmail: 'test@test.com',
+      accepted: true,
+      role: 'Admin',
+      project: { id: 'proj-1', name: 'My Project', preferredCurrency: 'EUR', isArchived: false },
+    },
+    currency: 'EUR',
+  })),
+}));
+
+jest.mock('../../../utils/categoryTheme', () => ({
+  getCategoryColor: () => '#0f76a8',
+}));
+
+jest.mock('../../../utils/categoryIcon', () => ({
+  getCategoryIcon: () => 'tag',
+}));
+
+jest.mock('../../../utils/currency', () => ({
+  getCurrencySymbol: () => '€',
+}));
+
+jest.mock('../../../utils/date', () => ({
+  currentMonth: () => '2026-06',
+  toDateOnly: (d: Date) => d.toISOString().split('T')[0],
+  fromDateOnly: (s: string) => new Date(s),
+  dateToMonth: () => '2026-06',
+  defaultDateForMonth: () => new Date('2026-06-01'),
+}));
+
+jest.mock('../../../utils/patch', () => ({
+  buildPatch: (fields: Record<string, unknown>) => Object.entries(fields).map(([path, value]) => ({ op: 'replace', path: `/${path}`, value })),
+  buildExpenseItemPatch: (_idx: number, fields: Record<string, unknown>) => Object.entries(fields).map(([path, value]) => ({ op: 'replace', path: `/${path}`, value })),
+}));
+
+jest.mock('../../../utils/amountValidation', () => ({
+  shouldShowAmountError: () => false,
+}));
+
+jest.mock('../../../utils/nameValidation', () => ({
+  isNameRequired: () => false,
+}));
+
+jest.mock('../../../utils/apiErrors', () => ({
+  extractApiErrors: () => ({}),
+}));
+
+// ─── Hook mocks ───────────────────────────────────────────────────────────────
+
+const mockCreateIncomeMutate = jest.fn();
+const mockCreateExpenseMutate = jest.fn();
+const mockAddExpenseItemMutate = jest.fn();
+const mockPatchExpenseMutate = jest.fn();
+const mockPatchIncomeMutate = jest.fn();
+
+jest.mock('../../../hooks/useCategories', () => ({
+  useCategoriesForMonth: jest.fn(() => ({
+    data: [
+      {
+        id: 'cat-1',
+        name: 'Food',
+        isArchived: false,
+        displayOrder: 0,
+        totalBudget: 100,
+        totalWaste: 0,
+        expenses: [],
+      },
+    ],
+  })),
+}));
+
+jest.mock('../../../hooks/useExpenses', () => ({
+  useExpensesForMonth: jest.fn(() => ({ data: [] })),
+  useCreateExpense: jest.fn(() => ({
+    mutate: mockCreateExpenseMutate,
+    isPending: false,
+  })),
+  useAddExpenseItem: jest.fn(() => ({
+    mutate: mockAddExpenseItemMutate,
+    isPending: false,
+  })),
+  usePatchExpense: jest.fn(() => ({
+    mutate: mockPatchExpenseMutate,
+    isPending: false,
+  })),
+}));
+
+jest.mock('../../../hooks/useIncomes', () => ({
+  useCreateIncome: jest.fn(() => ({
+    mutate: mockCreateIncomeMutate,
+    isPending: false,
+  })),
+  usePatchIncome: jest.fn(() => ({
+    mutate: mockPatchIncomeMutate,
+    isPending: false,
+  })),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const mockOnClose = jest.fn();
+
+function renderModal(props: Partial<React.ComponentProps<typeof QuickAddModal>> = {}) {
+  return render(
+    <QuickAddModal
+      visible
+      onClose={mockOnClose}
+      month="2026-06"
+      {...props}
+    />,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('QuickAddModal — Sentry captureError', () => {
+  beforeEach(() => {
+    mockCaptureError.mockReset();
+    mockOnClose.mockReset();
+    mockCreateIncomeMutate.mockReset();
+    mockCreateExpenseMutate.mockReset();
+    mockAddExpenseItemMutate.mockReset();
+    mockPatchExpenseMutate.mockReset();
+    mockPatchIncomeMutate.mockReset();
+  });
+
+  it('calls captureError with createIncome action when createIncome mutation errors', async () => {
+    const err = new Error('Create income failed');
+    mockCreateIncomeMutate.mockImplementation(
+      (_data: unknown, opts?: { onSuccess?: () => void; onError?: (e: unknown) => void }) => {
+        opts?.onError?.(err);
+      },
+    );
+
+    await act(async () => { renderModal(); });
+
+    // Switch to income type
+    await act(async () => {
+      fireEvent.press(screen.getByText('LabelIncome'));
+    });
+
+    // Submit
+    await act(async () => {
+      fireEvent.press(screen.getByText('ButtonAdd'));
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'QuickAddModal', action: 'createIncome' },
+      );
+    });
+  });
+
+  it('calls captureError with createExpense action when createExpense mutation errors', async () => {
+    const err = new Error('Create expense failed');
+    mockCreateExpenseMutate.mockImplementation(
+      (_data: unknown, opts?: { onSuccess?: () => void; onError?: (e: unknown) => void }) => {
+        opts?.onError?.(err);
+      },
+    );
+
+    await act(async () => { renderModal({ defaultCategoryId: 'cat-1' }); });
+
+    // Submit — category is pre-selected via defaultCategoryId
+    await act(async () => {
+      fireEvent.press(screen.getByText('ButtonAdd'));
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'QuickAddModal', action: 'createExpense' },
+      );
+    });
+  });
+
+  it('calls captureError with addExpenseItem action when addExpenseItem mutation errors', async () => {
+    const err = new Error('Add expense item failed');
+    mockAddExpenseItemMutate.mockImplementation(
+      (_data: unknown, opts?: { onSuccess?: () => void; onError?: (e: unknown) => void }) => {
+        opts?.onError?.(err);
+      },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (jest.requireMock('../../../hooks/useExpenses') as any).useExpensesForMonth.mockReturnValue({
+      data: [
+        { id: 'exp-1', name: 'Groceries', amount: 50, budget: 100, items: [] },
+      ],
+    });
+
+    await act(async () => { renderModal({ defaultCategoryId: 'cat-1', defaultExpenseId: 'exp-1' }); });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('ButtonAdd'));
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'QuickAddModal', action: 'addExpenseItem' },
+      );
+    });
+  });
+
+  it('calls captureError with updateExpense action when patchExpense mutation errors in edit mode', async () => {
+    const err = new Error('Patch expense failed');
+    mockPatchExpenseMutate.mockImplementation(
+      (_data: unknown, opts?: { onSuccess?: () => void; onError?: (e: unknown) => void }) => {
+        opts?.onError?.(err);
+      },
+    );
+
+    const editMode = {
+      type: 'expense' as const,
+      id: 'exp-1',
+      categoryId: 'cat-1',
+      hasItems: false,
+      initialValues: { name: 'Groceries', amount: 50, date: '2026-06-01', isDeductible: false, budget: 0 },
+    };
+
+    await act(async () => { renderModal({ editMode }); });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('ButtonSave'));
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'QuickAddModal', action: 'updateExpense' },
+      );
+    });
+  });
+
+  it('calls captureError with updateIncome action when patchIncome mutation errors in edit mode', async () => {
+    const err = new Error('Patch income failed');
+    mockPatchIncomeMutate.mockImplementation(
+      (_data: unknown, opts?: { onSuccess?: () => void; onError?: (e: unknown) => void }) => {
+        opts?.onError?.(err);
+      },
+    );
+
+    const editMode = {
+      type: 'income' as const,
+      id: 'inc-1',
+      initialValues: { name: 'Salary', amount: 3000, date: '2026-06-01' },
+    };
+
+    await act(async () => { renderModal({ editMode }); });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('ButtonSave'));
+    });
+
+    await waitFor(() => {
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        err,
+        { screen: 'QuickAddModal', action: 'updateIncome' },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Registration and auto-login failures in RegisterScreen were silently
swallowed — the onError callback and the auto-login catch block only
updated UI state without calling captureError, so errors never reached
Sentry. This adds captureError calls at both failure points (excluding
the expected 2FA redirect path) so all unexpected registration errors
are now observable in the Sentry dashboard.

https://claude.ai/code/session_01VvkrewdjBmguV3fs8yadPi