### PR TITLE
Fix silent failure in push notification toggle

### DIFF
--- a/econoflow-mobile/src/hooks/__tests__/usePushNotifications.test.ts
+++ b/econoflow-mobile/src/hooks/__tests__/usePushNotifications.test.ts
@@ -131,6 +131,43 @@ describe('registerPushNotificationsAsync', () => {
     expect(mockCaptureError).toHaveBeenCalledWith(apiError, { screen: 'usePushNotifications', action: 'register' });
     expect(setNotificationsEnabled).toHaveBeenCalledWith(false);
   });
+
+  it('captures error when getExpoPushTokenAsync throws', async () => {
+    const expoNotifications = jest.requireMock('expo-notifications') as {
+      getPermissionsAsync: jest.Mock;
+      getExpoPushTokenAsync: jest.Mock;
+    };
+
+    expoNotifications.getPermissionsAsync.mockResolvedValue({ status: 'granted' });
+
+    const tokenError = new Error('Expo push service unreachable');
+    expoNotifications.getExpoPushTokenAsync.mockRejectedValue(tokenError);
+
+    await expect(
+      registerPushNotificationsAsync(setExpoPushToken, setNotificationsEnabled),
+    ).resolves.toBeUndefined();
+
+    expect(mockCaptureError).toHaveBeenCalledWith(tokenError, { screen: 'usePushNotifications', action: 'register' });
+    expect(setNotificationsEnabled).toHaveBeenCalledWith(false);
+    expect(NotificationsApi.registerExpoPushToken).not.toHaveBeenCalled();
+  });
+
+  it('captures error when getPermissionsAsync throws', async () => {
+    const expoNotifications = jest.requireMock('expo-notifications') as {
+      getPermissionsAsync: jest.Mock;
+    };
+
+    const permError = new Error('Native module error');
+    expoNotifications.getPermissionsAsync.mockRejectedValue(permError);
+
+    await expect(
+      registerPushNotificationsAsync(setExpoPushToken, setNotificationsEnabled),
+    ).resolves.toBeUndefined();
+
+    expect(mockCaptureError).toHaveBeenCalledWith(permError, { screen: 'usePushNotifications', action: 'register' });
+    expect(setNotificationsEnabled).toHaveBeenCalledWith(false);
+    expect(NotificationsApi.registerExpoPushToken).not.toHaveBeenCalled();
+  });
 });
 
 describe('unregisterPushNotificationsAsync', () => {

--- a/econoflow-mobile/src/hooks/usePushNotifications.ts
+++ b/econoflow-mobile/src/hooks/usePushNotifications.ts
@@ -11,32 +11,38 @@ export async function registerPushNotificationsAsync(
   setNotificationsEnabled: (v: boolean) => void,
 ): Promise<void> {
   if (!Device.isDevice) {
+    // eslint-disable-next-line no-console
+    console.warn('[PushNotifications] Registration skipped — not a physical device');
     addBreadcrumb('Push registration skipped — not a physical device', 'debug');
     return;
   }
 
-  const { status: existingStatus } = await Notifications.getPermissionsAsync();
-  let finalStatus = existingStatus;
-
-  if (existingStatus === 'undetermined') {
-    const { status } = await Notifications.requestPermissionsAsync();
-    finalStatus = status;
-  }
-
-  if (finalStatus !== 'granted') {
-    addBreadcrumb('Push registration skipped — permission not granted', 'debug', { status: finalStatus });
-    return;
-  }
-
-  const tokenData = await Notifications.getExpoPushTokenAsync();
-  const token = tokenData.data;
-  const deviceName = Platform.OS === 'ios' ? 'iOS' : 'Android';
-
   try {
+    const { status: existingStatus } = await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+
+    if (existingStatus === 'undetermined') {
+      const { status } = await Notifications.requestPermissionsAsync();
+      finalStatus = status;
+    }
+
+    if (finalStatus !== 'granted') {
+      // eslint-disable-next-line no-console
+      console.warn('[PushNotifications] Registration skipped — permission not granted', finalStatus);
+      addBreadcrumb('Push registration skipped — permission not granted', 'debug', { status: finalStatus });
+      return;
+    }
+
+    const tokenData = await Notifications.getExpoPushTokenAsync();
+    const token = tokenData.data;
+    const deviceName = Platform.OS === 'ios' ? 'iOS' : 'Android';
+
     await apiRegister(token, deviceName);
     setExpoPushToken(token);
     setNotificationsEnabled(true);
   } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[PushNotifications] Registration failed', err);
     captureError(err, { screen: 'usePushNotifications', action: 'register' });
     setNotificationsEnabled(false);
   }
@@ -53,6 +59,8 @@ export async function unregisterPushNotificationsAsync(
   try {
     await apiUnregister(expoPushToken);
   } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[PushNotifications] Unregistration failed', err);
     captureError(err, { screen: 'usePushNotifications', action: 'unregister' });
   } finally {
     clearNotificationState();

--- a/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
@@ -97,6 +97,14 @@ const SettingToggleRow: React.FC<SettingToggleRowProps> = ({
     </View>
   );
 
+  if (onPress) {
+    return (
+      <TouchableOpacity onPress={onPress} activeOpacity={0.7} testID={testID}>
+        {inner}
+      </TouchableOpacity>
+    );
+  }
+
   return <View testID={testID}>{inner}</View>;
 };
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization

## Description

Fix silent failure in push notification toggle — wrap all await in try/catch, add console.* for dev visibility

Root cause: getExpoPushTokenAsync() and getPermissionsAsync() throws were unhandled promise rejections (no catch block around them). Only apiRegister() was inside try/catch.

Changes:
- Move try/catch to wrap the entire execution body after Device.isDevice guard
- Add console.warn at Device.isDevice early return
- Add console.warn at permission-denied early return
- Add console.error in catch blocks for register and unregister
- Add eslint-disable-next-line no-console comments per project rules
- Wrap SettingToggleRow in TouchableOpacity (matching SettingRow pattern)
- Add tests for getExpoPushTokenAsync and getPermissionsAsync throw paths

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
