### PR TITLE
Fix: send push registration failures to Sentry as errors

### DIFF
--- a/econoflow-mobile/src/hooks/__tests__/usePushNotifications.test.ts
+++ b/econoflow-mobile/src/hooks/__tests__/usePushNotifications.test.ts
@@ -30,10 +30,13 @@ jest.mock('expo-device', () => ({
 }));
 
 const mockCaptureError = jest.fn();
-const mockAddBreadcrumb = jest.fn();
 jest.mock('../../monitoring/sentry', () => ({
   captureError: (...args: unknown[]) => mockCaptureError(...args),
-  addBreadcrumb: (...args: unknown[]) => mockAddBreadcrumb(...args),
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+  Alert: { alert: jest.fn() },
 }));
 
 describe('registerPushNotificationsAsync', () => {
@@ -46,12 +49,15 @@ describe('registerPushNotificationsAsync', () => {
     jest.clearAllMocks();
   });
 
-  it('silently returns and adds breadcrumb when Device.isDevice is false', async () => {
+  it('captures error to Sentry when Device.isDevice is false', async () => {
     mockIsDevice.current = false;
 
     await registerPushNotificationsAsync(setExpoPushToken, setNotificationsEnabled);
 
-    expect(mockAddBreadcrumb).toHaveBeenCalled();
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('not a physical device') }),
+      { screen: 'usePushNotifications', action: 'register' },
+    );
     expect(NotificationsApi.registerExpoPushToken).not.toHaveBeenCalled();
     expect(setNotificationsEnabled).not.toHaveBeenCalled();
   });
@@ -82,32 +88,44 @@ describe('registerPushNotificationsAsync', () => {
     expect(setNotificationsEnabled).toHaveBeenCalledWith(true);
   });
 
-  it('skips registration when permission is denied', async () => {
+  it('captures error to Sentry and shows alert when permission is denied after request', async () => {
     const expoNotifications = jest.requireMock('expo-notifications') as {
       getPermissionsAsync: jest.Mock;
       requestPermissionsAsync: jest.Mock;
     };
+    const { Alert } = jest.requireMock('react-native') as { Alert: { alert: jest.Mock } };
 
     expoNotifications.getPermissionsAsync.mockResolvedValue({ status: 'undetermined' });
     expoNotifications.requestPermissionsAsync.mockResolvedValue({ status: 'denied' });
 
     await registerPushNotificationsAsync(setExpoPushToken, setNotificationsEnabled);
 
+    expect(Alert.alert).toHaveBeenCalled();
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('permission not granted') }),
+      { screen: 'usePushNotifications', action: 'register' },
+    );
     expect(NotificationsApi.registerExpoPushToken).not.toHaveBeenCalled();
     expect(setNotificationsEnabled).not.toHaveBeenCalled();
   });
 
-  it('skips registration when permission was previously denied', async () => {
+  it('captures error to Sentry and shows alert when permission was previously denied', async () => {
     const expoNotifications = jest.requireMock('expo-notifications') as {
       getPermissionsAsync: jest.Mock;
       requestPermissionsAsync: jest.Mock;
     };
+    const { Alert } = jest.requireMock('react-native') as { Alert: { alert: jest.Mock } };
 
     expoNotifications.getPermissionsAsync.mockResolvedValue({ status: 'denied' });
 
     await registerPushNotificationsAsync(setExpoPushToken, setNotificationsEnabled);
 
+    expect(Alert.alert).toHaveBeenCalled();
     expect(expoNotifications.requestPermissionsAsync).not.toHaveBeenCalled();
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('permission not granted') }),
+      { screen: 'usePushNotifications', action: 'register' },
+    );
     expect(NotificationsApi.registerExpoPushToken).not.toHaveBeenCalled();
   });
 

--- a/econoflow-mobile/src/hooks/usePushNotifications.ts
+++ b/econoflow-mobile/src/hooks/usePushNotifications.ts
@@ -1,10 +1,10 @@
 import { useState, useCallback } from 'react';
-import { Platform } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { registerExpoPushToken as apiRegister, unregisterExpoPushToken as apiUnregister } from '../api/notifications.api';
 import { useNotificationStore } from '../store/notificationStore';
-import { captureError, addBreadcrumb } from '../monitoring/sentry';
+import { captureError } from '../monitoring/sentry';
 
 export async function registerPushNotificationsAsync(
   setExpoPushToken: (t: string) => void,
@@ -13,7 +13,7 @@ export async function registerPushNotificationsAsync(
   if (!Device.isDevice) {
     // eslint-disable-next-line no-console
     console.warn('[PushNotifications] Registration skipped — not a physical device');
-    addBreadcrumb('Push registration skipped — not a physical device', 'debug');
+    captureError(new Error('Push registration skipped — not a physical device'), { screen: 'usePushNotifications', action: 'register' });
     return;
   }
 
@@ -29,7 +29,11 @@ export async function registerPushNotificationsAsync(
     if (finalStatus !== 'granted') {
       // eslint-disable-next-line no-console
       console.warn('[PushNotifications] Registration skipped — permission not granted', finalStatus);
-      addBreadcrumb('Push registration skipped — permission not granted', 'debug', { status: finalStatus });
+      captureError(new Error('Push registration skipped — permission not granted'), { screen: 'usePushNotifications', action: 'register' });
+      Alert.alert(
+        'Enable notifications',
+        'To receive push alerts, enable notifications in your device settings.',
+      );
       return;
     }
 

--- a/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
+++ b/econoflow-mobile/src/screens/profile/ProfileScreen.tsx
@@ -97,14 +97,6 @@ const SettingToggleRow: React.FC<SettingToggleRowProps> = ({
     </View>
   );
 
-  if (onPress) {
-    return (
-      <TouchableOpacity onPress={onPress} activeOpacity={0.7} testID={testID}>
-        {inner}
-      </TouchableOpacity>
-    );
-  }
-
   return <View testID={testID}>{inner}</View>;
 };
 


### PR DESCRIPTION
Fix: send push registration failures to Sentry as errors (not breadcrumbs), add Alert.alert for permission denied

Root cause: addBreadcrumb never transmits to Sentry without a subsequent error event — early returns (Device.isDevice, permission denied) were invisible.

Changes:
- Replace addBreadcrumb with captureError at both early return points so developers see these in Sentry dashboard immediately
- Add Alert.alert when push permission is denied so user gets visible feedback
- Remove addBreadcrumb import (no longer used)
- Revert SettingToggleRow TouchableOpacity to plain View (Switch onValueChange handles interaction, TouchableOpacity can interfere on Android)
- Update tests: expect captureError + Alert.alert for permission-denied paths

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
