### PR TITLE
feat: add liveness and readiness health check endpoints for Kubernetes

### DIFF
--- a/EasyFinance.Persistence/PersistenceServiceRegistration.cs
+++ b/EasyFinance.Persistence/PersistenceServiceRegistration.cs
@@ -25,9 +25,12 @@ namespace EasyFinance.Persistence
 
             services.AddDbContext<MyKeysContext>(
                 options => options.UseSqlServer(connectionString));
+#endif
 
-            services.AddHealthChecks()
-                .AddSqlServer(connectionString);
+            var healthChecksBuilder = services.AddHealthChecks();
+
+#if !DEBUG
+            healthChecksBuilder.AddSqlServer(connectionString);
 #endif
 
             services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/EasyFinance.Server.Tests/HealthChecks/S3StorageHealthCheckTests.cs
+++ b/EasyFinance.Server.Tests/HealthChecks/S3StorageHealthCheckTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyFinance.Application.Features.AttachmentService;
+using EasyFinance.Server.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+
+namespace EasyFinance.Server.Tests.HealthChecks
+{
+    public class S3StorageHealthCheckTests
+    {
+        private static HealthCheckContext CreateContext() => new();
+
+        private static IOptions<AttachmentStorageOptions> CreateOptions(
+            string provider,
+            string bucket = "test-bucket",
+            string endpoint = "localhost:9000")
+            => Options.Create(new AttachmentStorageOptions
+            {
+                Provider = provider,
+                Bucket = bucket,
+                Endpoint = endpoint,
+            });
+
+        private static IServiceProvider CreateServiceProvider(Mock<IMinioS3Client> minioClientMock) =>
+            new ServiceCollection()
+                .AddSingleton(minioClientMock.Object)
+                .BuildServiceProvider();
+
+        [Fact]
+        public async Task CheckHealth_CleanFileSystemProvider_ShouldBeHealthy()
+        {
+            // Arrange
+            var minioClientMock = new Mock<IMinioS3Client>();
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions("FileSystem"));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Healthy);
+            minioClientMock.Verify(x => x.EnsureBucketExistsAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CheckHealth_EmptyProvider_ShouldBeHealthy()
+        {
+            // Arrange
+            var minioClientMock = new Mock<IMinioS3Client>();
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions(string.Empty));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Healthy);
+            minioClientMock.Verify(x => x.EnsureBucketExistsAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CheckHealth_MinioProviderWithAvailableS3_ShouldBeHealthy()
+        {
+            // Arrange
+            var minioClientMock = new Mock<IMinioS3Client>();
+            minioClientMock
+                .Setup(x => x.EnsureBucketExistsAsync("test-bucket"))
+                .Returns(Task.CompletedTask);
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions("Minio"));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Healthy);
+            minioClientMock.Verify(x => x.EnsureBucketExistsAsync("test-bucket"), Times.Once);
+        }
+
+        [Fact]
+        public async Task CheckHealth_MinioProviderWithS3Unavailable_ShouldBeUnhealthy()
+        {
+            // Arrange
+            var minioClientMock = new Mock<IMinioS3Client>();
+            minioClientMock
+                .Setup(x => x.EnsureBucketExistsAsync(It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("S3 endpoint unreachable"));
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions("Minio"));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Unhealthy);
+            result.Exception.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task CheckHealth_MinioProviderWithoutBucket_ShouldBeUnhealthy()
+        {
+            // Arrange
+            var minioClientMock = new Mock<IMinioS3Client>();
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions("Minio", bucket: string.Empty));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Unhealthy);
+            minioClientMock.Verify(x => x.EnsureBucketExistsAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CheckHealth_UnknownProvider_ShouldBeUnhealthy()
+        {
+            // Arrange
+            var minioClientMock = new Mock<IMinioS3Client>();
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions("CustomProvider"));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Unhealthy);
+            minioClientMock.Verify(x => x.EnsureBucketExistsAsync(It.IsAny<string>()), Times.Never);
+        }
+    }
+}

--- a/EasyFinance.Server/HealthChecks/S3StorageHealthCheck.cs
+++ b/EasyFinance.Server/HealthChecks/S3StorageHealthCheck.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyFinance.Application.Features.AttachmentService;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace EasyFinance.Server.HealthChecks
+{
+    /// <summary>
+    /// Health check for S3-compatible storage (Minio). Returns Healthy when the
+    /// configured storage provider is <see cref="AttachmentStorageServiceFactory.FileSystemProvider"/>
+    /// (no external dependency) and when the S3 bucket is reachable for the Minio provider.
+    /// </summary>
+    public class S3StorageHealthCheck : IHealthCheck
+    {
+        private readonly IServiceProvider serviceProvider;
+        private readonly AttachmentStorageOptions storageOptions;
+
+        public S3StorageHealthCheck(
+            IServiceProvider serviceProvider,
+            IOptions<AttachmentStorageOptions> options)
+        {
+            this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            this.storageOptions = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            var provider = this.storageOptions.Provider;
+
+            if (string.IsNullOrWhiteSpace(provider)
+                || string.Equals(provider, AttachmentStorageServiceFactory.FileSystemProvider, StringComparison.OrdinalIgnoreCase))
+            {
+                return HealthCheckResult.Healthy("File system storage provider in use; no S3 dependency to check.");
+            }
+
+            if (string.Equals(provider, AttachmentStorageServiceFactory.MinioProvider, StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(this.storageOptions.Bucket))
+                    return HealthCheckResult.Unhealthy("S3 storage provider is configured but the bucket is not set.");
+
+                try
+                {
+                    var minioS3Client = this.serviceProvider.GetRequiredService<IMinioS3Client>();
+                    await minioS3Client.EnsureBucketExistsAsync(this.storageOptions.Bucket);
+                    return HealthCheckResult.Healthy("S3 storage is reachable.");
+                }
+                catch (Exception ex)
+                {
+                    return HealthCheckResult.Unhealthy($"S3 storage is unreachable: {ex.Message}", ex);
+                }
+            }
+
+            return HealthCheckResult.Unhealthy($"Unknown attachment storage provider '{provider}'.");
+        }
+    }
+}

--- a/EasyFinance.Server/Program.cs
+++ b/EasyFinance.Server/Program.cs
@@ -12,10 +12,12 @@ using EasyFinance.Persistence;
 using EasyFinance.Persistence.DatabaseContext;
 using EasyFinance.Server.Config;
 using EasyFinance.Server.Extensions;
+using EasyFinance.Server.HealthChecks;
 using EasyFinance.Server.Middleware;
 using EasyFinance.Server.MiddleWare;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -28,6 +30,11 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddPersistenceServices(builder.Configuration);
 builder.Services.AddApplicationServices();
+
+// Register the S3/Minio health check (readiness probe dependency).
+builder.Services.AddHealthChecks()
+    .AddCheck<S3StorageHealthCheck>("s3_storage", tags: new[] { "storage", "s3" });
+
 builder.Services.Configure<NotifierFallbackOptions>(builder.Configuration.GetSection(NotifierFallbackOptions.SectionName));
 builder.Services.Configure<WebPushOptions>(builder.Configuration.GetSection(WebPushOptions.SectionName));
 var expoPushSettings = builder.Configuration.GetSection(ExpoPushOptions.SectionName).Get<ExpoPushOptions>() ?? new ExpoPushOptions();
@@ -173,6 +180,21 @@ try
     app.UseProjectAuthorization();
 
     app.UseLocationMiddleware();
+
+    // Kubernete probes. Exposed under /api/health/* so the Angular dev-server
+    // proxy (src/proxy.conf.js) and ingress rules that forward /api/* can
+    // reach them.
+    // liveness: the process is up and can respond to HTTP requests.
+    // Predicate = _ => false means no dependency checks run; it returns Healthy
+    // whenever the process can serve requests.
+    app.MapHealthChecks("/api/health/live", new HealthCheckOptions
+    {
+        Predicate = _ => false,
+    });
+
+    // readiness: the application is ready to serve traffic only when all
+    // its dependency checks (SQL Server, S3/Minio storage) pass.
+    app.MapHealthChecks("/api/health/ready");
 
     app.MapControllers();
 

--- a/architecture.md
+++ b/architecture.md
@@ -163,14 +163,34 @@ All repositories are lazily initialized inside `UnitOfWork`. `CommitAsync()` is 
 ASP.NET Core 8 host. Everything in this layer is infrastructure for the HTTP boundary.
 
 #### Startup (`Program.cs`) — service registration order
-1. `AddPersistenceServices(configuration)` — registers DbContext, repositories, UoW.
+1. `AddPersistenceServices(configuration)` — registers DbContext, repositories, UoW, and health checks (SQL Server check in non-Debug builds).
 2. `AddApplicationServices()` — registers all application-layer services, background services, channels.
-3. Options: `NotifierFallbackOptions`, `WebPushOptions`, `FeatureRolloutOptions`, `TemporaryAttachmentCleanupOptions`.
-4. `AddAuthenticationServices(configuration, environment)` — JWT bearer, Identity, token providers.
-5. `AddControllers` with global `[Authorize]` filter.
-6. `AddSingleton<IApiService, Smtp2GoApiService>()` — e-mail dispatch.
-7. `UseSerilog()` to BetterStack.
-8. `AddDataProtection().PersistKeysToDbContext<MyKeysContext>()` (non-dev).
+3. **Health checks**: `AddHealthChecks().AddCheck<S3StorageHealthCheck>("s3_storage")` — S3/Minio dependency (readiness).
+4. Options: `NotifierFallbackOptions`, `WebPushOptions`, `FeatureRolloutOptions`, `TemporaryAttachmentCleanupOptions`.
+5. `AddAuthenticationServices(configuration, environment)` — JWT bearer, Identity, token providers.
+6. `AddControllers` with global `[Authorize]` filter.
+7. `AddSingleton<IApiService, Smtp2GoApiService>()` — e-mail dispatch.
+8. `UseSerilog()` to BetterStack.
+9. `AddDataProtection().PersistKeysToDbContext<MyKeysContext>()` (non-dev).
+
+#### Health / Kubernetes probes
+
+The server exposes two health-check endpoints consumed by Kubernetes for
+`livenessProbe` and `readinessProbe`. They are mapped under `/api/health/*`
+so they pass through the Angular dev-server proxy (`src/proxy.conf.js` for the
+`/api` context) and any ingress rule that forwards `/api/*` to the backend:
+
+| Endpoint         | Purpose                                                                 | Checks                                   |
+|------------------|-------------------------------------------------------------------------|------------------------------------------|
+| `/api/health/live`  | Liveness — returns `200 OK` as long as the process is alive and can serve HTTP requests (`Predicate = _ => false`, no dependency checks). | none            |
+| `/api/health/ready` | Readiness — returns `200 OK` only when all registered dependency checks pass, otherwise `503 Service Unavailable`. | SQL Server (`AspNetCore.HealthChecks.SqlServer`), S3/Minio storage (`S3StorageHealthCheck`). |
+
+The S3 check (`EasyFinance.Server/HealthChecks/S3StorageHealthCheck.cs`):
+- Returns **Healthy** when the configured storage provider is `FileSystem` (no external dependency).
+- For the `Minio` provider, it verifies connectivity by calling `EnsureBucketExistsAsync` on the configured bucket.
+- Returns **Unhealthy** with the exception detail when S3 is unreachable, or when the Minio bucket is not set.
+
+
 
 #### Middleware Pipeline (order matters)
 ```
@@ -186,7 +206,9 @@ ASP.NET Core 8 host. Everything in this layer is infrastructure for the HTTP bou
 10 UseAuthorization()
 11 UseProjectAuthorization()        ← role check for every {projectId} route
 12 UseLocationMiddleware()          ← sets culture from user preference
-13 MapControllers()
+13 MapHealthChecks("/api/health/live")  ← liveness; no dependency checks
+14 MapHealthChecks("/api/health/ready") ← readiness; SQL Server + S3 storage
+15 MapControllers()
 ```
 
 ---

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -75,6 +75,37 @@ The default `AttachmentStorage:Provider` is `FileSystem`, writing under the app
 base directory. The image declares `VOLUME ["/app/attachments"]` — mount a
 persistent volume there to keep uploads across restarts.
 
+## Health check probes
+
+The container exposes two HTTP endpoints for Kubernetes health probes. They
+are mapped under `/api/health/*` so they pass through the Angular dev-server
+proxy (`src/proxy.conf.js` `/api` context) and any ingress rule forwarding
+`/api/*` to the backend:
+
+| Endpoint            | Status                          | Probe type   |
+|---------------------|---------------------------------|--------------|
+| `/api/health/live`  | `200 OK` when the process is alive               | livenessProbe |
+| `/api/health/ready` | `200 OK` when SQL Server and S3/Minio are reachable; `503` otherwise | readinessProbe |
+
+Example Kubernetes probes:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /api/health/live
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /api/health/ready
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+```
+
+
 ## GitHub secrets (for the publish workflow)
 
 `.github/workflows/docker-publish.yml` runs on **push to `master`** and pushes


### PR DESCRIPTION
- Map /api/health/live (liveness: no dependency checks) and /api/health/ready (readiness: SQL Server + S3/Minio storage)
- Add S3StorageHealthCheck to verify S3/Minio bucket reachability (skips check when FileSystem provider is in use)
- Move AddHealthChecks() registration out of the Release-only block so it is always initialized; SQL Server check remains Release-only

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

Add liveness and readiness health check endpoints for Kubernetes

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #978 
- Closes #978 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
