### PR TITLE
fix: honour X-Forwarded-Proto/For from Traefik to remove 307 redirect…

### DIFF
--- a/EasyFinance.Server.Tests/ForwardedHeadersTests.cs
+++ b/EasyFinance.Server.Tests/ForwardedHeadersTests.cs
@@ -1,0 +1,226 @@
+using System.Net;
+using EasyFinance.Server.Extensions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace EasyFinance.Server.Tests
+{
+    /// <summary>
+    /// Verifies that X-Forwarded-Proto / X-Forwarded-For sent by the upstream proxy
+    /// (Traefik, TLS termination at the Ingress) are honoured only from trusted proxy
+    /// networks. This is the root cause of the 307 redirect loop behind the ingress:
+    /// without forwarded headers the app sees plain HTTP for every request and
+    /// UseHttpsRedirection answered everything (e.g. POST /api/AccessControl/register)
+    /// with a 307 to the very same HTTPS URL.
+    /// </summary>
+    public class ForwardedHeadersTests
+    {
+        private const string TrustedProxyIp = "10.42.1.5";
+        private const string ClientIp = "198.51.100.7";
+        private const string UntrustedPeerIp = "203.0.113.9";
+        private const string RegisterPath = "/api/AccessControl/register";
+
+        private static void ConfigureTrustedNetworks(ForwardedHeadersOptions options)
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            options.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("10.42.0.0"), 16));
+            options.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("10.43.0.0"), 16));
+        }
+
+        private static async Task<DefaultHttpContext> RunAsync(
+            RequestDelegate pipeline,
+            IServiceProvider services,
+            string path,
+            string scheme = "http",
+            string remoteIp = TrustedProxyIp,
+            string? xForwardedProto = null,
+            string? xForwardedFor = null)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.RequestServices = services;
+            ctx.Connection.RemoteIpAddress = IPAddress.Parse(remoteIp);
+            ctx.Request.Scheme = scheme;
+            ctx.Request.Host = new HostString("econoflow.fpssoftware.uk");
+            ctx.Request.Path = new PathString(path);
+            if (xForwardedProto != null)
+                ctx.Request.Headers["X-Forwarded-Proto"] = xForwardedProto;
+            if (xForwardedFor != null)
+                ctx.Request.Headers["X-Forwarded-For"] = xForwardedFor;
+            ctx.Response.Body = new MemoryStream();
+            await pipeline(ctx);
+            return ctx;
+        }
+
+        [Fact]
+        public void AddForwardedHeadersServices_ConfiguresProtoAndFor_AndKnownNetworks()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ForwardedHeaders:KnownNetworks:0"] = "10.42.0.0/16",
+                    ["ForwardedHeaders:KnownNetworks:1"] = "10.43.0.0/16",
+                })
+                .Build();
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+
+            services.AddForwardedHeadersServices(configuration);
+            var options = services.BuildServiceProvider()
+                .GetRequiredService<IOptions<ForwardedHeadersOptions>>().Value;
+
+            options.ForwardedHeaders.Should().HaveFlag(ForwardedHeaders.XForwardedProto);
+            options.ForwardedHeaders.Should().HaveFlag(ForwardedHeaders.XForwardedFor);
+            options.KnownIPNetworks.Should().Contain(network => network.ToString() == "10.42.0.0/16");
+            options.KnownIPNetworks.Should().Contain(network => network.ToString() == "10.43.0.0/16");
+        }
+
+        [Fact]
+        public void GetKnownNetworks_WithoutConfiguration_ShouldReturnEmpty()
+        {
+            var configuration = new ConfigurationBuilder().Build();
+
+            EasyFinance.Server.Extensions.ForwardedHeadersExtensions.GetKnownNetworks(configuration).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetKnownNetworks_WithInvalidEntries_ShouldSkipThem()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ForwardedHeaders:KnownNetworks:0"] = "not-a-network",
+                    ["ForwardedHeaders:KnownNetworks:1"] = "10.42.0.0/16",
+                })
+                .Build();
+
+            var networks = EasyFinance.Server.Extensions.ForwardedHeadersExtensions.GetKnownNetworks(configuration);
+
+            networks.Should().HaveCount(1);
+            networks.Single().PrefixLength.Should().Be(16);
+        }
+
+        [Fact]
+        public async Task TrustedProxy_WithHttpsProto_ShouldRewriteSchemeToHttps()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.Configure<ForwardedHeadersOptions>(ConfigureTrustedNetworks);
+            var provider = services.BuildServiceProvider();
+
+            var builder = new ApplicationBuilder(provider);
+            builder.UseMiddleware<ForwardedHeadersMiddleware>();
+            string? schemeAfter = null;
+            builder.Run(ctx =>
+            {
+                schemeAfter = ctx.Request.Scheme;
+                return Task.CompletedTask;
+            });
+
+            await RunAsync(builder.Build(), provider, RegisterPath, xForwardedProto: "https");
+
+            schemeAfter.Should().Be("https");
+        }
+
+        [Fact]
+        public async Task TrustedProxy_WithForwardedFor_ShouldRestoreRealClientIp()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.Configure<ForwardedHeadersOptions>(ConfigureTrustedNetworks);
+            var provider = services.BuildServiceProvider();
+
+            var builder = new ApplicationBuilder(provider);
+            builder.UseMiddleware<ForwardedHeadersMiddleware>();
+            IPAddress? remoteIpAfter = null;
+            builder.Run(ctx =>
+            {
+                remoteIpAfter = ctx.Connection.RemoteIpAddress;
+                return Task.CompletedTask;
+            });
+
+            await RunAsync(builder.Build(), provider, RegisterPath, xForwardedFor: ClientIp);
+
+            remoteIpAfter.Should().Be(IPAddress.Parse(ClientIp));
+        }
+
+        [Fact]
+        public async Task UntrustedPeer_WithHttpsProto_ShouldBeIgnored()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.Configure<ForwardedHeadersOptions>(ConfigureTrustedNetworks);
+            var provider = services.BuildServiceProvider();
+
+            var builder = new ApplicationBuilder(provider);
+            builder.UseMiddleware<ForwardedHeadersMiddleware>();
+            string? schemeAfter = null;
+            builder.Run(ctx =>
+            {
+                schemeAfter = ctx.Request.Scheme;
+                return Task.CompletedTask;
+            });
+
+            await RunAsync(builder.Build(), provider, RegisterPath, remoteIp: UntrustedPeerIp, xForwardedProto: "https");
+
+            schemeAfter.Should().Be("http");
+        }
+
+        [Fact]
+        public async Task RegisterPost_WithTrustedHttpsProto_RedirectStepSeesHttps_SoNoRedirect()
+        {
+            // HttpsRedirectionMiddleware cannot be composed with UseMiddleware<> (multiple
+            // constructors), so a stub records the scheme it observes at the redirect step —
+            // the exact input the real middleware uses to decide whether to redirect.
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.Configure<ForwardedHeadersOptions>(ConfigureTrustedNetworks);
+            var provider = services.BuildServiceProvider();
+
+            var builder = new ApplicationBuilder(provider);
+            builder.UseMiddleware<ForwardedHeadersMiddleware>();
+            string? schemeAtRedirectStep = null;
+            builder.Run(ctx =>
+            {
+                schemeAtRedirectStep = ctx.Request.Scheme;
+                return Task.CompletedTask;
+            });
+
+            await RunAsync(builder.Build(), provider, RegisterPath, xForwardedProto: "https");
+
+            schemeAtRedirectStep.Should().Be("https");
+        }
+
+        [Fact]
+        public async Task RegisterPost_PlainHttp_RedirectStepSeesHttp_SoWouldRedirect()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.Configure<ForwardedHeadersOptions>(ConfigureTrustedNetworks);
+            var provider = services.BuildServiceProvider();
+
+            var builder = new ApplicationBuilder(provider);
+            builder.UseMiddleware<ForwardedHeadersMiddleware>();
+            string? schemeAtRedirectStep = null;
+            builder.Run(ctx =>
+            {
+                schemeAtRedirectStep = ctx.Request.Scheme;
+                return Task.CompletedTask;
+            });
+
+            await RunAsync(builder.Build(), provider, RegisterPath);
+
+            schemeAtRedirectStep.Should().Be("http");
+        }
+    }
+}

--- a/EasyFinance.Server/Extensions/ForwardedHeadersExtensions.cs
+++ b/EasyFinance.Server/Extensions/ForwardedHeadersExtensions.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyFinance.Server.Extensions
+{
+    /// <summary>
+    /// Configures ASP.NET Core's Forwarded Headers middleware. External traffic is TLS-
+    /// terminated at the Traefik Ingress, so the app only ever sees plain HTTP on the
+    /// socket. Honouring X-Forwarded-Proto/X-Forwarded-For (from trusted proxies only)
+    /// lets HSTS, UseHttpsRedirection, callback/absolute-URL generation and request
+    /// logging see the real scheme and client IP instead of redirecting everything to
+    /// https in a loop.
+    /// </summary>
+    public static class ForwardedHeadersExtensions
+    {
+        /// <summary>
+        /// Registers ForwardedHeadersOptions: honour Proto+For headers and trust the
+        /// proxy networks from configuration (ForwardedHeaders:KnownNetworks).
+        /// </summary>
+        public static IServiceCollection AddForwardedHeadersServices(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                foreach (var network in GetKnownNetworks(configuration))
+                    options.KnownIPNetworks.Add(network);
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Reads ForwardedHeaders:KnownNetworks (one CIDR per item, e.g.
+        /// "10.42.0.0/16") from configuration. Invalid entries are skipped; the list is
+        /// empty when nothing is configured (no proxy is trusted).
+        /// </summary>
+        public static IReadOnlyList<System.Net.IPNetwork> GetKnownNetworks(IConfiguration configuration)
+        {
+            var networks = new List<System.Net.IPNetwork>();
+            var section = configuration.GetSection("ForwardedHeaders:KnownNetworks");
+
+            foreach (var child in section.GetChildren())
+            {
+                var value = child.Value;
+                if (string.IsNullOrWhiteSpace(value))
+                    continue;
+
+                if (System.Net.IPNetwork.TryParse(value, out var network))
+                    networks.Add(network);
+            }
+
+            return networks;
+        }
+    }
+}

--- a/EasyFinance.Server/Program.cs
+++ b/EasyFinance.Server/Program.cs
@@ -18,6 +18,7 @@ using EasyFinance.Server.MiddleWare;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -30,6 +31,11 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddPersistenceServices(builder.Configuration);
 builder.Services.AddApplicationServices();
+
+// Honour X-Forwarded-Proto/X-Forwarded-For from the upstream Traefik Ingress
+// (TLS termination) so HSTS, UseHttpsRedirection, callback URLs and logging
+// see the real scheme and client IP instead of a 307 loop back to the same URL.
+builder.Services.AddForwardedHeadersServices(builder.Configuration);
 
 // Register the S3/Minio health check (readiness probe dependency).
 builder.Services.AddHealthChecks()
@@ -149,6 +155,7 @@ async Task EnsureSystemRolesAsync(IServiceProvider services)
 try
 {
     var app = builder.Build();
+    app.UseForwardedHeaders();
     app.UseSerilogRequestLogging();
     app.UseCustomExceptionHandler();
 

--- a/EasyFinance.Server/appsettings.json
+++ b/EasyFinance.Server/appsettings.json
@@ -6,6 +6,11 @@
     }
   },
   "AllowedHosts": "*",
+  "ForwardedHeaders": {
+    "KnownNetworks": [
+      "10.42.0.0/16"
+    ]
+  },
   "Turnstile": {
     "SiteKey": "",
     "SecretKey": ""

--- a/architecture.md
+++ b/architecture.md
@@ -198,26 +198,50 @@ The S3 check (`EasyFinance.Server/HealthChecks/S3StorageHealthCheck.cs`):
 - For the `Minio` provider, it verifies connectivity by calling `EnsureBucketExistsAsync` on the configured bucket.
 - Returns **Unhealthy** with the exception detail when S3 is unreachable, or when the Minio bucket is not set.
 
+### Forwarded headers (proxy behind Traefik)
+
+TLS is terminated at the Traefik Ingress and the container listens on plain HTTP, so
+without extra configuration the app would treat every request as `http`. That breaks
+HSTS, `UseHttpsRedirection` (307 loops for API POSTs such as `/api/AccessControl/register`),
+callback/absolute-URL generation (`Request.Scheme`) and client-IP logging.
+
+`app.UseForwardedHeaders()` runs **first** in the pipeline and honours
+`X-Forwarded-Proto` / `X-Forwarded-For` **only from a trusted proxy network** (spoofing
+protection). Trusted networks come from `ForwardedHeaders:KnownNetworks` in
+`appsettings.json`/env (`ForwardedHeaders__KnownNetworks__0=…`), defaulting to the k3s
+pod CIDR `10.42.0.0/16` (the loopback `127.0.0.0/8` is always trusted by the
+framework). Configuration lives in
+`EasyFinance.Server/Extensions/ForwardedHeadersExtensions.cs`.
+
+> **Why the health-probe bypass above is still needed.** The two mechanisms cover
+> different traffic. Kubelet liveness/readiness probes hit the pod IP directly — they
+> carry no `X-Forwarded-*` headers and their source is **not** in the trusted network,
+> so `UseForwardedHeaders` leaves them as `http` and, without the `MapWhen` bypass,
+> `UseHttpsRedirection` would 307 them again. Forwarded headers fix *external* traffic
+> routed through Traefik; the probe bypass fixes *direct-to-pod* kubelet probes. Both
+> are required.
+
 
 
 #### Middleware Pipeline (order matters)
 ```
-1  UseSerilogRequestLogging()
-2  UseCustomExceptionHandler()      ← catches unhandled exceptions → 500
-3  UseSafeHeaders()                 ← security headers (HSTS, CSP, …)
-4  UseSwagger/UseSwaggerUI          ← dev only
-5  UseMigration()                   ← auto-apply EF migrations on startup (prod only)
-6  UseDefaultFiles() + UseStaticFiles()
-7  MapWhen(IsHealthProbePath && !https) → HealthProbeResponseWriter   ← answers probes over plain HTTP so UseHttpsRedirection cannot 307 them
-8  UseHttpsRedirection()
-9  UseAuthentication()
-10 UseCorrelationId()               ← sets/reads X-Correlation-Id header
-11 UseAuthorization()
-12 UseProjectAuthorization()        ← role check for every {projectId} route
-13 UseLocationMiddleware()          ← sets culture from user preference
-14 MapHealthChecks("/api/health/live")  ← liveness; no dependency checks
-15 MapHealthChecks("/api/health/ready") ← readiness; SQL Server + S3 storage
-16 MapControllers()
+1  UseForwardedHeaders()            ← honour X-Forwarded-Proto/For from trusted proxies FIRST so all later middleware see the real scheme/IP
+2  UseSerilogRequestLogging()
+3  UseCustomExceptionHandler()      ← catches unhandled exceptions → 500
+4  UseSafeHeaders()                 ← security headers (HSTS, CSP, …)
+5  UseSwagger/UseSwaggerUI          ← dev only
+6  UseMigration()                   ← auto-apply EF migrations on startup (prod only)
+7  UseDefaultFiles() + UseStaticFiles()
+8  MapWhen(IsHealthProbePath && !https) → HealthProbeResponseWriter   ← answers probes over plain HTTP so UseHttpsRedirection cannot 307 them
+9  UseHttpsRedirection()
+10 UseAuthentication()
+11 UseCorrelationId()               ← sets/reads X-Correlation-Id header
+12 UseAuthorization()
+13 UseProjectAuthorization()        ← role check for every {projectId} route
+14 UseLocationMiddleware()          ← sets culture from user preference
+15 MapHealthChecks("/api/health/live")  ← liveness; no dependency checks
+16 MapHealthChecks("/api/health/ready") ← readiness; SQL Server + S3 storage
+17 MapControllers()
 ```
 
 ---

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -95,6 +95,17 @@ answering these probes with a `307` (which would keep the container permanently
 redirect middleware runs. The recognised probe paths live in
 `HealthCheckPathPolicy` (`/api/health/live`, `/api/health/ready`).
 
+For all non-probe traffic, the app honours the proxied scheme via
+`UseForwardedHeaders` (runs first). It trusts `X-Forwarded-Proto`/`X-Forwarded-For`
+only from the networks in `ForwardedHeaders:KnownNetworks`
+(default `10.42.0.0/16`, the k3s pod CIDR; override with
+`ForwardedHeaders__KnownNetworks__0=…` env vars when the cluster uses different
+CIDRs or the proxy runs with `hostNetwork`). This makes HSTS, HTTPS redirects for
+direct HTTP access, callback URLs and client-IP logging behave correctly behind
+Traefik. The health-probe bypass above remains necessary: kubelet probes reach the
+pod directly without forwarded headers and from an untrusted source, so they would
+otherwise still be 307-redirected by `UseHttpsRedirection`.
+
 Example Kubernetes probes:
 
 ```yaml


### PR DESCRIPTION
… loop

TLS is terminated at the Traefik Ingress, so the container sees plain HTTP for every request. Without forwarded headers, UseHttpsRedirection answered all non-probe requests (e.g. POST /api/AccessControl/register) with a 307 to the very same HTTPS URL — a redirect loop.

Register UseForwardedHeaders as the FIRST middleware, trusting X-Forwarded- Proto/For only from the configured known networks (default 10.42.0.0/16, overridable via ForwardedHeaders__KnownNetworks__* env vars). This makes HSTS, HTTPS redirects, callback URLs and client-IP logging see the real scheme/IP. The existing health-probe MapWhen bypass remains: kubelet probes hit the pod directly (no forwarded headers, untrusted source) and would otherwise still be 307-redirected.

Tests: ForwardedHeadersTests covers trusted rewrite, spoofing rejection, register-POST scheme observation, and KnownNetworks config parsing.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
