### PR TITLE
Log only API traffic in request logs; silence health probes and root

### DIFF
--- a/EasyFinance.Server.Tests/RequestLoggingPathPolicyTests.cs
+++ b/EasyFinance.Server.Tests/RequestLoggingPathPolicyTests.cs
@@ -1,0 +1,126 @@
+using System;
+using EasyFinance.Server.HealthChecks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Serilog.Events;
+
+namespace EasyFinance.Server.Tests
+{
+    /// <summary>
+    /// Verifies which request paths are excluded from the Serilog request-completion
+    /// log. Only real /api traffic is logged: health-probe endpoints and every
+    /// non-API path (root, static assets, Swagger) are filtered out.
+    /// </summary>
+    public class RequestLoggingPathPolicyTests
+    {
+        [Theory]
+        [InlineData("/")]
+        [InlineData("/favicon.ico")]
+        [InlineData("/assets/version.json")]
+        [InlineData("/swagger/index.html")]
+        [InlineData("")]
+        public void GetLevel_NonApiPaths_ShouldReturnVerbose(string path)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString(path);
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: null);
+
+            level.Should().Be(LogEventLevel.Verbose);
+        }
+
+        [Theory]
+        [InlineData("/api/health/live")]
+        [InlineData("/api/health/ready")]
+        [InlineData("/API/health/live")]
+        public void GetLevel_HealthProbes_ShouldReturnVerbose_DespiteBeingApi(string path)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString(path);
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: null);
+
+            level.Should().Be(LogEventLevel.Verbose);
+        }
+
+        [Theory]
+        [InlineData("/api/projects")]
+        [InlineData("/api/expenses")]
+        [InlineData("/api/health/other")]
+        public void GetLevel_ApiPaths_ShouldReturnInformation(string path)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString(path);
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: null);
+
+            level.Should().Be(LogEventLevel.Information);
+        }
+
+        [Theory]
+        [InlineData("/Push")]
+        [InlineData("/push/public-key")]
+        [InlineData("/PUSH/register")]
+        public void GetLevel_PushControllerRoutes_ShouldReturnInformation(string path)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString(path);
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: null);
+
+            level.Should().Be(LogEventLevel.Information);
+        }
+
+        [Theory]
+        [InlineData("/apixxx/whatever")]
+        [InlineData("/apitemp")]
+        [InlineData("/pushkin")]
+        public void GetLevel_MisleadingPrefixes_ShouldReturnVerbose(string path)
+        {
+            // Only actual api/push path segments count, not lookalike prefixes.
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString(path);
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: null);
+
+            level.Should().Be(LogEventLevel.Verbose);
+        }
+
+        [Fact]
+        public void GetLevel_ApiPathWithErrorStatus_ShouldReturnError()
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString("/api/projects");
+            ctx.Response.StatusCode = 500;
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: null);
+
+            level.Should().Be(LogEventLevel.Error);
+        }
+
+        [Fact]
+        public void GetLevel_ApiPathWithException_ShouldReturnError()
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString("/api/projects");
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: new Exception("boom"));
+
+            level.Should().Be(LogEventLevel.Error);
+        }
+
+        [Fact]
+        public void GetLevel_HealthProbeWithErrorStatus_ShouldRemainVerbose()
+        {
+            // Health endpoints and other excluded paths should never surface in the
+            // request logs, even when they return an error status.
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString("/api/health/ready");
+            ctx.Response.StatusCode = 503;
+
+            var level = RequestLoggingPathPolicy.GetLevel(ctx, elapsedMs: 1, ex: null);
+
+            level.Should().Be(LogEventLevel.Verbose);
+        }
+    }
+}

--- a/EasyFinance.Server/HealthChecks/RequestLoggingPathPolicy.cs
+++ b/EasyFinance.Server/HealthChecks/RequestLoggingPathPolicy.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Http;
+using Serilog.Events;
+
+namespace EasyFinance.Server.HealthChecks
+{
+    /// <summary>
+    /// Centralises which request paths are surfaced in the Serilog
+    /// request-completion log. Only real API traffic is logged: any path under
+    /// <c>/api</c> (plus the <c>PushController</c>'s secondary <c>/push</c> route)
+    /// other than the Kubernetes health probes. Everything else — static
+    /// downloads, Swagger, the SPA root — adds noise and stays silent.
+    /// </summary>
+    public static class RequestLoggingPathPolicy
+    {
+        /// <summary>
+        /// Returns the Serilog level at which the request-completion event is
+        /// emitted. Non-API paths and the health probes are dropped to
+        /// <see cref="LogEventLevel.Verbose"/>, which is below the configured
+        /// minimum level, so they are never written. API paths keep Serilog's
+        /// default behaviour (Information, or Error for failed requests).
+        /// </summary>
+        public static LogEventLevel GetLevel(HttpContext httpContext, double elapsedMs, Exception? ex)
+        {
+            if (ShouldExclude(httpContext.Request.Path))
+                return LogEventLevel.Verbose;
+
+            if (ex != null || httpContext.Response.StatusCode > 499)
+                return LogEventLevel.Error;
+
+            return LogEventLevel.Information;
+        }
+
+        /// <summary>
+        /// Returns true for requests that should not appear in the logs: the
+        /// health probes and anything that is not API traffic.
+        /// </summary>
+        public static bool ShouldExclude(PathString path)
+        {
+            if (!path.HasValue)
+                return true;
+
+            var value = path.Value ?? string.Empty;
+
+            // Only real API traffic is of interest; the probes are API-shaped but
+            // silent, everything else (root, static assets, Swagger) is excluded.
+            // /push is the PushController's secondary non-/api route.
+            return HealthCheckPathPolicy.IsHealthProbePath(path)
+                || !(IsApiPath(value) || IsPushPath(value));
+        }
+
+        private static bool IsApiPath(string value) =>
+            value.StartsWith("/api", StringComparison.OrdinalIgnoreCase)
+            && (value.Length == 4 || value[4] == '/');
+
+        private static bool IsPushPath(string value) =>
+            value.StartsWith("/push", StringComparison.OrdinalIgnoreCase)
+            && (value.Length == 5 || value[5] == '/');
+    }
+}

--- a/EasyFinance.Server/Program.cs
+++ b/EasyFinance.Server/Program.cs
@@ -156,7 +156,10 @@ try
 {
     var app = builder.Build();
     app.UseForwardedHeaders();
-    app.UseSerilogRequestLogging();
+    // Log only real API traffic in the request-completion log, keeping health
+    // probes, root, and static/Swagger noise silent (see RequestLoggingPathPolicy).
+    app.UseSerilogRequestLogging(options =>
+        options.GetLevel = RequestLoggingPathPolicy.GetLevel);
     app.UseCustomExceptionHandler();
 
     app.UseSafeHeaders();


### PR DESCRIPTION
Filter Serilog request-completion logging to real API paths (/api/* and the PushController's /push route), dropping health probes, root, and static/Swagger noise. Adds RequestLoggingPathPolicy wired into UseSerilogRequestLogging via GetLevel.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
