### PR TITLE
feat: add log level and rendered message to console/file JSON logs

### DIFF
--- a/EasyFinance.Server.Tests/Logging/JsonLogFormatterTests.cs
+++ b/EasyFinance.Server.Tests/Logging/JsonLogFormatterTests.cs
@@ -1,0 +1,183 @@
+using System.Text.Json;
+using EasyFinance.Server.Logging;
+using FluentAssertions;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace EasyFinance.Server.Tests.Logging;
+
+/// <summary>
+/// Verifies the console/file JSON formatter used on Kubernetes keeps the
+/// log level and the fully rendered message in every event, so Grafana can
+/// filter on the level and display a readable message without re-rendering
+/// the message template.
+/// </summary>
+public class JsonLogFormatterTests
+{
+    private static readonly EconoFlowJsonFormatter Formatter = new();
+
+    private static LogEvent CreateEvent(
+        LogEventLevel level,
+        string template,
+        Exception? exception = null,
+        params KeyValuePair<string, LogEventPropertyValue>[] properties)
+        => new(DateTimeOffset.UtcNow, level, exception, new MessageTemplateParser().Parse(template),
+            properties.Select(p => new LogEventProperty(p.Key, p.Value)));
+
+    private static string Format(LogEvent logEvent)
+    {
+        using var output = new StringWriter();
+        Formatter.Format(logEvent, output);
+        return output.ToString();
+    }
+
+    [Theory]
+    [InlineData(LogEventLevel.Verbose, "verbose")]
+    [InlineData(LogEventLevel.Debug, "debug")]
+    [InlineData(LogEventLevel.Information, "information")]
+    [InlineData(LogEventLevel.Warning, "warning")]
+    [InlineData(LogEventLevel.Error, "error")]
+    [InlineData(LogEventLevel.Fatal, "fatal")]
+    public void Format_AlwaysWritesLevel_EvenForInformation(LogEventLevel level, string expectedLevel)
+    {
+        var output = Format(CreateEvent(level, "Request completed"));
+
+        using var document = JsonDocument.Parse(output);
+        document.RootElement.GetProperty("@l").GetString().Should().Be(expectedLevel);
+    }
+
+    [Fact]
+    public void Format_WritesRenderedMessageAlongsideTemplate()
+    {
+        const string template = "HTTP {RequestMethod} {RequestPath} responded {StatusCode}";
+        var logEvent = CreateEvent(
+            LogEventLevel.Information,
+            template,
+            properties:
+            [
+                new("RequestMethod", new ScalarValue("GET")),
+                new("RequestPath", new ScalarValue("/api/Account/Notifications")),
+                new("StatusCode", new ScalarValue(200)),
+            ]);
+
+        var output = Format(logEvent);
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+
+        root.GetProperty("@mt").GetString().Should().Be(template);
+        root.GetProperty("@m").GetString().Should().Be("HTTP \"GET\" \"/api/Account/Notifications\" responded 200");
+    }
+
+    [Fact]
+    public void Format_WritesEnrichedPropertiesAndTimestamp()
+    {
+        var logEvent = CreateEvent(
+            LogEventLevel.Warning,
+            "Something happened",
+            properties:
+            [
+                new("CorrelationId", new ScalarValue("19986c2b-1e63-4dd3-8d25-6a3029b2adcf")),
+                new("Application", new ScalarValue("EconoFlow")),
+            ]);
+
+        var output = Format(logEvent);
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+
+        root.GetProperty("CorrelationId").GetString().Should().Be("19986c2b-1e63-4dd3-8d25-6a3029b2adcf");
+        root.GetProperty("Application").GetString().Should().Be("EconoFlow");
+        root.TryGetProperty("@t", out var timestamp).Should().BeTrue();
+        timestamp.GetDateTimeOffset().Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void Format_WritesFormattedRenderingsForTemplatesWithFormatTokens()
+    {
+        const string template = "Responded in {Elapsed:0.0000} ms";
+        var logEvent = CreateEvent(
+            LogEventLevel.Information,
+            template,
+            properties: [new("Elapsed", new ScalarValue(11.928291))]);
+
+        var output = Format(logEvent);
+        using var document = JsonDocument.Parse(output);
+
+        document.RootElement.GetProperty("@r")[0].GetString().Should().Be("11.9283");
+        document.RootElement.GetProperty("@m").GetString().Should().Be("Responded in 11.9283 ms");
+    }
+
+    [Fact]
+    public void Format_WritesExceptionDetail()
+    {
+        var logEvent = CreateEvent(LogEventLevel.Error, "Boom", exception: new InvalidOperationException("kaboom"));
+
+        var output = Format(logEvent);
+        using var document = JsonDocument.Parse(output);
+
+        document.RootElement.GetProperty("@x").GetString().Should().Contain("kaboom");
+    }
+
+    [Fact]
+    public void Format_EmitsOneSelfContainedJsonLine()
+    {
+        var output = Format(CreateEvent(LogEventLevel.Information, "Message"));
+
+        output.TrimEnd('\r', '\n').Split('\n').Should().ContainSingle();
+        using var document = JsonDocument.Parse(output); // would throw if the line is not valid JSON
+        document.RootElement.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public void Format_WritesTypedScalarProperties()
+    {
+        var logEvent = CreateEvent(
+            LogEventLevel.Information,
+            "Payload",
+            properties:
+            [
+                new("StatusCode", new ScalarValue(200)),
+                new("Succeeded", new ScalarValue(true)),
+                new("Amount", new ScalarValue(11.928291)),
+            ]);
+
+        var output = Format(logEvent);
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+
+        root.GetProperty("StatusCode").ValueKind.Should().Be(JsonValueKind.Number);
+        root.GetProperty("StatusCode").GetInt32().Should().Be(200);
+        root.GetProperty("Succeeded").ValueKind.Should().Be(JsonValueKind.True);
+        root.GetProperty("Amount").ValueKind.Should().Be(JsonValueKind.Number);
+    }
+
+    [Fact]
+    public void Format_WritesNullScalarAsJsonNull()
+    {
+        var logEvent = CreateEvent(
+            LogEventLevel.Information,
+            "Payload",
+            properties: [new("NullableValue", new ScalarValue(null))]);
+
+        using var document = JsonDocument.Parse(Format(logEvent));
+        document.RootElement.GetProperty("NullableValue").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void Format_WritesNonFiniteDoubleAsString_InsteadOfThrowing()
+    {
+        var nan = CreateEvent(
+            LogEventLevel.Information,
+            "Payload",
+            properties: [new("Ratio", new ScalarValue(double.NaN))]);
+        var infinity = CreateEvent(
+            LogEventLevel.Information,
+            "Payload",
+            properties: [new("Ratio", new ScalarValue(double.PositiveInfinity))]);
+
+        using var nanDocument = JsonDocument.Parse(Format(nan));
+        nanDocument.RootElement.GetProperty("Ratio").ValueKind.Should().Be(JsonValueKind.String);
+
+        using var infinityDocument = JsonDocument.Parse(Format(infinity));
+        infinityDocument.RootElement.GetProperty("Ratio").ValueKind.Should().Be(JsonValueKind.String);
+    }
+}

--- a/EasyFinance.Server/Logging/EconoFlowJsonFormatter.cs
+++ b/EasyFinance.Server/Logging/EconoFlowJsonFormatter.cs
@@ -1,0 +1,190 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Parsing;
+
+namespace EasyFinance.Server.Logging;
+
+/// <summary>
+/// Compact JSON (CLEF-style) formatter for the console and file sinks that
+/// always writes the log level (<c>@l</c>) and the fully rendered message
+/// (<c>@m</c>) alongside the message template (<c>@mt</c>). The stock
+/// <c>CompactJsonFormatter</c> drops both, which hides the level and forces
+/// Grafana to re-render templates by hand. Otherwise the shape matches the
+/// stock compact format (timestamp, renderings, exception, trace/span ids,
+/// enriched properties) so existing log consumers keep working.
+/// </summary>
+public sealed class EconoFlowJsonFormatter : ITextFormatter
+{
+    /// <inheritdoc />
+    public void Format(LogEvent logEvent, TextWriter output)
+    {
+        using var stream = new MemoryStream();
+        using (var buffer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Indented = false,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        }))
+        {
+            buffer.WriteStartObject();
+
+            buffer.WriteString("@t", logEvent.Timestamp.UtcDateTime.ToString("O", CultureInfo.InvariantCulture));
+            buffer.WriteString("@l", logEvent.Level.ToString().ToLowerInvariant());
+            buffer.WriteString("@mt", logEvent.MessageTemplate.Text);
+
+            var tokensWithFormat = logEvent.MessageTemplate.Tokens
+                .OfType<PropertyToken>()
+                .Where(token => token.Format != null)
+                .ToList();
+
+            if (tokensWithFormat.Count > 0)
+            {
+                buffer.WriteStartArray("@r");
+                foreach (var token in tokensWithFormat)
+                {
+                    var rendering = new StringWriter(CultureInfo.InvariantCulture);
+                    token.Render(logEvent.Properties, rendering);
+                    buffer.WriteStringValue(rendering.ToString());
+                }
+                buffer.WriteEndArray();
+            }
+
+            buffer.WriteString("@m", logEvent.RenderMessage(CultureInfo.InvariantCulture));
+
+            if (logEvent.Exception is not null)
+                buffer.WriteString("@x", logEvent.Exception.ToString());
+
+            if (logEvent.TraceId is not null)
+                buffer.WriteString("@tr", logEvent.TraceId.Value.ToString());
+
+            if (logEvent.SpanId is not null)
+                buffer.WriteString("@sp", logEvent.SpanId.Value.ToString());
+
+            foreach (var property in logEvent.Properties)
+            {
+                if (property.Key.StartsWith('@'))
+                    continue;
+
+                buffer.WritePropertyName(property.Key);
+                WriteValue(buffer, property.Value);
+            }
+
+            buffer.WriteEndObject();
+        }
+
+        output.WriteLine(Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    private static void WriteValue(Utf8JsonWriter writer, LogEventPropertyValue value)
+    {
+        switch (value)
+        {
+            case ScalarValue scalar:
+                if (scalar.Value is null)
+                {
+                    writer.WriteNullValue();
+                }
+                else if (scalar.Value is bool b)
+                {
+                    writer.WriteBooleanValue(b);
+                }
+                else if (scalar.Value is byte byteValue)
+                {
+                    writer.WriteNumberValue(byteValue);
+                }
+                else if (scalar.Value is sbyte sbyteValue)
+                {
+                    writer.WriteNumberValue(sbyteValue);
+                }
+                else if (scalar.Value is short shortValue)
+                {
+                    writer.WriteNumberValue(shortValue);
+                }
+                else if (scalar.Value is ushort ushortValue)
+                {
+                    writer.WriteNumberValue(ushortValue);
+                }
+                else if (scalar.Value is int intValue)
+                {
+                    writer.WriteNumberValue(intValue);
+                }
+                else if (scalar.Value is uint uintValue)
+                {
+                    writer.WriteNumberValue(uintValue);
+                }
+                else if (scalar.Value is long longValue)
+                {
+                    writer.WriteNumberValue(longValue);
+                }
+                else if (scalar.Value is ulong ulongValue)
+                {
+                    writer.WriteNumberValue(ulongValue);
+                }
+                else if (scalar.Value is float floatValue)
+                {
+                    if (float.IsFinite(floatValue))
+                        writer.WriteNumberValue(floatValue);
+                    else
+                        writer.WriteStringValue(floatValue.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (scalar.Value is double doubleValue)
+                {
+                    if (double.IsFinite(doubleValue))
+                        writer.WriteNumberValue(doubleValue);
+                    else
+                        writer.WriteStringValue(doubleValue.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (scalar.Value is decimal decimalValue)
+                {
+                    writer.WriteNumberValue(decimalValue);
+                }
+                else if (scalar.Value is DateTime dt)
+                {
+                    writer.WriteStringValue(dt);
+                }
+                else if (scalar.Value is DateTimeOffset dto)
+                {
+                    writer.WriteStringValue(dto);
+                }
+                else
+                {
+                    writer.WriteStringValue(scalar.Value.ToString() ?? string.Empty);
+                }
+                break;
+
+            case SequenceValue sequence:
+                writer.WriteStartArray();
+                foreach (var element in sequence.Elements)
+                    WriteValue(writer, element);
+                writer.WriteEndArray();
+                break;
+
+            case StructureValue structure:
+                writer.WriteStartObject();
+                foreach (var member in structure.Properties)
+                {
+                    writer.WritePropertyName(member.Name);
+                    WriteValue(writer, member.Value);
+                }
+                writer.WriteEndObject();
+                break;
+
+            case DictionaryValue dictionary:
+                writer.WriteStartObject();
+                foreach (var entry in dictionary.Elements)
+                {
+                    writer.WritePropertyName(entry.Key.Value?.ToString() ?? string.Empty);
+                    WriteValue(writer, entry.Value);
+                }
+                writer.WriteEndObject();
+                break;
+
+            default:
+                writer.WriteStringValue(value.ToString() ?? string.Empty);
+                break;
+        }
+    }
+}

--- a/EasyFinance.Server/appsettings.json
+++ b/EasyFinance.Server/appsettings.json
@@ -78,7 +78,7 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+          "formatter": "EasyFinance.Server.Logging.EconoFlowJsonFormatter, EasyFinance.Server"
         }
       },
       {
@@ -87,7 +87,7 @@
           "path": "logs/log-.txt",
           "rollingInterval": "Day",
           "rollOnFileSizeLimit": true,
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+          "formatter": "EasyFinance.Server.Logging.EconoFlowJsonFormatter, EasyFinance.Server"
         }
       },
       {

--- a/architecture.md
+++ b/architecture.md
@@ -721,6 +721,7 @@ Variables marked **required** will throw at startup (or on first use) if absent.
 | `AttachmentStorage:Migration.BatchSize` | `500` | Attachments processed per migration run |
 | `FeatureRollout.EnabledForAllUsers` | `"WebPush"` | Feature flags available to everyone |
 | `FeatureRollout.EnabledForBetaTesters` | `"WebPush, PwaInstall"` | Additional flags for beta testers |
+| `Serilog:WriteTo[:Console/File].Args.formatter` | `EasyFinance.Server.Logging.EconoFlowJsonFormatter` | Console/File sinks use `EconoFlowJsonFormatter` (compact CLEF-like JSON) — it always writes the level (`@l`) and the fully rendered message (`@m`) beside the template (`@mt`) so log level and readable messages survive in Grafana. The stock `CompactJsonFormatter` drops both. |
 
 ---
 


### PR DESCRIPTION
Replace the stock CompactJsonFormatter on the Console and File Serilog sinks with EconoFlowJsonFormatter, which always writes the level (@l) and the fully rendered message (@m) alongside the message template (@mt). The stock formatter drops both, losing the level on Kubernetes and forcing Grafana to re-render templates by hand. Typed scalars (numbers/bools), nulls, non-finite floats, and CLEF fields (@t/@r/@x/@tr/@sp) are preserved for existing log consumers.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

Improved logs to kubernetes

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
