### PR TITLE
refactor(#985): migrate auth middleware to generic AddChassisJwtBearer

### DIFF
--- a/EasyFinance.Common.Tests/EasyFinance.Common.Tests.csproj
+++ b/EasyFinance.Common.Tests/EasyFinance.Common.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="fpssoftware.chassis" Version="1.0.1" />
+    <PackageReference Include="fpssoftware.chassis" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.11" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />

--- a/EasyFinance.Common.Tests/TokenFactory.cs
+++ b/EasyFinance.Common.Tests/TokenFactory.cs
@@ -8,7 +8,7 @@ namespace EasyFinance.Common.Tests
 {
     public static class TokenFactory
     {
-        public static string CreateAccessToken(JwtTokenSettings settings, User user, IReadOnlyCollection<Claim> extraClaims = null)
+        public static string CreateAccessToken(JwtTokenSettings settings, User user, IReadOnlyCollection<Claim>? extraClaims = null)
         {
             var claims = new List<Claim>
             {

--- a/EasyFinance.Infrastructure/EasyFinance.Infrastructure.csproj
+++ b/EasyFinance.Infrastructure/EasyFinance.Infrastructure.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="fpssoftware.chassis" Version="1.0.1" />
+    <PackageReference Include="fpssoftware.chassis" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyFinance.Server/MiddleWare/AuthenticationMiddleware.cs
+++ b/EasyFinance.Server/MiddleWare/AuthenticationMiddleware.cs
@@ -1,11 +1,9 @@
-using System.Text;
 using EasyFinance.Domain.AccessControl;
 using EasyFinance.Persistence.DatabaseContext;
 using EasyFinance.Server.Extensions;
 using FpsSoftware.Chassis;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EasyFinance.Server.Middleware
 {
@@ -18,12 +16,13 @@ namespace EasyFinance.Server.Middleware
             tokenSettings.SecretKey = environment.IsDevelopment() ? "TestEnvironmentKeyNotUseInProduction" : Environment.GetEnvironmentVariable("EconoFlow_TOKEN_SECRET_KEY") ?? tokenSettings.SecretKey;
             tokenSettings.Issuer = Environment.GetEnvironmentVariable("EconoFlow_ISSUER") ?? tokenSettings.Issuer;
             tokenSettings.Audience = Environment.GetEnvironmentVariable("EconoFlow_AUDIENCE") ?? tokenSettings.Audience;
-            services.AddSingleton(tokenSettings);
 
+            // Application-specific Identity wiring stays in EconoFlow (user type, stores,
+            // roles, claims factory, API endpoints are business/domain concerns).
             services.AddAuthorizationBuilder();
             services.AddHttpContextAccessor();
 
-            services.AddIdentityCore<User>()
+            var identityBuilder = services.AddIdentityCore<User>()
                 .AddSignInManager()
                 .AddRoles<IdentityRole<Guid>>()
                 .AddEntityFrameworkStores<EasyFinanceDatabaseContext>()
@@ -57,44 +56,8 @@ namespace EasyFinance.Server.Middleware
                 options.TokenLifespan = TimeSpan.FromSeconds(tokenSettings.RefreshTokenExpireSeconds);
             });
 
-            services
-                .AddAuthentication(config =>
-                {
-                    config.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-                    config.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-                    config.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
-                })
-                .AddJwtBearer(config =>
-                {
-                    config.RequireHttpsMetadata = true;
-                    config.SaveToken = true;
-                    config.TokenValidationParameters = new TokenValidationParameters
-                    {
-                        ValidateIssuerSigningKey = true,
-                        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(tokenSettings.SecretKey)),
-                        ValidateIssuer = !string.IsNullOrEmpty(tokenSettings.Issuer),
-                        ValidIssuer = tokenSettings.Issuer,
-                        ValidateAudience = !string.IsNullOrEmpty(tokenSettings.Audience),
-                        ValidAudience = tokenSettings.Audience,
-                        ClockSkew = TimeSpan.Zero
-                    };
-                    config.Events = new JwtBearerEvents
-                    {
-                        OnMessageReceived = context =>
-                        {
-                            // Check if token comes from Authorization header
-                            var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
-                            if (!string.IsNullOrEmpty(authHeader) && authHeader.StartsWith("Bearer "))
-                                context.Token = authHeader.Substring("Bearer ".Length).Trim();
-                            // Fallback: get token from cookie
-                            else if (context.Request.Cookies.ContainsKey("AuthToken"))
-                                context.Token = context.Request.Cookies["AuthToken"];
-
-                            return Task.CompletedTask;
-                        }
-                    };
-
-                });
+            // Generic JWT bearer setup comes from the fpssoftware.chassis package.
+            services.AddChassisJwtBearer(tokenSettings, accessTokenCookieName: "AuthToken");
 
             return services;
         }


### PR DESCRIPTION
EconoFlow's AuthenticationMiddleware keeps its app-specific Identity wiring (User type, roles, EF stores, claims factory, API endpoints, IdentityOptions) and delegates the generic JWT bearer setup to `AddChassisJwtBearer` from `fpssoftware.chassis 1.1.0`.

- Chassis 1.1.0 adds `AddChassisJwtBearer(JwtTokenSettings, accessTokenCookieName?, configureJwtBearer?)`
- EconoFlow passes `AuthToken` cookie fallback; env-var token overrides stay in EconoFlow
- 63 auth-related Server tests pass; EconoFlow builds with 0 errors