### PR TITLE
fix: restore SPA rendering after chassis security-policy migration

### DIFF
--- a/EasyFinance.Common.Tests/EasyFinance.Common.Tests.csproj
+++ b/EasyFinance.Common.Tests/EasyFinance.Common.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="fpssoftware.chassis" Version="1.1.0" />
+    <PackageReference Include="fpssoftware.chassis" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.11" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />

--- a/EasyFinance.Infrastructure/EasyFinance.Infrastructure.csproj
+++ b/EasyFinance.Infrastructure/EasyFinance.Infrastructure.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="fpssoftware.chassis" Version="1.1.0" />
+    <PackageReference Include="fpssoftware.chassis" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyFinance.Server.Tests/Config/SecurityPolicyOptionsFactoryTests.cs
+++ b/EasyFinance.Server.Tests/Config/SecurityPolicyOptionsFactoryTests.cs
@@ -1,0 +1,57 @@
+using EasyFinance.Server.Config;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+using Moq;
+
+namespace EasyFinance.Server.Tests.Config;
+
+public class SecurityPolicyOptionsFactoryTests
+{
+    [Fact]
+    public void Create_ShouldSetFullCsp()
+    {
+        var environment = Mock.Of<IWebHostEnvironment>();
+
+        var options = SecurityPolicyOptionsFactory.Create(environment);
+
+        options.CspValue.Should().Contain("default-src 'self'");
+        options.CspValue.Should().Contain("'nonce-{{nonce}}'");
+        options.CspValue.Should().Contain("https://challenges.cloudflare.com");
+        options.CspValue.Should().Contain("https://fonts.googleapis.com");
+        options.CspValue.Should().Contain("https://fonts.gstatic.com");
+        options.CspValue.Should().Contain("frame-ancestors 'none'");
+        options.CspValue.Should().Contain("object-src 'none'");
+        options.CspValue.Should().Contain("{{nonce}}");
+    }
+
+    [Fact]
+    public void Create_ShouldResolveIndexFromContentRoot()
+    {
+        // Web host environment whose content root contains the published SPA at
+        // wwwroot/index.html (the same layout the runtime Docker image produces).
+        var contentRoot = Path.Combine(Path.GetTempPath(), "EconoFlow-SecurityPolicy-Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(contentRoot, "wwwroot"));
+        var indexHtml = Path.Combine(contentRoot, "wwwroot", "index.html");
+        File.WriteAllText(indexHtml, "<html data-nonce=\"{{nonce}}\"></html>");
+
+        try
+        {
+            var environment = new Mock<IWebHostEnvironment>();
+            environment.Setup(e => e.ContentRootFileProvider)
+                       .Returns(new PhysicalFileProvider(contentRoot));
+
+            var options = SecurityPolicyOptionsFactory.Create(environment.Object);
+
+            options.FileProvider.Should().NotBeNull();
+            var file = options.FileProvider!.GetFileInfo("wwwroot/index.html");
+            file.Exists.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+}

--- a/EasyFinance.Server/Config/SecurityPolicyOptionsFactory.cs
+++ b/EasyFinance.Server/Config/SecurityPolicyOptionsFactory.cs
@@ -1,0 +1,49 @@
+using FpsSoftware.Chassis;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+
+namespace EasyFinance.Server.Config;
+
+/// <summary>
+/// Builds the <see cref="SecurityPolicyOptions"/> that power the SPA content-security
+/// policy middleware. The CSP is the original, complete one (styles, fonts, images,
+/// Cloudflare Turnstile, etc.) that the old app-local middleware applied, and the text
+/// of <c>index.html</c> is resolved from the web root so the nonce placeholder is
+/// substituted correctly.
+/// </summary>
+public static class SecurityPolicyOptionsFactory
+{
+    /// <summary>
+    /// Content-Security-Policy served on every non-API, non-asset SPA route. The
+    /// nonce placeholder is replaced by the middleware with a per-request value.
+    /// </summary>
+    public const string CspValue =
+        "default-src 'self'; " +
+        "script-src 'self' 'nonce-{{nonce}}' https://challenges.cloudflare.com; " +
+        "style-src 'self' https://fonts.googleapis.com 'nonce-{{nonce}}'; " +
+        "font-src 'self' https://fonts.gstatic.com; " +
+        "img-src 'self' data:; " +
+        "connect-src 'self' https://econoflow.pt; " +
+        "frame-src https://challenges.cloudflare.com; " +
+        "frame-ancestors 'none'; " +
+        "object-src 'none'; " +
+        "base-uri 'self'; " +
+        "form-action 'self';";
+
+    /// <summary>
+    /// Creates the default options for the deployed application, resolving the SPA
+    /// index document from the content root file provider.
+    /// </summary>
+    public static SecurityPolicyOptions Create(IWebHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        // Reading the index via the content root (…/wwwroot/index.html) matches the
+        // original app-local middleware and lets the nonce placeholder be replaced.
+        return new SecurityPolicyOptions
+        {
+            CspValue = CspValue,
+            FileProvider = environment.ContentRootFileProvider,
+        };
+    }
+}

--- a/EasyFinance.Server/Program.cs
+++ b/EasyFinance.Server/Program.cs
@@ -173,7 +173,8 @@ try
     else
     {
         app.UseHsts();
-        app.UseSecurityPolicy();
+        app.UseSecurityPolicy(
+            SecurityPolicyOptionsFactory.Create(app.Environment));
         app.UseMigration();
         EnsureSystemRolesAsync(app.Services).GetAwaiter().GetResult();
     }

--- a/architecture.md
+++ b/architecture.md
@@ -239,21 +239,28 @@ framework). Configuration lives in
 1  UseForwardedHeaders()            ← honour X-Forwarded-Proto/For from trusted proxies FIRST so all later middleware see the real scheme/IP
 2  UseSerilogRequestLogging()
 3  UseCustomExceptionHandler()      ← catches unhandled exceptions → 500
-4  UseSafeHeaders()                 ← security headers (HSTS, CSP, …)
-5  UseSwagger/UseSwaggerUI          ← dev only
-6  UseMigration()                   ← auto-apply EF migrations on startup (prod only)
-7  UseDefaultFiles() + UseStaticFiles()
-8  MapWhen(IsHealthProbePath && !https) → HealthProbeResponseWriter   ← answers probes over plain HTTP so UseHttpsRedirection cannot 307 them
-9  UseHttpsRedirection()
-10 UseAuthentication()
-11 UseCorrelationId()               ← sets/reads X-Correlation-Id header
-12 UseAuthorization()
-13 UseProjectAuthorization()        ← role check for every {projectId} route
-14 UseLocationMiddleware()          ← sets culture from user preference
-15 MapHealthChecks("/api/health/live")  ← liveness; no dependency checks
-16 MapHealthChecks("/api/health/ready") ← readiness; SQL Server + S3 storage
-17 MapControllers()
+4  UseSafeHeaders()                 ← security headers (HSTS, …)
+5  UseSecurityPolicy(SecurityPolicyOptionsFactory.Create(env))  ← prod only: SPA CSP + nonce
+6  UseSwagger/UseSwaggerUI          ← dev only
+7  UseMigration()                   ← auto-apply EF migrations on startup (prod only)
+8  UseDefaultFiles() + UseStaticFiles()
+9  MapWhen(IsHealthProbePath && !https) → HealthProbeResponseWriter   ← answers probes over plain HTTP so UseHttpsRedirection cannot 307 them
+10 UseHttpsRedirection()
+11 UseAuthentication()
+12 UseCorrelationId()               ← sets/reads X-Correlation-Id header
+13 UseAuthorization()
+14 UseProjectAuthorization()        ← role check for every {projectId} route
+15 UseLocationMiddleware()          ← sets culture from user preference
+16 MapHealthChecks("/api/health/live")  ← liveness; no dependency checks
+17 MapHealthChecks("/api/health/ready") ← readiness; SQL Server + S3 storage
+18 MapControllers()
 ```
+
+`SecurityPolicyMiddleware` (from `fpssoftware.chassis`) is the SPA CSP fallback: for non-API, non-asset
+routes it reads `wwwroot/index.html` through `SecurityPolicyOptionsFactory.Create(env)` (backed by the
+content-root `IFileProvider`) and serves it with a per-request nonce substituted into `{{nonce}}` and a
+full `Content-Security-Policy` header (Turnstile, Google Fonts, fonts.gstatic, `connect-src` for the API,
+etc.). If the index document is not servable, the middleware falls through to `UseDefaultFiles()/UseStaticFiles()`.
 
 ---
 


### PR DESCRIPTION
## What

Restores the EconoFlow front-end (https://econoflow.pt), which has been returning blank/empty HTTP 200 pages for `/`, `/login` and `/register` since adopting `fpssoftware.chassis 1.1.0`'s `SecurityPolicyMiddleware`.

## Root cause

`app.UseSecurityPolicy()` was called with the package defaults, whose `IFileProvider` is `null`. The middleware short-circuits every non-API, non-asset route and wrote an empty body (it does not chain to the next middleware). The old app-local middleware read `wwwroot/index.html` from disk and applied the full CSP.

## Fix

- Bump `fpssoftware.chassis` 1.1.0 → 1.1.1 (package fix: middleware falls through to the next middleware when no index document is servable, so routes are never blank).
- Wire `UseSecurityPolicy(SecurityPolicyOptionsFactory.Create(env))`: provides the content-root `IFileProvider` so `wwwroot/index.html` is served with the nonce substituted, and restores the original complete CSP (Turnstile, Google Fonts, fonts, images, connect-src, etc.).
- Add `SecurityPolicyOptionsFactory` + unit tests.

## Tests

- `EasyFinance.Server.Tests`: 130 passed
- `EasyFinance.Domain.Tests`: 112 passed
- `EasyFinance.Application.Tests`: 200 passed
- Chassis suite (1.1.1): 58 passed