### PR TITLE
fix: auto-enable Minio attachment provider when S3 endpoint configured

### DIFF
--- a/EasyFinance.Application.Tests/AttachmentStorageServiceFactoryTests.cs
+++ b/EasyFinance.Application.Tests/AttachmentStorageServiceFactoryTests.cs
@@ -36,12 +36,99 @@ namespace EasyFinance.Application.Tests
         }
 
         [Fact]
+        public void Create_WhenProviderIsDefaultButS3EndpointSet_ShouldReturnMinioStorage()
+        {
+            var options = Options.Create(new AttachmentStorageOptions
+            {
+                Provider = AttachmentStorageOptions.DefaultProvider, // "FileSystem"
+                Endpoint = "minio.shared-services.svc.cluster.local",
+                Bucket = "econoflow",
+            });
+
+            var storage = AttachmentStorageServiceFactory.Create(options, () => new FakeMinioS3Client());
+
+            storage.Should().BeOfType<MinioAttachmentStorageService>();
+        }
+
+        [Fact]
+        public void Create_WhenProviderIsDefaultAndNoS3Endpoint_ShouldReturnFileSystemStorage()
+        {
+            var options = Options.Create(StorageOptions(AttachmentStorageOptions.DefaultProvider));
+
+            var storage = AttachmentStorageServiceFactory.Create(options, () => null);
+
+            storage.Should().BeOfType<FileSystemAttachmentStorageService>();
+        }
+
+        [Fact]
+        public void IsMinioConfigured_ExplicitMinio_ShouldReturnTrue()
+        {
+            var settings = new AttachmentStorageOptions { Provider = "Minio", Bucket = "b" };
+
+            AttachmentStorageServiceFactory.IsMinioConfigured(settings).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsMinioConfigured_ExplicitMinioWithoutBucket_ShouldReturnTrue()
+        {
+            // Provider is explicit; the factory throws a dedicated bucket-required
+            // error at creation time rather than treating the config as FileSystem.
+            var settings = new AttachmentStorageOptions { Provider = "Minio" };
+
+            AttachmentStorageServiceFactory.IsMinioConfigured(settings).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsMinioConfigured_DefaultProviderWithS3EndpointAndBucket_ShouldReturnTrue()
+        {
+            var settings = new AttachmentStorageOptions
+            {
+                Provider = AttachmentStorageOptions.DefaultProvider,
+                Endpoint = "minio.internal",
+                Bucket = "econoflow",
+            };
+
+            AttachmentStorageServiceFactory.IsMinioConfigured(settings).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("FileSystem")]
+        [InlineData("filesystem")]
+        [InlineData("")]
+        public void IsMinioConfigured_NoS3Config_ShouldReturnFalse(string provider)
+        {
+            var settings = new AttachmentStorageOptions { Provider = provider };
+
+            AttachmentStorageServiceFactory.IsMinioConfigured(settings).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(false, true)] // Endpoint present, Bucket missing
+        [InlineData(true, false)]  // Bucket present, Endpoint missing
+        public void IsMinioConfigured_PartialS3Config_ShouldReturnFalse(bool endpointSet, bool bucketSet)
+        {
+            var settings = new AttachmentStorageOptions
+            {
+                Provider = AttachmentStorageOptions.DefaultProvider,
+                Endpoint = endpointSet ? "minio.internal" : string.Empty,
+                Bucket = bucketSet ? "econoflow" : string.Empty,
+            };
+
+            AttachmentStorageServiceFactory.IsMinioConfigured(settings).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsMinioConfigured_NullSettings_ShouldReturnFalse()
+        {
+            AttachmentStorageServiceFactory.IsMinioConfigured(null).Should().BeFalse();
+        }
+
+        [Fact]
         public void Create_WhenProviderIsUnknown_ShouldThrow()
         {
             var options = Options.Create(StorageOptions("UnknownProvider"));
 
             Action act = () => AttachmentStorageServiceFactory.Create(options, () => null);
-
             act.Should().Throw<InvalidOperationException>();
         }
 

--- a/EasyFinance.Application/Features/AttachmentService/AttachmentStorageServiceFactory.cs
+++ b/EasyFinance.Application/Features/AttachmentService/AttachmentStorageServiceFactory.cs
@@ -14,7 +14,7 @@ namespace EasyFinance.Application.Features.AttachmentService
         {
             var settings = options?.Value ?? new AttachmentStorageOptions();
 
-            if (string.Equals(settings.Provider, MinioProvider, StringComparison.OrdinalIgnoreCase))
+            if (IsMinioConfigured(settings))
             {
                 if (string.IsNullOrWhiteSpace(settings.Bucket))
                     throw new InvalidOperationException("Attachment storage bucket name is required when using the Minio provider.");
@@ -32,6 +32,26 @@ namespace EasyFinance.Application.Features.AttachmentService
             }
 
             throw new InvalidOperationException($"Unknown attachment storage provider '{settings.Provider}'.");
+        }
+
+        /// <summary>
+        /// The Minio provider is used when explicitly configured, or when the storage
+        /// is still the default (FileSystem) but an S3 endpoint and bucket are present.
+        /// The latter lets S3 configuration (S3_ENDPOINT / S3_BUCKET) activate Minio
+        /// without an explicit AttachmentStorage__Provider override.
+        /// </summary>
+        public static bool IsMinioConfigured(AttachmentStorageOptions settings)
+        {
+            if (settings == null)
+                return false;
+
+            if (string.Equals(settings.Provider, MinioProvider, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return (string.IsNullOrWhiteSpace(settings.Provider)
+                    || string.Equals(settings.Provider, FileSystemProvider, StringComparison.OrdinalIgnoreCase))
+                   && !string.IsNullOrWhiteSpace(settings.Endpoint)
+                   && !string.IsNullOrWhiteSpace(settings.Bucket);
         }
     }
 }

--- a/EasyFinance.Server.Tests/HealthChecks/S3StorageHealthCheckTests.cs
+++ b/EasyFinance.Server.Tests/HealthChecks/S3StorageHealthCheckTests.cs
@@ -18,12 +18,13 @@ namespace EasyFinance.Server.Tests.HealthChecks
         private static IOptions<AttachmentStorageOptions> CreateOptions(
             string provider,
             string bucket = "test-bucket",
-            string endpoint = "localhost:9000")
+            string endpoint = "localhost:9000",
+            bool s3Configured = false)
             => Options.Create(new AttachmentStorageOptions
             {
                 Provider = provider,
-                Bucket = bucket,
-                Endpoint = endpoint,
+                Bucket = s3Configured ? bucket : string.Empty,
+                Endpoint = s3Configured ? endpoint : string.Empty,
             });
 
         private static IServiceProvider CreateServiceProvider(Mock<IMinioS3Client> minioClientMock) =>
@@ -75,7 +76,7 @@ namespace EasyFinance.Server.Tests.HealthChecks
                 .Returns(Task.CompletedTask);
             var check = new S3StorageHealthCheck(
                 CreateServiceProvider(minioClientMock),
-                CreateOptions("Minio"));
+                CreateOptions("Minio", s3Configured: true));
 
             // Act
             var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
@@ -95,7 +96,7 @@ namespace EasyFinance.Server.Tests.HealthChecks
                 .ThrowsAsync(new InvalidOperationException("S3 endpoint unreachable"));
             var check = new S3StorageHealthCheck(
                 CreateServiceProvider(minioClientMock),
-                CreateOptions("Minio"));
+                CreateOptions("Minio", s3Configured: true));
 
             // Act
             var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
@@ -113,6 +114,45 @@ namespace EasyFinance.Server.Tests.HealthChecks
             var check = new S3StorageHealthCheck(
                 CreateServiceProvider(minioClientMock),
                 CreateOptions("Minio", bucket: string.Empty));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Unhealthy);
+            minioClientMock.Verify(x => x.EnsureBucketExistsAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CheckHealth_DefaultProviderWithS3EndpointConfigured_ShouldVerifyS3()
+        {
+            // Arrange: Provider still the FileSystem default but an S3 endpoint/bucket
+            // are configured, so the effective provider is Minio.
+            var minioClientMock = new Mock<IMinioS3Client>();
+            minioClientMock
+                .Setup(x => x.EnsureBucketExistsAsync("test-bucket"))
+                .Returns(Task.CompletedTask);
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions("FileSystem", s3Configured: true));
+
+            // Act
+            var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);
+
+            // Assert
+            result.Status.ShouldBe(HealthStatus.Healthy);
+            minioClientMock.Verify(x => x.EnsureBucketExistsAsync("test-bucket"), Times.Once);
+        }
+
+        [Fact]
+        public async Task CheckHealth_PartialS3Config_ShouldBeUnhealthy()
+        {
+            // Only an Endpoint is set (Bucket missing): Minio cannot activate, so
+            // uploads would silently fall back to disk. Surface the misconfiguration.
+            var minioClientMock = new Mock<IMinioS3Client>();
+            var check = new S3StorageHealthCheck(
+                CreateServiceProvider(minioClientMock),
+                CreateOptions("FileSystem", s3Configured: true, bucket: string.Empty));
 
             // Act
             var result = await check.CheckHealthAsync(CreateContext(), CancellationToken.None);

--- a/EasyFinance.Server/HealthChecks/S3StorageHealthCheck.cs
+++ b/EasyFinance.Server/HealthChecks/S3StorageHealthCheck.cs
@@ -10,8 +10,10 @@ namespace EasyFinance.Server.HealthChecks
 {
     /// <summary>
     /// Health check for S3-compatible storage (Minio). Returns Healthy when the
-    /// configured storage provider is <see cref="AttachmentStorageServiceFactory.FileSystemProvider"/>
+    /// effective storage provider is <see cref="AttachmentStorageServiceFactory.FileSystemProvider"/>
     /// (no external dependency) and when the S3 bucket is reachable for the Minio provider.
+    /// A partial S3 configuration (endpoint or bucket, not both) is reported Unhealthy
+    /// so a misconfiguration is surfaced instead of silently falling back to disk.
     /// </summary>
     public class S3StorageHealthCheck : IHealthCheck
     {
@@ -32,13 +34,7 @@ namespace EasyFinance.Server.HealthChecks
         {
             var provider = this.storageOptions.Provider;
 
-            if (string.IsNullOrWhiteSpace(provider)
-                || string.Equals(provider, AttachmentStorageServiceFactory.FileSystemProvider, StringComparison.OrdinalIgnoreCase))
-            {
-                return HealthCheckResult.Healthy("File system storage provider in use; no S3 dependency to check.");
-            }
-
-            if (string.Equals(provider, AttachmentStorageServiceFactory.MinioProvider, StringComparison.OrdinalIgnoreCase))
+            if (AttachmentStorageServiceFactory.IsMinioConfigured(this.storageOptions))
             {
                 if (string.IsNullOrWhiteSpace(this.storageOptions.Bucket))
                     return HealthCheckResult.Unhealthy("S3 storage provider is configured but the bucket is not set.");
@@ -53,6 +49,25 @@ namespace EasyFinance.Server.HealthChecks
                 {
                     return HealthCheckResult.Unhealthy($"S3 storage is unreachable: {ex.Message}", ex);
                 }
+            }
+
+            // A partial S3 configuration (endpoint or bucket, but not both) cannot
+            // activate the Minio provider, yet silently leaves uploads on disk.
+            // Surface it so operators notice the misconfiguration instead of a green probe.
+            var isFileSystemProvider = string.IsNullOrWhiteSpace(provider)
+                || string.Equals(provider, AttachmentStorageServiceFactory.FileSystemProvider, StringComparison.OrdinalIgnoreCase);
+
+            if (isFileSystemProvider
+                && (!string.IsNullOrWhiteSpace(this.storageOptions.Endpoint)
+                    || !string.IsNullOrWhiteSpace(this.storageOptions.Bucket)))
+            {
+                return HealthCheckResult.Unhealthy(
+                    "S3 storage is partially configured (set both S3_ENDPOINT and S3_BUCKET); uploads are falling back to the file system.");
+            }
+
+            if (isFileSystemProvider)
+            {
+                return HealthCheckResult.Healthy("File system storage provider in use; no S3 dependency to check.");
             }
 
             return HealthCheckResult.Unhealthy($"Unknown attachment storage provider '{provider}'.");

--- a/architecture.md
+++ b/architecture.md
@@ -458,7 +458,7 @@ Cleanup job (7-day TTL) deletes orphaned IsTemporary attachments.
 
 `IAttachmentStorageService` abstracts the storage backend. The default implementation (`FileSystemAttachmentStorageService`) writes to disk. A second implementation (`MinioAttachmentStorageService`) writes to any S3-compatible object storage (MinIO) via a decoupled `IMinioS3Client` adapter — swapping to Amazon S3 later requires only a new `IMinioS3Client` implementation.
 
-The active provider is selected via `AttachmentStorage:Provider` (`FileSystem` default, `Minio` opt-in). Object keys are identical in both backends (`yyyy/MM/dd/{guid}{ext}`), so existing `StorageKey` values in the database map 1:1 to MinIO object names with no schema change.
+The active provider is selected via `AttachmentStorage:Provider` (`FileSystem` default, `Minio` opt-in). Setting the S3 configuration alone is enough to activate `Minio`: when `AttachmentStorage:Provider` is still the default (`FileSystem`) but both an S3 `Endpoint` and `Bucket` are present, `AttachmentStorageServiceFactory.IsMinioConfigured` treats the effective provider as `Minio`. The same check drives the `S3StorageHealthCheck` readiness probe; a partial S3 configuration (endpoint or bucket set, but not both) is reported as Unhealthy because uploads would otherwise silently fall back to the file system. Object keys are identical in both backends (`yyyy/MM/dd/{guid}{ext}`), so existing `StorageKey` values in the database map 1:1 to MinIO object names with no schema change.
 
 An optional one-shot migration job (`AttachmentMigrationBackgroundService` + `AttachmentMigrationService`) copies existing local files into the object storage under their original keys. See the cutover runbook below.
 


### PR DESCRIPTION
## Problem

Uploading a file failed with:

```
System.UnauthorizedAccessException: Access to the path '/app/attachments/2026' is denied.
```

The deployment sets `S3_ENDPOINT` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` / `S3_BUCKET`, but `AttachmentStorage:Provider` stays at its `appsettings.json` default of `FileSystem`. As a result the app wrote to the container filesystem and hit `Permission denied` — MinIO/S3 was never actually used.

## Fix

Auto-select the **Minio** provider when an S3 endpoint and bucket are present, even if `AttachmentStorage:Provider` is left at the default:

- `AttachmentStorageServiceFactory` gains a public `IsMinioConfigured()` used by `Create()` to pick the storage backend (explicit `Minio`, or default/`FileSystem` + endpoint & bucket set).
- `S3StorageHealthCheck` uses the same effective-provider decision so the readiness probe actually verifies S3 connectivity, and reports **Unhealthy** on a partial S3 config (endpoint XOR bucket) so a misconfiguration can't silently fall back to disk behind a green probe.
- `architecture.md` updated to document the behavior.

No ArgoCD manifest change is required — redeploying the image is enough. Optionally set `S3_ENDPOINT` to the internal `minio.shared-services.svc.cluster.local` for robustness.

## Verification

- Tests: Application **211/211**, Server **132/132**, Domain **112/112** pass.
- `dotnet format --verify-no-changes` clean on all changed files.
- Code review (isolated subagent): **no Action Items**.