### PR TITLE
fix: retry and log transient MinIO AccessDenied on attachment reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Public name **EconoFlow**, internal codebase name **EasyFinance** — appears in
 
 | Directory | Stack |
 |-----------|-------|
-| `EasyFinance.*` (6 csproj) | ASP.NET Core 8 Clean Architecture |
+| `EasyFinance.*` (6 csproj) | ASP.NET Core 10 Clean Architecture |
 | `easyfinance.client/` | Angular 21 SPA |
 | `econoflow-mobile/` | React Native 0.85 + Expo SDK 56 |
 
@@ -95,7 +95,7 @@ dotnet list package --vulnerable --include-transitive # NuGet vulnerability scan
 
 ### CI / Pipelines
 
-- `global.json` pins SDK to 8.0.x to avoid issues with .NET 10 runner pre-installs
+- `global.json` pins the SDK to 10.0.0 (`rollForward: latestMajor`)
 - All `dotnet restore` / `dotnet build` / `dotnet test` commands target explicit `.csproj` files (never the `.sln`) to skip `easyfinance.client.esproj` which has no target framework
 - `EASBuild.yml` is mobile-only and not affected
 
@@ -106,7 +106,7 @@ dotnet ef migrations add {Name} --context EasyFinanceDatabaseContext --project E
 
 ### Architecture pitfalls
 
-- **Infrastructure** targets `netstandard2.1` (shared primitives). All other layers target `net8.0`.
+- **Infrastructure** targets `netstandard2.1` (shared primitives). All other layers target `net10.0`.
 - **`fpssoftware.chassis`** (private NuGet, `https://gitea.fpssoftware.uk/api/packages/fps-software/nuget/index.json`) holds application-agnostic building blocks: `AppResponse`/`AppMessage`/`Paging`/`AddPrefix`, `ChassisJsonFormatter`, `FlagsEnumArrayConverter`, generic middleware (correlation id, exception, localization, safe headers, security policy), and `JwtTokenService`/`JwtTokenSettings`/`AddChassisJwtAuthentication`. See `FelipePSoares/chassis`.
 - **AppResponse<T>** (`FpsSoftware.Chassis`) is the universal return type. Never throw for expected business failures; return `AppResponse.Error(...)`.
 - **Entity mutation**: private setters + `SetXxx()` methods only. Never assign properties directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Once all tests are green and lint is clean, spawn the `codereview` subagent (def
 
 ## Project Overview
 
-EconoFlow (codebase name: EasyFinance) is a personal/company budget tracking application. It uses an ASP.NET Core 8 backend serving an Angular 21 SPA frontend, backed by SQL Server via EF Core.
+EconoFlow (codebase name: EasyFinance) is a personal/company budget tracking application. It uses an ASP.NET Core 10 backend serving an Angular 21 SPA frontend, backed by SQL Server via EF Core.
 
 ---
 
@@ -110,13 +110,13 @@ The solution follows Clean Architecture with a strict dependency direction:
 ```
 EasyFinance.Infrastructure  (netstandard2.1 — shared primitives, no dependencies)
         ↓
-EasyFinance.Domain          (net8.0 — entities, business rules)
+EasyFinance.Domain          (net10.0 — entities, business rules)
         ↓
-EasyFinance.Application     (net8.0 — services, DTOs, mappers, contracts)
+EasyFinance.Application     (net10.0 — services, DTOs, mappers, contracts)
         ↓
-EasyFinance.Persistence     (net8.0 — EF Core, repositories, migrations)
+EasyFinance.Persistence     (net10.0 — EF Core, repositories, migrations)
         ↓
-EasyFinance.Server          (net8.0 — ASP.NET controllers, middleware, startup)
+EasyFinance.Server          (net10.0 — ASP.NET controllers, middleware, startup)
         ↓
 easyfinance.client          (Angular 21 SPA — embedded as SPA proxy in dev)
 ```

--- a/EasyFinance.Application.Tests/MinioS3ClientAdapterTests.cs
+++ b/EasyFinance.Application.Tests/MinioS3ClientAdapterTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyFinance.Application.Features.AttachmentService;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Minio;
+using Minio.DataModel.Args;
+using Minio.Exceptions;
+using Moq;
+
+namespace EasyFinance.Application.Tests
+{
+    public class MinioS3ClientAdapterTests
+    {
+        private readonly Mock<IMinioClient> minioClient = new();
+        private readonly MinioS3ClientAdapter adapter;
+
+        public MinioS3ClientAdapterTests()
+        {
+            this.adapter = new MinioS3ClientAdapter(this.minioClient.Object);
+        }
+
+        [Fact]
+        public async Task GetObjectAsync_WhenTransientAccessDenied_ShouldRetryAndSucceed()
+        {
+            this.minioClient
+                .SetupSequence(client => client.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new AccessDeniedException("transient denied"))
+                .ThrowsAsync(new AccessDeniedException("transient denied"))
+                .ReturnsAsync((Minio.DataModel.ObjectStat)null!);
+
+            var stream = await this.adapter.GetObjectAsync("bucket", "2026/08/14/file.pdf");
+
+            stream.Should().NotBeNull();
+            this.minioClient.Verify(
+                client => client.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(3));
+        }
+
+        [Fact]
+        public async Task GetObjectAsync_WhenRetrying_ShouldLogWarning()
+        {
+            var logger = new Mock<ILogger<MinioS3ClientAdapter>>();
+            var adapterWithLogging = new MinioS3ClientAdapter(this.minioClient.Object, logger.Object);
+
+            this.minioClient
+                .SetupSequence(client => client.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new AccessDeniedException("transient denied"))
+                .ReturnsAsync((Minio.DataModel.ObjectStat)null!);
+
+            var stream = await adapterWithLogging.GetObjectAsync("bucket", "2026/08/14/file.pdf");
+
+            stream.Should().NotBeNull();
+            logger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => true),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)!),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetObjectAsync_WhenPersistentAccessDenied_ShouldThrow()
+        {
+            this.minioClient
+                .Setup(client => client.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new AccessDeniedException("still denied"));
+
+            Func<Task> act = async () => await this.adapter.GetObjectAsync("bucket", "file.pdf");
+
+            await act.Should().ThrowAsync<AccessDeniedException>();
+            this.minioClient.Verify(
+                client => client.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(3));
+        }
+
+        [Fact]
+        public async Task GetObjectAsync_WhenObjectMissing_ShouldWrapInMinioObjectNotFoundException()
+        {
+            this.minioClient
+                .Setup(client => client.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ObjectNotFoundException());
+
+            Func<Task> act = async () => await this.adapter.GetObjectAsync("bucket", "missing.pdf");
+
+            await act.Should().ThrowAsync<MinioObjectNotFoundException>()
+                .WithMessage("missing.pdf");
+        }
+    }
+}

--- a/EasyFinance.Application/ApplicationServiceRegistration.cs
+++ b/EasyFinance.Application/ApplicationServiceRegistration.cs
@@ -27,6 +27,7 @@ using EasyFinance.Application.Features.UserKeyService;
 using EasyFinance.Application.Features.UserService;
 using EasyFinance.Application.Features.WebPushService;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace EasyFinance.Application
 {
@@ -51,7 +52,8 @@ namespace EasyFinance.Application
             services.AddSingleton<IMinioS3Client>(provider =>
             {
                 var settings = provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<AttachmentStorageOptions>>().Value;
-                return MinioClientFactory.CreateS3Client(settings);
+                var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger<MinioS3ClientAdapter>();
+                return MinioClientFactory.CreateS3Client(settings, logger);
             });
             services.AddSingleton<IAttachmentStorageService>(provider =>
             {

--- a/EasyFinance.Application/EasyFinance.Application.csproj
+++ b/EasyFinance.Application/EasyFinance.Application.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.11" />
     <PackageReference Include="Minio" Version="7.0.0" />
+    <PackageReference Include="Polly.Core" Version="8.7.0" />
     <PackageReference Include="Smtp2Go.ApiClient" Version="0.0.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageReference Include="WebPush" Version="1.0.13" />

--- a/EasyFinance.Application/Features/AttachmentService/MinioClientFactory.cs
+++ b/EasyFinance.Application/Features/AttachmentService/MinioClientFactory.cs
@@ -6,6 +6,9 @@ namespace EasyFinance.Application.Features.AttachmentService
     public static class MinioClientFactory
     {
         public static IMinioS3Client CreateS3Client(AttachmentStorageOptions settings)
+            => CreateS3Client(settings, logger: null);
+
+        public static IMinioS3Client CreateS3Client(AttachmentStorageOptions settings, Microsoft.Extensions.Logging.ILogger<MinioS3ClientAdapter>? logger)
         {
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
@@ -25,7 +28,7 @@ namespace EasyFinance.Application.Features.AttachmentService
             if (!string.IsNullOrWhiteSpace(settings.Region))
                 minioClient = minioClient.WithRegion(settings.Region);
 
-            return new MinioS3ClientAdapter(minioClient.Build());
+            return new MinioS3ClientAdapter(minioClient.Build(), logger);
         }
 
         public static string NormalizeEndpoint(string endpoint)

--- a/EasyFinance.Application/Features/AttachmentService/MinioS3ClientAdapter.cs
+++ b/EasyFinance.Application/Features/AttachmentService/MinioS3ClientAdapter.cs
@@ -1,9 +1,12 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Minio;
 using Minio.DataModel.Args;
 using Minio.Exceptions;
+using Polly;
+using Polly.Retry;
 
 namespace EasyFinance.Application.Features.AttachmentService
 {
@@ -14,11 +17,65 @@ namespace EasyFinance.Application.Features.AttachmentService
     /// </summary>
     public class MinioS3ClientAdapter : IMinioS3Client
     {
+        /// <summary>
+        /// MinIO can fleetingly return <see cref="AccessDeniedException"/> for a valid
+        /// credential on the first request after a period of inactivity (its IAM policy
+        /// cache is still warming up). A short bounded retry makes reads resilient to that
+        /// transient denial. This is the number of retries AFTER the initial attempt, so a
+        /// read is attempted MaxGetRetries + 1 times total before the denial propagates.
+        /// </summary>
+        private const int MaxGetRetries = 2;
+
+        /// <summary>
+        /// MinIO IAM cache warms up almost immediately, so a short constant backoff is enough.
+        /// </summary>
+        private static readonly TimeSpan GetRetryDelay = TimeSpan.FromMilliseconds(100);
+
         private readonly IMinioClient client;
+        private readonly ILogger<MinioS3ClientAdapter>? logger;
+        private readonly ResiliencePipeline getObjectRetryPipeline;
+
+        /// <summary>Carries the bucket name into the retry handler so retry logs are actionable.</summary>
+        private static readonly ResiliencePropertyKey<string> BucketContextKey = new("Bucket");
+
+        /// <summary>Carries the object key into the retry handler so retry logs are actionable.</summary>
+        private static readonly ResiliencePropertyKey<string> ObjectKeyContextKey = new("ObjectKey");
 
         public MinioS3ClientAdapter(IMinioClient client)
+            : this(client, logger: null)
+        {
+        }
+
+        public MinioS3ClientAdapter(IMinioClient client, ILogger<MinioS3ClientAdapter>? logger)
         {
             this.client = client ?? throw new ArgumentNullException(nameof(client));
+            this.logger = logger;
+
+            this.getObjectRetryPipeline = new ResiliencePipelineBuilder()
+                .AddRetry(new RetryStrategyOptions
+                {
+                    MaxRetryAttempts = MaxGetRetries,
+                    Delay = GetRetryDelay,
+                    BackoffType = DelayBackoffType.Constant,
+                    UseJitter = false,
+                    ShouldHandle = new PredicateBuilder().Handle<AccessDeniedException>(),
+                    OnRetry = args =>
+                    {
+                        args.Context.Properties.TryGetValue(BucketContextKey, out var logBucket);
+                        args.Context.Properties.TryGetValue(ObjectKeyContextKey, out var logKey);
+
+                        this.logger?.LogWarning(
+                            "MinIO returned {AccessDeniedException} for bucket {Bucket} key {ObjectKey} on attempt {AttemptNumber}; retrying in {RetryDelay}.",
+                            nameof(AccessDeniedException),
+                            logBucket,
+                            logKey,
+                            args.AttemptNumber + 1,
+                            args.RetryDelay);
+
+                        return default;
+                    },
+                })
+                .Build();
         }
 
         public async Task EnsureBucketExistsAsync(string bucket)
@@ -58,7 +115,24 @@ namespace EasyFinance.Application.Features.AttachmentService
 
             try
             {
-                await this.client.GetObjectAsync(args).ConfigureAwait(false);
+                var resilienceContext = ResilienceContextPool.Shared.Get();
+                try
+                {
+                    resilienceContext.Properties.Set(BucketContextKey, bucket);
+                    resilienceContext.Properties.Set(ObjectKeyContextKey, key);
+
+                    await this.getObjectRetryPipeline.ExecuteAsync(
+                        async _ =>
+                        {
+                            memoryStream.SetLength(0);
+                            await this.client.GetObjectAsync(args).ConfigureAwait(false);
+                        },
+                        resilienceContext).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ResilienceContextPool.Shared.Return(resilienceContext);
+                }
             }
             catch (ObjectNotFoundException)
             {

--- a/architecture.md
+++ b/architecture.md
@@ -2,7 +2,7 @@
 
 ## 1. High-Level Overview
 
-EconoFlow is a full-stack financial planning application composed of three clients (Angular SPA, React Native mobile app, PWA) sharing a single ASP.NET Core 8 API backed by SQL Server.
+EconoFlow is a full-stack financial planning application composed of three clients (Angular SPA, React Native mobile app, PWA) sharing a single ASP.NET Core 10 API backed by SQL Server.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -16,7 +16,7 @@ EconoFlow is a full-stack financial planning application composed of three clien
             │   HTTPS / JWT     │                   │
             ▼                   ▼                   ▼
 ┌───────────────────────────────────────────────────────────────┐
-│  ASP.NET Core 8  (EasyFinance.Server)                         │
+│  ASP.NET Core 10  (EasyFinance.Server)                        │
 │  ┌─────────────────────────────────────────────────────────┐  │
 │  │  Middleware Pipeline                                     │  │
 │  │  Serilog → CustomExceptionHandler → SafeHeaders →        │  │
@@ -45,10 +45,10 @@ EconoFlow is a full-stack financial planning application composed of three clien
 ```
 EconoFlow/
 ├── EasyFinance.Infrastructure/   # netstandard2.1 — DTOs, validation, shared primitives
-├── EasyFinance.Domain/           # net8.0 — entities, business rules
-├── EasyFinance.Application/      # net8.0 — services, mappers, contracts, background jobs
-├── EasyFinance.Persistence/      # net8.0 — EF Core, DbContext, repositories, migrations
-├── EasyFinance.Server/           # net8.0 — ASP.NET controllers, middleware, JWT, startup
+├── EasyFinance.Domain/           # net10.0 — entities, business rules
+├── EasyFinance.Application/      # net10.0 — services, mappers, contracts, background jobs
+├── EasyFinance.Persistence/      # net10.0 — EF Core, DbContext, repositories, migrations
+├── EasyFinance.Server/           # net10.0 — ASP.NET controllers, middleware, JWT, startup
 ├── EasyFinance.Common.Tests/     # Shared test builders and helpers
 ├── EasyFinance.Domain.Tests/
 ├── EasyFinance.Application.Tests/
@@ -171,7 +171,7 @@ All repositories are lazily initialized inside `UnitOfWork`. `CommitAsync()` is 
 
 ### 3.5 Server (`EasyFinance.Server`)
 
-ASP.NET Core 8 host. Everything in this layer is infrastructure for the HTTP boundary.
+ASP.NET Core 10 host. Everything in this layer is infrastructure for the HTTP boundary.
 
 #### Startup (`Program.cs`) — service registration order
 1. `AddPersistenceServices(configuration)` — registers DbContext, repositories, UoW, and health checks (SQL Server check in non-Debug builds).


### PR DESCRIPTION
## What & why

MinIO can intermittently return a transient `403 AccessDenied` on the first S3 request of a client — its IAM policy cache is still warming up, typically after a period of inactivity. The app had no retry, so that single 403 surfaced on the first download attempt and a manual retry succeeded.

### Changes
- **Retry** — `MinioS3ClientAdapter.GetObjectAsync` now runs through a `Polly` (`Polly.Core` 8.7.0) resilience pipeline that retries `AccessDeniedException` up to 2 times (3 total attempts) with a 100 ms constant backoff.
- **Observability** — logs a `Warning` whenever a retry is triggered (bucket, key, attempt number, retry delay), so an always-failing first attempt is easy to spot in the logs.
- Wired an `ILogger<MinioS3ClientAdapter>` through `MinioClientFactory` and the DI registration.
- **Docs** — corrected stale `.NET 8 / net8.0`-era references to the real `net10.0 / ASP.NET Core 10` in `AGENTS.md`, `CLAUDE.md`, and `architecture.md`.

## Tests
Added `MinioS3ClientAdapterTests` (retry-then-succeed, persistent-denial throws, missing-object mapping, and retry-logging). All backend suites green:
- Application.Tests: 215 passed
- Server.Tests: 132 passed
- Domain.Tests: 112 passed
- `dotnet format --verify-no-changes` clean for changed files

## Notes
The specific missing file referenced by an earlier log (`2026/08/14/8431e...pdf`) is genuinely absent from object storage and its DB row is gone — that is a separate data issue and is not addressed by this PR.
